### PR TITLE
fix(eli): rozpoznaj artykuły z indeksem górnym w tekst --fragment (np. art. 730(1))

### DIFF
--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -121,9 +121,16 @@ def _fragmenty(txt, fraza, maks=8):
     inna fraza działa jak wyszukiwanie pełnotekstowe (bez rozróżniania wielkości liter).
     """
     bounds = [m.start() for m in re.finditer(_GRANICE, txt)]
-    m = re.match(r"(?i)^art\.?\s*(\d+[a-z]*)\.?$", fraza.strip())
+    m = re.match(r"(?i)^art\.?\s*(\d+)(?:\((\w+)\))?([a-z]*)\.?$", fraza.strip())
     if m:
-        hits = [h.start() for h in re.finditer(rf"(?m)^Art\.\s*{m.group(1)}\.", txt)]
+        # Artykuł z indeksem górnym (np. "art. 730(1)", "art. 505(29a)") w tekście po
+        # konwersji HTML→tekst jest sklejony: "Art. 730¹." renderuje się jako "Art. 7301.".
+        # Łączymy numer z indeksem i dopuszczamy opcjonalną spację, zachowując zgodność
+        # wstecz dla "art. 299" oraz "art. 1a"/"art. 168e".
+        base, tail = m.group(1), (m.group(2) or "") + (m.group(3) or "")
+        pat = (rf"(?m)^Art\.\s*{re.escape(base)}\s*{re.escape(tail)}\."
+               if tail else rf"(?m)^Art\.\s*{re.escape(base)}\.")
+        hits = [h.start() for h in re.finditer(pat, txt)]
     else:
         low, f = txt.lower(), fraza.lower()
         hits, p = [], low.find(f)

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -72,6 +72,14 @@ class TestFragmenty(unittest.TestCase):
         self.assertIn("Dwudziesty pierwszy", frags[0])
         self.assertNotIn("indeksem", frags[0])  # "Art. 211." to inny artykuł
 
+    def test_artykul_z_indeksem_gornym(self):
+        # "art. 21(1)" (= art. 21 ze zn. 1) trafia w "Art. 211." (indeks górny po
+        # konwersji HTML→tekst jest sklejony z numerem), a NIE w "Art. 21."
+        frags = self._frag("art. 21(1)")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("indeksem", frags[0])
+        self.assertNotIn("Dwudziesty pierwszy", frags[0])
+
     def test_fraza_pelnotekstowa_docieta_do_artykulu(self):
         frags = self._frag("o którym mowa")
         self.assertEqual(len(frags), 1)


### PR DESCRIPTION
## Problem

`tekst <syg> --fragment "art. 730(1)"` (oraz inne artykuły z indeksem górnym: `art. 505(29a)`, `art. 18(2)` itd.) nie znajduje przepisu. Dotyczy m.in. KPC, EPU (505²⁸⁻³⁷), u.p.e.a. — czyli częstych przepisów.

**Przyczyna:** po `html_to_text` indeks górny jest sklejony z numerem — `<sup>1</sup>` renderuje się inline, więc nagłówek „Art. 730¹." staje się `Art. 7301.`. Regex nagłówkowy `^art\.?\s*(\d+[a-z]*)\.?$` nie obejmuje formy z nawiasem, więc zapytanie spada do wyszukiwania pełnotekstowego „art. 730(1)", którego w tekście nie ma → „Nie znaleziono frazy".

**Repro** (na `DU/2024/1568`, KPC): spłaszczony nagłówek = `Art. 7301.`; `--fragment "art. 730(1)"` → brak trafień.

## Zmiana

Parser frazy w `_fragmenty` rozpoznaje teraz także formę `art. N(M)` / `art. N(Ma)`, skleja numer z indeksem i dopuszcza opcjonalną spację (matchuje `Art. 7301.` oraz `Art. 730 1.`). Zgodność wstecz dla `art. 299`, `art. 1a`, `art. 168e` zachowana.

## Test

Dodany offline unit test `test_artykul_z_indeksem_gornym` w `tools/test_eli.py` (`art. 21(1)` → „Art. 211.", nie „Art. 21."). Uruchomienie: `python3 tools/test_eli.py`.
