### PR TITLE
fix(eli): rozróżnij art. 21¹ od art. 211 (indeks górny w <sup>)

### DIFF
--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -89,6 +89,11 @@ class _Stripper(HTMLParser):
             self.skip += 1
         if tag in ("p", "br", "div", "tr", "li", "h1", "h2", "h3", "h4"):
             self.out.append("\n")
+        # Indeks górny artykułu (np. "Art. 21<sup>1</sup>.") rozdzielamy spacją, żeby
+        # "Art. 21 1." było odróżnialne od "Art. 211." — inaczej art. 21¹ i art. 211
+        # sklejają się do tego samego napisu i _fragmenty zwraca oba (znany bug).
+        if tag == "sup":
+            self.out.append(" ")
 
     def handle_endtag(self, tag):
         if tag in ("script", "style") and self.skip:
@@ -113,6 +118,10 @@ def html_to_text(html):
 # granice jednostek redakcyjnych w tekście po konwersji (nagłówki na początku linii)
 _GRANICE = r"(?m)^(Art\.\s*\d|Tytuł\s|TYTUŁ\s|Dział\s|DZIAŁ\s|Rozdział\s|Oddział\s|Księga\s|KSIĘGA\s|Załącznik)"
 
+# unicodowe indeksy górne (art. 21¹) — do rozpoznania w zapytaniu i przełożenia na cyfry ASCII
+_SUPS = "¹²³⁴⁵⁶⁷⁸⁹⁰"
+_SUP = str.maketrans(_SUPS, "1234567890")
+
 
 def _fragmenty(txt, fraza, maks=8):
     """Spany (start, end) fragmentów z frazą, docięte do granic jednostek redakcyjnych.
@@ -121,15 +130,25 @@ def _fragmenty(txt, fraza, maks=8):
     inna fraza działa jak wyszukiwanie pełnotekstowe (bez rozróżniania wielkości liter).
     """
     bounds = [m.start() for m in re.finditer(_GRANICE, txt)]
-    m = re.match(r"(?i)^art\.?\s*(\d+)(?:\((\w+)\))?([a-z]*)\.?$", fraza.strip())
+    # Baza + opcjonalny INDEKS GÓRNY (art. 21¹: unicode "21¹", nawiasowy "21(1)"/"21[1]"/"21^1")
+    # + opcjonalny SUFIKS LITEROWY (art. 1a, art. 168e). Rozróżnienie jest istotne, bo w tekście
+    # indeks górny ma spację ("Art. 21 1." — patrz _Stripper), a sufiks literowy jest sklejony
+    # ("Art. 1a."); dlatego indeks matchujemy z \s+, a literę z \s*.
+    m = re.match(
+        r"(?i)^art\.?\s*(\d+)"                                  # (1) baza
+        r"(?:[\(\[\^]\s*(\d+[a-z]?)\s*[\)\]]?|([" + _SUPS + r"]+))?"  # (2) nawiasowy | (3) unicode indeks
+        r"([a-z]*)\.?$",                                        # (4) sufiks literowy
+        fraza.strip())
     if m:
-        # Artykuł z indeksem górnym (np. "art. 730(1)", "art. 505(29a)") w tekście po
-        # konwersji HTML→tekst jest sklejony: "Art. 730¹." renderuje się jako "Art. 7301.".
-        # Łączymy numer z indeksem i dopuszczamy opcjonalną spację, zachowując zgodność
-        # wstecz dla "art. 299" oraz "art. 1a"/"art. 168e".
-        base, tail = m.group(1), (m.group(2) or "") + (m.group(3) or "")
-        pat = (rf"(?m)^Art\.\s*{re.escape(base)}\s*{re.escape(tail)}\."
-               if tail else rf"(?m)^Art\.\s*{re.escape(base)}\.")
+        base = m.group(1)
+        idx = m.group(2) or (m.group(3).translate(_SUP) if m.group(3) else "")
+        letter = m.group(4) or ""
+        if idx:                       # indeks górny → w tekście rozdzielony spacją
+            pat = rf"(?m)^Art\.\s*{re.escape(base)}\s+{re.escape(idx)}{re.escape(letter)}\."
+        elif letter:                  # sufiks literowy → sklejony z numerem
+            pat = rf"(?m)^Art\.\s*{re.escape(base)}\s*{re.escape(letter)}\."
+        else:
+            pat = rf"(?m)^Art\.\s*{re.escape(base)}\."
         hits = [h.start() for h in re.finditer(pat, txt)]
     else:
         low, f = txt.lower(), fraza.lower()

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -48,12 +48,21 @@ class TestHtmlToText(unittest.TestCase):
         t = eli.html_to_text("<div><p>A</p><p></p><p></p><p>B</p></div>")
         self.assertNotIn("\n\n\n", t)
 
+    def test_superscript_gets_space(self):
+        # Indeks górny w <sup> musi zostać rozdzielony spacją, żeby art. 21¹
+        # ("Art. 21 1.") był odróżnialny od art. 211 ("Art. 211.").
+        self.assertEqual(eli.html_to_text("<p>Art.\xa021<sup>1</sup>.</p>"), "Art. 21 1.")
+        self.assertEqual(eli.html_to_text("<p>Art.\xa0211.</p>"), "Art. 211.")
+
 
 class TestFragmenty(unittest.TestCase):
+    # Tekst po konwersji HTML→tekst: art. 21¹ (indeks górny w <sup>) renderuje się
+    # jako "Art. 21 1." (patrz _Stripper), a art. 211 jako "Art. 211." — odróżnialne.
     TXT = ("Tytuł I\n\nArt. 1.\nPierwszy przepis.\n\n"
            "Art. 2.\n§ 1. Drugi przepis o spółce.\n§ 2. Odesłanie, o którym mowa w art. 1.\n\n"
            "Art. 21.\nDwudziesty pierwszy przepis.\n\n"
-           "Art. 211.\nPrzepis z indeksem (art. 21 ze zn. 1).\n")
+           "Art. 21 1.\nPrzepis z indeksem górnym (art. 21 ze zn. 1).\n\n"
+           "Art. 211.\nDwieście jedenasty przepis.\n")
 
     def _frag(self, fraza):
         spans = eli._fragmenty(self.TXT, fraza)
@@ -70,15 +79,25 @@ class TestFragmenty(unittest.TestCase):
         frags = self._frag("art. 21")
         self.assertEqual(len(frags), 1)
         self.assertIn("Dwudziesty pierwszy", frags[0])
-        self.assertNotIn("indeksem", frags[0])  # "Art. 211." to inny artykuł
+        self.assertNotIn("indeksem górnym", frags[0])  # "Art. 21 1." to inny artykuł
+        self.assertNotIn("Dwieście", frags[0])          # "Art. 211." to inny artykuł
 
     def test_artykul_z_indeksem_gornym(self):
-        # "art. 21(1)" (= art. 21 ze zn. 1) trafia w "Art. 211." (indeks górny po
-        # konwersji HTML→tekst jest sklejony z numerem), a NIE w "Art. 21."
-        frags = self._frag("art. 21(1)")
+        # "art. 21(1)" oraz "art. 21¹" trafiają w "Art. 21 1." (indeks górny),
+        # a NIE w "Art. 21." ani "Art. 211.".
+        for fraza in ("art. 21(1)", "art. 21¹"):
+            frags = self._frag(fraza)
+            self.assertEqual(len(frags), 1, fraza)
+            self.assertIn("indeksem górnym", frags[0], fraza)
+            self.assertNotIn("Dwudziesty pierwszy", frags[0], fraza)
+            self.assertNotIn("Dwieście", frags[0], fraza)
+
+    def test_rozroznia_indeks_gorny_od_pelnego_numeru(self):
+        # "art. 211" trafia TYLKO w art. 211, nie w art. 21¹ (to był bug).
+        frags = self._frag("art. 211")
         self.assertEqual(len(frags), 1)
-        self.assertIn("indeksem", frags[0])
-        self.assertNotIn("Dwudziesty pierwszy", frags[0])
+        self.assertIn("Dwieście jedenasty", frags[0])
+        self.assertNotIn("indeksem górnym", frags[0])
 
     def test_fraza_pelnotekstowa_docieta_do_artykulu(self):
         frags = self._frag("o którym mowa")


### PR DESCRIPTION
## Problem

`--fragment "art. 211"` na KSH (Dz.U. 2024 poz. 18) zwraca **dwa** artykuły: art. 21¹ (grupy spółek) **i** art. 211 (zakaz konkurencji członka zarządu). To ta sama klasa błędu, którą obecny `SKILL.md` obchodzi ostrzeżeniem „`--art N` myli artykuły z indeksem górnym".

## Przyczyna

W źródłowym HTML nagłówki wyglądają tak:

```
<B CLASS="b">Art.&nbsp;211.</B>            ← art. 211
<B CLASS="b">Art.&nbsp;21<SUP>1</SUP>.</B> ← art. 21¹
```

`_Stripper` nie obsługuje `<sup>`, więc oba renderują się do identycznego `"Art. 211."` — `_fragmenty` nie ma jak ich rozróżnić i zwraca oba.

## Fix (chirurgiczny, 2 miejsca w `eli.py`)

1. **`_Stripper.handle_starttag`** wstawia spację na `<sup>` → `"Art. 21 1."` staje się odróżnialne od `"Art. 211."`.
2. **`_fragmenty`** parsuje indeks górny (unicode `21¹`, nawiasowy `21(1)`/`21[1]`/`21^1`) osobno od sufiksu literowego (`1a`) i matchuje indeks z `\s+` (spacja gwarantowana po pkt. 1), a literę z `\s*`. Dzięki temu `art. 211` nie łapie już `art. 21¹` i odwrotnie.

Zachowana jest istniejąca zaleta line-anchoringu `(?m)^Art\.` (trafienie w nagłówek jednostki, nie w odesłanie w treści).

## Weryfikacja na żywo (KSH, Dz.U. 2024 poz. 18)

| zapytanie | trafienia | treść |
|---|---|---|
| `art. 211` | 1 | zakaz konkurencji (członek zarządu) ✅ |
| `art. 21(1)` / `art. 21¹` | 1 | grupy spółek ✅ |
| `art. 21` | 1 | tylko art. 21 (nie 21¹ ani 211) ✅ |
| `art. 299` | 1 | nie łapie już art. 299¹ ✅ |

Sprawdzone też międzyaktowo (KC art. 484) — bez regresji.

## Testy

`tools/test_eli.py`: zaktualizowany fixture `TestFragmenty` do nowego (poprawnego) renderu, przepisany `test_artykul_z_indeksem_gornym`, dodany `test_rozroznia_indeks_gorny_od_pelnego_numeru` (dyskryminacja 211 vs 21¹) oraz `test_superscript_gets_space` w `TestHtmlToText`. **14 → 16 testów, wszystkie zielone**; `tools/validate.py` OK; `test_eurlex`/`test_saos` nietknięte.

## Uwaga

Nie ruszam `__version__`/lockstepu — zostawiam bump do decyzji maintainera przy release. Gotowy dopisać do `SKILL.md` nową składnię indeksu (`art. 21¹` / `art. 21(1)`), jeśli wolisz to w tym samym PR.

Dzięki za świetny, czysty skill — używamy go u nas jako vendorowany silnik.
