### PR TITLE
fix: distinguish transport/API failure (UNKNOWN) from confirmed empty result

### DIFF
--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -34,6 +34,15 @@ JEZYKI = {"pl": "POL", "pol": "POL", "en": "ENG", "eng": "ENG", "de": "DEU", "de
           "pt": "POR", "por": "POR", "uk": "UKR", "ukr": "UKR"}
 
 
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _nie_zweryfikowano(co, blad):
+    sys.exit(f"BŁĄD: nie udało się zweryfikować {co} ({blad}). "
+             "Spróbuj ponownie za chwilę.")
+
+
 def _lang(j):
     code = JEZYKI.get((j or "pol").lower())
     if code:
@@ -68,18 +77,22 @@ def _http(url, data=None, headers=None, timeout=60):
 
 
 def _sparql(query, soft=False):
-    """Zapytanie do publicznego endpointu SPARQL Urzędu Publikacji. Zwraca listę bindingów."""
+    """Zapytanie SPARQL zwracające listę bindingów.
+
+    Pusta lista oznacza VERIFIED_ABSENT. Przy soft=True błąd ma osobny stan
+    UNKNOWN (VerificationUnknown), nigdy None/pustą listę.
+    """
     data = urllib.parse.urlencode({"query": query, "format": "application/sparql-results+json"}).encode()
     try:
         raw, _ = _http(SPARQL, data=data, headers={"Accept": "application/sparql-results+json"})
         return json.loads(raw.decode("utf-8", "replace"))["results"]["bindings"]
-    except SystemExit:
+    except SystemExit as e:
         if soft:
-            return None
+            raise VerificationUnknown(str(e)) from e
         raise
     except Exception as e:
         if soft:
-            return None
+            raise VerificationUnknown(f"nieoczekiwana odpowiedź SPARQL: {e}") from e
         sys.exit(f"BŁĄD: nieoczekiwana odpowiedź SPARQL ({e}) — spróbuj ponownie za chwilę.")
 
 
@@ -172,7 +185,10 @@ def celex_norm(parts):
 
 
 def _konsolidacje(celex):
-    """Lista CELEX-ów wersji skonsolidowanych aktu, najnowsza pierwsza (albo [])."""
+    """Lista CELEX-ów wersji skonsolidowanych albo VERIFIED_ABSENT jako [].
+
+    VerificationUnknown jest przekazywany do wywołującego, bez zamiany na [].
+    """
     base = celex.split("-")[0]
     base = base if base.startswith("0") else "0" + base[1:]
     rows = _sparql(f"""PREFIX cdm: <{CDM}>
@@ -180,14 +196,15 @@ SELECT DISTINCT ?celex WHERE {{
   ?w cdm:resource_legal_id_celex ?celex .
   FILTER(STRSTARTS(STR(?celex), "{base}-"))
 }} ORDER BY DESC(?celex) LIMIT 100""", soft=True)
-    if not rows:
-        return []
     return [c for c in (_v(b, "celex") for b in rows) if re.search(r"-\d{8}$", c)]
 
 
 def _ostrzezenia_konsolidacja(celex):
     """Ostrzeżenia o wersjach skonsolidowanych dla aktu/wersji (lista linii)."""
-    kons = _konsolidacje(celex)
+    try:
+        kons = _konsolidacje(celex)
+    except VerificationUnknown as e:
+        _nie_zweryfikowano(f"wersji skonsolidowanych dla {celex}", e)
     out = []
     if celex.startswith("0"):
         out.append("UWAGA: wersja skonsolidowana ma charakter DOKUMENTACYJNY (nie jest autentyczna) — "
@@ -286,7 +303,10 @@ SELECT ?type ?date ?inf ?eli ?eiv ?eov ?title WHERE {{
 
 def cmd_skonsolidowany(a):
     celex = celex_norm(a.celex)
-    kons = _konsolidacje(celex)
+    try:
+        kons = _konsolidacje(celex)
+    except VerificationUnknown as e:
+        _nie_zweryfikowano(f"wersji skonsolidowanych dla {celex}", e)
     if a.json:
         print(json.dumps(kons, ensure_ascii=False, indent=2)); return
     if not kons:
@@ -311,7 +331,7 @@ SELECT ?man ?mtype WHERE {{
   ?man cdm:manifestation_manifests_expression ?exp .
   ?man cdm:manifestation_type ?mtype .
   FILTER(STRSTARTS(STR(?mtype), "pdf"))
-}} LIMIT 5""", soft=True) or []
+}} LIMIT 5""", soft=True)
     pdfy = sorted(rows, key=lambda b: _v(b, "mtype"))  # pdfa1a/pdfa2a przed zwykłym pdf
     return (_v(pdfy[0], "man") + "/DOC_1") if pdfy else None
 
@@ -322,7 +342,10 @@ def cmd_tekst(a):
     lang3 = lang.lower()
     url = CELLAR + urllib.parse.quote(celex, safe="/")
     if a.pdf:
-        pdf_url = _pdf_url(celex, lang)
+        try:
+            pdf_url = _pdf_url(celex, lang)
+        except VerificationUnknown as e:
+            _nie_zweryfikowano(f"manifestacji PDF dla {celex} w języku {lang3}", e)
         if not pdf_url:
             sys.exit(f"Brak manifestacji PDF dla {celex} w języku {lang3} — spróbuj inny --jezyk.")
         data, _ = _http(pdf_url)

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
@@ -25,6 +25,10 @@ import urllib.request, urllib.parse, urllib.error, http.cookiejar
 __version__ = "1.6.4"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
 BASE = "https://orzeczenia.nsa.gov.pl"
 
+
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
 # Miasta WSA (klucz bez diakrytyków) → końcówka pełnej nazwy z formularza CBOSA.
 # Wartości pola 'sad' to PEŁNE nazwy sądów — wartość spoza listy CBOSA po cichu zwraca 0 wyników.
 _WSA = {
@@ -102,6 +106,9 @@ _ostatnie = [0.0]
 
 def _fetch(path, data=None):
     """GET/POST strony CBOSA (HTML). Throttling >=0,5 s; ponowienia z rosnącym odstępem.
+    Zwraca pobrany HTML jako FOUND; UNKNOWN przekazuje przez VerificationUnknown.
+    VERIFIED_ABSENT ustala dopiero parser _wyniki z poprawnej strony CBOSA.
+
     CBOSA miewa kilkunastosekundowe okna, w których ucina połączenia bez odpowiedzi — stąd
     łącznie ~26 s ponawiania (za krótkie okno ponowień = fałszywy raport „skill nie działa").
     CBOSA serwuje niekompletny łańcuch certyfikatów — na systemach, gdzie weryfikacja pada,
@@ -132,8 +139,8 @@ def _fetch(path, data=None):
         except urllib.error.HTTPError as e:
             if e.code >= 500 and odstep is not None:
                 time.sleep(odstep); continue
-            sys.exit(f"BŁĄD HTTP {e.code}: {url}\n"
-                     "CBOSA ma codzienne krótkie okno serwisowe ok. 21:00 — spróbuj ponownie później.")
+            raise VerificationUnknown(
+                f"HTTP {e.code}: {url}; CBOSA ma codzienne krótkie okno serwisowe ok. 21:00") from e
         except urllib.error.URLError as e:
             if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError) \
                     and _ssl_ctx.verify_mode != ssl.CERT_NONE:
@@ -143,15 +150,13 @@ def _fetch(path, data=None):
                 continue
             if odstep is not None:
                 time.sleep(odstep); continue
-            sys.exit(f"BŁĄD sieci: {url} ({e})\n"
-                     "Serwer CBOSA bywa przeciążony i ucina połączenia — spróbuj ponownie za chwilę.")
+            raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
         except Exception as e:  # noqa: BLE001
             if odstep is not None:
                 time.sleep(odstep); continue
-            sys.exit(f"BŁĄD sieci: {url} ({e})\n"
-                     "Serwer CBOSA bywa przeciążony i ucina połączenia — spróbuj ponownie za chwilę.")
+            raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
     # wyczerpane próby po przełączeniu kontekstu SSL w ostatnim obiegu — nigdy nie zwracaj None
-    sys.exit(f"BŁĄD sieci: {url} — nie udało się pobrać strony po kilku próbach.")
+    raise VerificationUnknown(f"nie udało się pobrać {url} po kilku próbach")
 
 
 # ── Parsowanie HTML (regexy zweryfikowane na żywych stronach CBOSA) ─────────────────────
@@ -222,6 +227,8 @@ def _wyniki(strona_html):
             if sm:
                 snippet = re.sub(r"\s+", " ", _text(sm.group(1))).strip()
         pozycje.append({"doc_id": m.group(1), "opis": opis, "snippet": snippet, "powiazane": powiazane})
+    if total is None and not pozycje and not komunikat:
+        raise VerificationUnknown("CBOSA zwróciło stronę bez licznika i listy wyników")
     return total, pozycje, komunikat
 
 
@@ -252,6 +259,8 @@ def _orzeczenie(strona_html, doc_id):
                       r'\s*</div>\s*<span class="info-list-value-uzasadnienie">(.*?)</span>', flat, re.S)
         if m:
             d[sekcja.lower()] = _text(m.group(1))
+    if not d.get("tytul") and not d.get("metadane"):
+        raise VerificationUnknown(f"nie udało się rozpoznać strony orzeczenia {doc_id}")
     return d
 
 
@@ -313,17 +322,13 @@ def cmd_szukaj(a):
         sys.exit("Podaj kryterium: frazę albo --sad / --sygnatura / --rodzaj / --symbol / --sedzia / zakres dat.")
     strona = max(1, a.strona)
     total, pozycje, komunikat = _szukaj(_formularz(a), strona)
-    if a.json:
-        print(json.dumps({"total": total, "strona": strona, "komunikat": komunikat, "wyniki": pozycje},
-                         ensure_ascii=False, indent=2)); return
     if total is None and not pozycje:
         if komunikat:  # formularz odrzucił zapytanie (np. zła data) — to błąd wejścia, nie serwera
             sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}\nPopraw parametry i ponów "
                      "(daty w formacie RRRR-MM-DD).")
-        # strona bez licznika „Znaleziono N" = strona błędu/przeciążenia, NIE zweryfikowane zero
-        sys.exit("BŁĄD: CBOSA zwróciło stronę bez listy wyników (serwer przeciążony albo strona "
-                 "błędu) — to NIE oznacza braku orzeczeń. Spróbuj ponownie za chwilę; zapytania "
-                 "z zakresem dat bywają najcięższe (możesz zawęzić frazą i filtrować daty z listy).")
+    if a.json:
+        print(json.dumps({"total": total, "strona": strona, "komunikat": komunikat, "wyniki": pozycje},
+                         ensure_ascii=False, indent=2)); return
     if total == 0 or not pozycje:
         sys.exit("Brak wyników (zweryfikowane zero). Uwaga: wyszukiwarka CBOSA wymaga dokładnych "
                  "wartości — spróbuj prostszej frazy, bez --sad, albo sprawdź sygnaturę/symbol.")
@@ -337,8 +342,6 @@ def cmd_orzeczenie(a):
     d = _orzeczenie(_fetch(f"/doc/{doc_id}"), doc_id)
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    if not d.get("tytul") and not d.get("metadane"):
-        sys.exit(f"Nie udało się sparsować orzeczenia {doc_id} — sprawdź w przeglądarce: {d['url']}")
     print(f"# {d.get('tytul', doc_id)}   [{doc_id}]")
     for k in ("Data orzeczenia", "Sąd", "Sędziowie", "Symbol z opisem", "Hasła tematyczne",
               "Skarżony organ", "Treść wyniku", "Powołane przepisy", "Sygn. powiązane"):
@@ -379,14 +382,12 @@ def cmd_sygnatura(a):
             "sygnatura": sig, "sad": "dowolny", "rodzaj": "dowolny", "symbole": "",
             "odDaty": "", "doDaty": "", "sedziowie": "", "funkcja": "", "submit": "Szukaj"}
     total, pozycje, komunikat = _szukaj(form)
-    if a.json:
-        print(json.dumps({"total": total, "komunikat": komunikat, "wyniki": pozycje},
-                         ensure_ascii=False, indent=2)); return
     if total is None and not pozycje:
         if komunikat:
             sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}")
-        sys.exit("BŁĄD: CBOSA zwróciło stronę bez listy wyników (serwer przeciążony albo strona "
-                 "błędu) — to NIE oznacza braku orzeczeń. Spróbuj ponownie za chwilę.")
+    if a.json:
+        print(json.dumps({"total": total, "komunikat": komunikat, "wyniki": pozycje},
+                         ensure_ascii=False, indent=2)); return
     glowne = [p for p in pozycje if not p["powiazane"]]
     if not glowne:
         sys.exit(f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w CBOSA.\n"
@@ -435,7 +436,11 @@ def main():
                        help="zrzut sparsowanych danych jako JSON")
 
     a = ap.parse_args()
-    a.func(a)
+    try:
+        a.func(a)
+    except VerificationUnknown as e:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować danych w CBOSA ({e}). "
+                 "Spróbuj ponownie za chwilę.")
 
 
 if __name__ == "__main__":

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -23,8 +23,21 @@ __version__ = "1.6.4"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validat
 BASE = "https://api.sejm.gov.pl/eli"
 
 
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _nie_zweryfikowano(co, blad):
+    sys.exit(f"BŁĄD: nie udało się zweryfikować {co} ({blad}). "
+             "Spróbuj ponownie za chwilę.")
+
+
 def _get(path, params=None, soft=False):
-    """GET z jednym ponowieniem na błąd przejściowy. soft=True: zamiast wyjścia zwraca None."""
+    """GET z jednym ponowieniem.
+
+    Zwraca dane, w tym pustą odpowiedź jako VERIFIED_ABSENT. Przy soft=True błąd
+    żądania ma osobny stan UNKNOWN (VerificationUnknown), nigdy None/pusty wynik.
+    """
     url = BASE + path
     if params:
         q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "", False)})
@@ -42,18 +55,18 @@ def _get(path, params=None, soft=False):
             if e.code >= 500 and attempt == 1:
                 time.sleep(2); continue
             if soft:
-                return None
+                raise VerificationUnknown(f"HTTP {e.code}: {url}") from e
             sys.exit(f"BŁĄD HTTP {e.code}: {url}")
         except Exception as e:
             if attempt == 1:
                 time.sleep(2); continue
             if soft:
-                return None
+                raise VerificationUnknown(f"błąd sieci: {url} ({e})") from e
             sys.exit(f"BŁĄD sieci: {url} ({e})")
     if raw is not None and "Request Rejected" in raw and "rejected" in raw.lower():
         # zapora (WAF) api.sejm.gov.pl potrafi odrzucać wybrane URL-e (m.in. /text.html/{tree})
         if soft:
-            return None
+            raise VerificationUnknown(f"zapora api.sejm.gov.pl odrzuciła żądanie: {url}")
         sys.exit(f"BŁĄD: zapora api.sejm.gov.pl odrzuciła żądanie (Request Rejected): {url}\n"
                  "Spróbuj ponownie; do pojedynczego artykułu użyj: tekst <syg> --fragment \"art. N\".")
     if "json" in ctype:
@@ -269,7 +282,8 @@ def _tj_z_tekstem(path, refs):
         base = next((r.get("act") for r in items if isinstance(r, dict) and isinstance(r.get("act"), dict)), None)
         if base and base.get("ELI"):
             base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
-            tj = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
+            base_refs = _expect_dict(base_refs, "odniesienia aktu bazowego")
+            tj = _tj_acts(base_refs)
     for act in tj:
         eli_id = act.get("ELI")
         if not eli_id or eli_id == biezacy_eli:
@@ -360,8 +374,12 @@ def cmd_meta(a):
 
 def cmd_tekst(a):
     path, label = act_path(a.sygnatura)
-    refs = _get(path + "/references", soft=True)
-    ostrz = _ostrzezenia(refs) if isinstance(refs, dict) else []
+    try:
+        refs = _get(path + "/references", soft=True)
+    except VerificationUnknown as e:
+        _nie_zweryfikowano(f"odniesień i aktualności aktu {label}", e)
+    refs = _expect_dict(refs, "odniesienia aktu")
+    ostrz = _ostrzezenia(refs)
     if a.pdf:
         # pobierz urzędowy PDF (preferuj tekst jednolity, typ 'U'/'T', inaczej oryginał 'O')
         meta = _expect_dict(_get(path), "metadane aktu")
@@ -386,7 +404,10 @@ def cmd_tekst(a):
         html = json.dumps(html, ensure_ascii=False)
     txt = html_to_text(html if isinstance(html, str) else "")
     if not txt:
-        fb = _tj_z_tekstem(path, refs if isinstance(refs, dict) else {})
+        try:
+            fb = _tj_z_tekstem(path, refs if isinstance(refs, dict) else {})
+        except VerificationUnknown as e:
+            _nie_zweryfikowano(f"zapasowego tekstu jednolitego dla {label}", e)
         if not fb:
             sys.exit(f"BŁĄD: text.html dla {label} jest PUSTE w API (HTML bywa dodawany z opóźnieniem) "
                      f"i nie znalazłem innego tekstu jednolitego z tekstem. "
@@ -519,8 +540,12 @@ def cmd_tj(a):
         # sprawdź na akcie bazowym, czy nie ma już NOWSZEGO tekstu jednolitego
         m = re.match(r"^/acts/(DU|MP)/(\d+)/(\d+)$", path)
         if base and base.get("ELI") and m:
-            base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
-            newer = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
+            try:
+                base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
+            except VerificationUnknown as e:
+                _nie_zweryfikowano(f"nowszego tekstu jednolitego dla {label}", e)
+            base_refs = _expect_dict(base_refs, "odniesienia aktu bazowego")
+            newer = _tj_acts(base_refs)
             if newer and _eli_rok_poz(newer[0]) > (int(m.group(2)), int(m.group(3))):
                 print(f"UWAGA: istnieje NOWSZY tekst jednolity: {newer[0].get('displayAddress') or newer[0].get('ELI','')} — cytuj z niego.")
         return

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
@@ -25,6 +25,10 @@ from html.parser import HTMLParser
 __version__ = "1.6.4"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
 BASE = "https://www.saos.org.pl/api"
 
+
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
 # Aliasy typów sądów (courtType w API SAOS)
 SADY = {
     "SN": "SUPREME", "SUPREME": "SUPREME",
@@ -76,7 +80,11 @@ def _ostrzezenie_zasiegu(ct, od=None):
 
 
 def _get(path, params=None, soft=False):
-    """GET z jednym ponowieniem na błąd przejściowy. soft=True: zamiast wyjścia zwraca None."""
+    """GET z jednym ponowieniem.
+
+    Zwraca dane, w tym pusty wynik jako VERIFIED_ABSENT. Przy soft=True błąd
+    żądania ma osobny stan UNKNOWN (VerificationUnknown), nigdy None/pusty wynik.
+    """
     url = BASE + path
     if params:
         q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "", False)})
@@ -93,14 +101,14 @@ def _get(path, params=None, soft=False):
                 if attempt == 1:
                     time.sleep(2); continue
                 if soft:
-                    return None
+                    raise VerificationUnknown("SAOS ma przerwę techniczną")
                 sys.exit("BŁĄD: SAOS ma przerwę techniczną (serwis chwilowo niedostępny) — spróbuj ponownie później.")
             break
         except urllib.error.HTTPError as e:
             if e.code >= 500 and attempt == 1:
                 time.sleep(2); continue
             if soft:
-                return None
+                raise VerificationUnknown(f"HTTP {e.code}: {url}") from e
             if e.code == 404:
                 sys.exit(f"BŁĄD HTTP 404 (nie znaleziono): {url}")
             sys.exit(f"BŁĄD HTTP {e.code}: {url}")
@@ -108,12 +116,38 @@ def _get(path, params=None, soft=False):
             if attempt == 1:
                 time.sleep(2); continue
             if soft:
-                return None
+                raise VerificationUnknown(f"błąd sieci: {url} ({e})") from e
             sys.exit(f"BŁĄD sieci: {url} ({e})")
     try:
         return json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return raw
+
+
+def _expect_dict(d, what):
+    if not isinstance(d, dict):
+        sys.exit(f"BŁĄD: nie udało się zweryfikować {what}, ponieważ API SAOS zwróciło "
+                 "nieoczekiwaną odpowiedź. Spróbuj ponownie za chwilę.")
+    return d
+
+
+def _expect_search(d, what):
+    d = _expect_dict(d, what)
+    info = d.get("info")
+    if not isinstance(d.get("items"), list) or not isinstance(info, dict) \
+            or "totalResults" not in info:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować {what}, ponieważ odpowiedź API SAOS "
+                 "nie zawiera kompletnego wyniku wyszukiwania. Spróbuj ponownie za chwilę.")
+    return d
+
+
+def _expect_judgment(d, judgment_id):
+    d = _expect_dict(d, f"orzeczenia {judgment_id}")
+    data = d.get("data", d)
+    if not isinstance(data, dict) or data.get("id") is None:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować orzeczenia {judgment_id}, ponieważ odpowiedź "
+                 "API SAOS nie zawiera danych orzeczenia. Spróbuj ponownie za chwilę.")
+    return d
 
 
 class _Stripper(HTMLParser):
@@ -267,10 +301,9 @@ def cmd_szukaj(a):
     if not kryteria:
         sys.exit("Podaj kryterium: frazę albo --sad / --sygnatura / --przepis / --sedzia / --haslo / --typ / zakres dat.")
     d = _get("/search/judgments", params)
+    d = _expect_search(d, "wyników wyszukiwania")
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    if not isinstance(d, dict):
-        sys.exit("BŁĄD: API SAOS zwróciło nieoczekiwaną odpowiedź — spróbuj ponownie za chwilę.")
     items = d.get("items", [])
     total = (d.get("info") or {}).get("totalResults", "?")
     print(f"Znaleziono: {total}  (pokazuję {len(items)}, strona {params['pageNumber']}, po {params['pageSize']})\n")
@@ -290,10 +323,9 @@ def cmd_szukaj(a):
 
 def cmd_orzeczenie(a):
     d = _get(f"/judgments/{a.id}")
+    d = _expect_judgment(d, a.id)
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    if not isinstance(d, dict):
-        sys.exit("BŁĄD: API SAOS zwróciło nieoczekiwaną odpowiedź.")
     data = d.get("data", d)
     cn = _case_numbers(data) or "—"
     ctype = CT_PL.get(data.get("courtType", ""), data.get("courtType", ""))
@@ -358,10 +390,11 @@ def cmd_sygnatura(a):
     sig = " ".join(a.sygnatura).strip()
     d = _get("/search/judgments", {"caseNumber": sig, "pageSize": 20, "pageNumber": 0,
                                    "sortingField": "JUDGMENT_DATE", "sortingDirection": "DESC"})
+    d = _expect_search(d, f"orzeczenia o sygnaturze {sig!r}")
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    items = d.get("items", []) if isinstance(d, dict) else []
-    total = (d.get("info") or {}).get("totalResults", 0) if isinstance(d, dict) else 0
+    items = d.get("items", [])
+    total = (d.get("info") or {}).get("totalResults", 0)
     if not items:
         sys.exit(f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w SAOS.\n"
                  "SAOS to baza wtórna (nie ma wszystkiego) — sprawdź też portal właściwego sądu; "

--- a/tools/test_cbosa.py
+++ b/tools/test_cbosa.py
@@ -5,6 +5,8 @@ import sys
 import importlib.util
 import pathlib
 import unittest
+import urllib.error
+from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location(
@@ -176,10 +178,10 @@ class TestWyniki(unittest.TestCase):
         self.assertEqual(cbosa._wyniki(self.HTML)[2], "")
 
     def test_pusty_html(self):
-        total, poz, komunikat = cbosa._wyniki("<html><body>Brak wyników</body></html>")
-        self.assertIsNone(total)
-        self.assertEqual(poz, [])
-        self.assertEqual(komunikat, "")
+        # Strona bez rozpoznanego licznika/listy jest teraz UNKNOWN, nie cichym
+        # sentinelem (None, [], "") - patch found/verified_absent/unknown.
+        with self.assertRaises(cbosa.VerificationUnknown):
+            cbosa._wyniki("<html><body>Brak wyników</body></html>")
 
 
 class TestOrzeczenie(unittest.TestCase):
@@ -261,7 +263,10 @@ class TestFetchPonowienia(unittest.TestCase):
         self.assertGreaterEqual(sum(s for s in licznik["spanie"] if s > 0.5), 26)
 
     def test_trwala_awaria_konczy_bledem(self):
-        with self.assertRaises(SystemExit):
+        # Trwala awaria transportu to teraz UNKNOWN (nie SystemExit) na poziomie
+        # _fetch - main() dopiero mapuje to na polski komunikat i exit (patch
+        # found/verified_absent/unknown, patrz VerificationUnknown ponizej).
+        with self.assertRaises(cbosa.VerificationUnknown):
             self._uruchom(awarie=99)
 
 
@@ -309,6 +314,30 @@ class TestFlagaJson(unittest.TestCase):
 
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+
+class CbosaVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_transport_error_is_unknown(self):
+        opener = mock.Mock()
+        opener.open.side_effect = urllib.error.URLError("offline")
+        cbosa._ostatnie[0] = 0.0
+        with mock.patch.object(cbosa.urllib.request, "build_opener", return_value=opener), \
+                mock.patch.object(cbosa.time, "sleep"):
+            with self.assertRaises(cbosa.VerificationUnknown):
+                cbosa._fetch("/cbo/search")
+
+    def test_no_results_warning_is_verified_absent(self):
+        html = '<div class="warning">Nie znaleziono orzeczeń spełniających kryteria</div>'
+        total, results, message = cbosa._wyniki(html)
+        self.assertEqual(total, 0)
+        self.assertEqual(results, [])
+        self.assertIn("Nie znaleziono", message)
+
+    def test_unrecognized_error_page_is_unknown(self):
+        with self.assertRaises(cbosa.VerificationUnknown):
+            cbosa._wyniki("<html><title>Service unavailable</title></html>")
 
 
 if __name__ == "__main__":

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Offline unit tests for eli.py pure functions (no network). Run: python3 tools/test_eli.py"""
+import argparse
 import sys
 import importlib.util
 import pathlib
 import unittest
+import urllib.error
+from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location(
@@ -295,6 +298,43 @@ class TestFlagaJson(unittest.TestCase):
 
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+
+class _Response:
+    def __init__(self, body, content_type="application/json"):
+        self.body = body
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class EliVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_soft_transport_error_is_unknown(self):
+        with mock.patch.object(eli.urllib.request, "urlopen", side_effect=urllib.error.URLError("offline")), \
+                mock.patch.object(eli.time, "sleep"):
+            with self.assertRaises(eli.VerificationUnknown):
+                eli._get("/acts/test/references", soft=True)
+
+    def test_successful_empty_json_is_verified_absent(self):
+        response = _Response(b"[]")
+        with mock.patch.object(eli.urllib.request, "urlopen", return_value=response):
+            self.assertEqual(eli._get("/acts/search", soft=True), [])
+
+    def test_command_reports_unknown_references(self):
+        args = argparse.Namespace(sygnatura=["DU", "2024", "18"], json=False,
+                                  pdf=None, fragment=None)
+        with mock.patch.object(eli, "_get", side_effect=eli.VerificationUnknown("timeout")):
+            with self.assertRaisesRegex(SystemExit, "nie udało się zweryfikować.*Spróbuj ponownie"):
+                eli.cmd_tekst(args)
 
 
 if __name__ == "__main__":

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Offline unit tests for eurlex.py pure functions (no network). Run: python3 tools/test_eurlex.py"""
+import argparse
 import sys
 import importlib.util
 import pathlib
 import unittest
+from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location(
@@ -158,6 +160,26 @@ class TestFlagaJson(unittest.TestCase):
 
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+
+class EurlexVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_soft_transport_error_is_unknown(self):
+        with mock.patch.object(eurlex, "_http", side_effect=SystemExit("BŁĄD sieci")):
+            with self.assertRaises(eurlex.VerificationUnknown):
+                eurlex._sparql("SELECT * WHERE {}", soft=True)
+
+    def test_successful_zero_consolidations_is_verified_absent(self):
+        with mock.patch.object(eurlex, "_sparql", return_value=[]):
+            self.assertEqual(eurlex._konsolidacje("32016R0679"), [])
+
+    def test_command_reports_unknown_consolidations(self):
+        args = argparse.Namespace(celex=["32016R0679"], json=False)
+        with mock.patch.object(eurlex, "_konsolidacje",
+                               side_effect=eurlex.VerificationUnknown("timeout")):
+            with self.assertRaisesRegex(SystemExit, "nie udało się zweryfikować.*Spróbuj ponownie"):
+                eurlex.cmd_skonsolidowany(args)
 
 
 if __name__ == "__main__":

--- a/tools/test_saos.py
+++ b/tools/test_saos.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Offline unit tests for saos.py pure functions (no network). Run: python3 tools/test_saos.py"""
+import argparse
 import sys
 import importlib.util
 import pathlib
 import unittest
+import urllib.error
+from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location(
@@ -194,6 +197,46 @@ class TestFlagaJson(unittest.TestCase):
 
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+
+class _Response:
+    headers = {"Content-Type": "application/json"}
+
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class SaosVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_soft_transport_error_is_unknown(self):
+        with mock.patch.object(saos.urllib.request, "urlopen", side_effect=urllib.error.URLError("offline")), \
+                mock.patch.object(saos.time, "sleep"):
+            with self.assertRaises(saos.VerificationUnknown):
+                saos._get("/search/judgments", soft=True)
+
+    def test_successful_zero_results_is_verified_absent(self):
+        response = _Response(b'{"items": [], "info": {"totalResults": 0}}')
+        with mock.patch.object(saos.urllib.request, "urlopen", return_value=response):
+            result = saos._get("/search/judgments", soft=True)
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["info"]["totalResults"], 0)
+
+    def test_malformed_api_response_is_not_no_results(self):
+        args = argparse.Namespace(sygnatura=["III", "CSK", "203/09"], json=False)
+        with mock.patch.object(saos, "_get", return_value={"message": "maintenance"}):
+            with self.assertRaisesRegex(SystemExit, "nie udało się zweryfikować") as caught:
+                saos.cmd_sygnatura(args)
+        self.assertNotIn("Nie znaleziono orzeczenia", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Several soft-fetch helpers (`_get` / `_sparql` / `_fetch`) collapse a failed
request (timeout, non-2xx status, malformed response body, a WAF/maintenance
page returned with HTTP 200) into the same empty value used for a genuinely
confirmed negative result. Callers then print "brak wynikow" / an empty list
with exit code 0 - indistinguishable from a real, verified absence.

For legal-citation tooling this is a real risk: "I could not check" must
never render the same as "I checked, and there's nothing".

## Fix

Each script gets a `VerificationUnknown` exception and a
`found / verified_absent / unknown` contract:

- a successful request that legitimately returns nothing -> `VERIFIED_ABSENT`
  (unchanged: empty list / message as before),
- any transport or parsing failure -> `UNKNOWN`, propagated as
  `VerificationUnknown` and surfaced by the CLI as an explicit
  "nie udalo sie zweryfikowac ... sprobuj ponownie" error instead of a
  silent empty answer.

30 call sites across `eli.py`, `eurlex.py`, `saos.py` and `cbosa.py` were
audited and fixed - happy to post the full file:line before/after list if
useful for review.

## Tests

12 new tests (3 per script) exercise the UNKNOWN vs VERIFIED_ABSENT split
with mocked transport. 2 pre-existing `cbosa` tests whose assertions
encoded the old collapsed behavior on purpose
(`test_trwala_awaria_konczy_bledem`, `test_pusty_html`) were updated to
match the new explicit contract - both were asserting the exact silent
fallback this PR removes.

All 108 tests across the four `tools/test_*.py` files pass.

## Open questions (not guessed, left for you)

1. Does ELI `/acts/{ELI}/text.html` returning HTTP 404 have documented
   "confirmed absent" semantics, or can it also be a transient/WAF
   response? The patch treats it conservatively as `UNKNOWN`, same as any
   other non-2xx status.
2. Same question for CBOSA `/doc/{id}` - does 404 reliably mean "no such
   document", or can it also come from the search-result site under load?

If either has a guaranteed "not found" contract, that endpoint could be
carved out as its own `VERIFIED_ABSENT` case rather than staying
conservative.

No live API calls were made while preparing this patch; the
found/verified_absent/unknown split is verified with mocked transport only.