### PR TITLE
fix: authenticate transport for legal-citation sources (HTTPS for CELLAR, explicit TLS opt-in for CBOSA)

### DIFF
--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/references/api.md
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/references/api.md
@@ -6,9 +6,12 @@ Wszystko publiczne, bez klucza. Read-only.
 
 - **SPARQL**: `https://publications.europa.eu/webapi/rdf/sparql`
   POST/GET z `query=` + `format=application/sparql-results+json` (też XML/CSV).
-- **CELLAR REST (treść)**: `http://publications.europa.eu/resource/celex/{CELEX}`
-  z nagłówkami `Accept: application/xhtml+xml` i `Accept-Language: pol|eng|…` (kod 3-literowy,
-  małymi). PDF NIE działa przez negocjację — pobierz URL manifestacji przez SPARQL
+- **CELLAR REST (treść)**: URI zasobu ma postać
+  `http://publications.europa.eu/resource/celex/{CELEX}`, ale żądanie sieciowe wysyłaj przez
+  `https://publications.europa.eu/resource/celex/{CELEX}`. `eurlex.py` podnosi schemat do HTTPS
+  tuż przed pobraniem, także dla URL manifestacji zwróconych przez SPARQL. Używa nagłówków
+  `Accept: application/xhtml+xml` i `Accept-Language: pol|eng|…` (kod 3-literowy, małymi).
+  PDF NIE działa przez negocjację — pobierz URL manifestacji przez SPARQL
   (`cdm:manifestation_manifests_expression`, `cdm:manifestation_type` zaczynający się od `pdf`)
   i doklej `/DOC_1`.
 - **ELI URI**: `http://data.europa.eu/eli/reg/2016/679/oj` → przekierowanie na EUR-Lex.

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -65,9 +65,14 @@ def _wymus_https(url):
     (CDM, LANG_AUTH, TYPE_AUTH, XSD_STR) zostają nietknięte, bo zmiana ich
     postaci zerwałaby dopasowanie w zapytaniach SPARQL.
     """
-    if url.startswith("http://") and url[len("http://"):].split("/", 1)[0].endswith(
-            ("europa.eu", "europa.eu:80")):
-        return "https://" + url[len("http://"):]
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    cellar_host = "publications.europa.eu"
+    if parsed.scheme.lower() == "http" and (
+            host == cellar_host or host.endswith("." + cellar_host)):
+        # Zmieniamy wyłącznie schemat. Oryginalna pisownia hosta, user-info, port,
+        # ścieżka, parametry, query i fragment pozostają bajt w bajt bez zmian.
+        return "https" + url[len(parsed.scheme):]
     return url
 
 

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -52,8 +52,28 @@ def _lang(j):
     sys.exit(f"Nieznany język: {j!r}. Użyj np. pol, eng, deu, fra (kod 3-literowy).")
 
 
+def _wymus_https(url):
+    """Podnosi http:// do https:// dla adresów, z których realnie pobieramy treść.
+
+    CELLAR identyfikuje zasoby URI w formie ``http://`` i tak też zwraca adresy
+    manifestacji w wynikach SPARQL — to poprawne jako *nazwa* zasobu, ale jako
+    *transport* oznacza pobieranie tekstu aktu prawnego kanałem bez szyfrowania
+    i bez uwierzytelnienia serwera. Treść trafia stąd do cytatów prawnych, więc
+    podmiana w tranzycie jest realnym ryzykiem, nie teoretycznym.
+
+    Podnosimy schemat wyłącznie tuż przed żądaniem; stałe URI przestrzeni nazw
+    (CDM, LANG_AUTH, TYPE_AUTH, XSD_STR) zostają nietknięte, bo zmiana ich
+    postaci zerwałaby dopasowanie w zapytaniach SPARQL.
+    """
+    if url.startswith("http://") and url[len("http://"):].split("/", 1)[0].endswith(
+            ("europa.eu", "europa.eu:80")):
+        return "https://" + url[len("http://"):]
+    return url
+
+
 def _http(url, data=None, headers=None, timeout=60):
     """GET/POST z jednym ponowieniem na błąd przejściowy. Zwraca (bytes, content-type)."""
+    url = _wymus_https(url)
     req = urllib.request.Request(url, data=data, headers={
         "User-Agent": f"eurlex-skill/{__version__}", **(headers or {})})
     for attempt in (1, 2):

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
@@ -91,7 +91,11 @@ Typowy przepływ: `szukaj` (zawęź `--sad`/`--od`/`--symbol`) → wybierz doc_i
 5. **Nie myl orzeczenia z przepisem.** Brzmienie i aktualność powołanych przepisów potwierdź w ELI
    (skill prawo-pl-eli) — orzeczenie mogło zapaść na starszym stanie prawnym.
 6. **Okno serwisowe:** CBOSA ma codzienną krótką przerwę ok. 21:00 — błędy o tej porze są normalne.
-7. Szczegóły kontraktu HTML (pola formularza, struktura stron): `references/api.md`.
+7. **Błąd certyfikatu TLS nie obniża zabezpieczeń automatycznie.** Domyślnie daje `UNKNOWN`.
+   Jeżeli operator świadomie akceptuje ryzyko, może dla jednego uruchomienia ustawić
+   `CBOSA_INSECURE_TLS=1`. Wynik JSON ma wtedy `transport_tls_verified: false`, a wynik tekstowy
+   ostrzeżenie przy treści. Takiej treści nie cytuj bez sprawdzenia w innym źródle.
+8. Szczegóły kontraktu HTML (pola formularza, struktura stron): `references/api.md`.
 
 ## Czego ten skill NIE obejmuje
 

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/references/api.md
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/references/api.md
@@ -72,8 +72,11 @@ POST zwraca stronę 1 + ciasteczka sesji (`Set-Cookie`). Kolejne strony: `GET /c
 
 - **Throttling ≥0,5 s** między żądaniami (wbudowany). Serwer bywa przeciążony i ucina połączenia bez
   odpowiedzi — silnik ponawia z rosnącym odstępem; nie zrównoleglaj zapytań.
-- **SSL:** CBOSA serwuje niekompletny łańcuch certyfikatów — na części systemów weryfikacja pada;
-  silnik przechodzi wtedy (tylko dla tego hosta) na kontekst bez weryfikacji łańcucha (dane publiczne).
+- **SSL:** gdy system nie potrafi zweryfikować łańcucha certyfikatów CBOSA, domyślnym wynikiem jest
+  `UNKNOWN`, bez automatycznego obniżenia zabezpieczeń. Jednorazowy, świadomy opt-in
+  `CBOSA_INSECURE_TLS=1 python3 scripts/cbosa.py ...` pozwala ponowić żądanie bez weryfikacji TLS.
+  Taki wynik ma w JSON pole `transport_tls_verified: false`, a w formacie tekstowym wyraźną
+  adnotację przy treści. Nie cytuj jej bez sprawdzenia w innym źródle.
 - **Symbole spraw** (pole `symbole`): 4-cyfrowe oznaczenia repertoriów, np. `611x` podatki
   (6112 PIT, 6110 VAT), `6014` prawo budowlane, `6320` pomoc społeczna, `6480` informacja publiczna.
   Pełny wykaz: zarządzenie Prezesa NSA (dostępne na stronach NSA).

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
@@ -19,7 +19,7 @@ Komendy:
 Globalnie: --json  (zrzut sparsowanych danych jako JSON zamiast podsumowania; działa przed
 komendą i po niej)
 """
-import sys, json, re, time, argparse, ssl, calendar, html as html_mod
+import sys, os, json, re, time, argparse, ssl, calendar, html as html_mod
 import urllib.request, urllib.parse, urllib.error, http.cookiejar
 
 __version__ = "1.6.5"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
@@ -148,12 +148,26 @@ def _fetch(path, data=None):
             dopisek = "; CBOSA ma codzienne krótkie okno serwisowe ok. 21:00" if e.code >= 500 else ""
             raise VerificationUnknown(f"HTTP {e.code}: {url}{dopisek}") from e
         except urllib.error.URLError as e:
-            if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError) \
-                    and _ssl_ctx.verify_mode != ssl.CERT_NONE:
-                ctx = ssl.create_default_context()
-                ctx.check_hostname, ctx.verify_mode = False, ssl.CERT_NONE
-                _ssl_ctx = ctx
-                continue
+            if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
+                # Cichy downgrade TLS jest tu grozniejszy niz awaria: tresc orzeczenia
+                # trafia do cytatow w pismach procesowych, wiec zgoda na niezweryfikowany
+                # certyfikat oznacza zgode na cytowanie tresci od dowolnego posrednika.
+                # Domyslnie odmawiamy; obnizenie wymaga jawnej, swiadomej decyzji operatora.
+                if os.environ.get("CBOSA_INSECURE_TLS") != "1":
+                    raise VerificationUnknown(
+                        f"blad weryfikacji certyfikatu TLS: {url} ({e.reason}). "
+                        "Tresc z niezweryfikowanego polaczenia nie nadaje sie do cytowania. "
+                        "Jesli swiadomie akceptujesz to ryzyko (np. znany problem po stronie "
+                        "serwera), ustaw CBOSA_INSECURE_TLS=1 dla tego wywolania."
+                    ) from e
+                if _ssl_ctx.verify_mode != ssl.CERT_NONE:
+                    print("UWAGA: CBOSA_INSECURE_TLS=1 — weryfikacja certyfikatu WYLACZONA dla "
+                          f"{url}. Tresc pobrana tym polaczeniem NIE jest uwierzytelniona i nie "
+                          "powinna byc cytowana bez sprawdzenia w innym zrodle.", file=sys.stderr)
+                    ctx = ssl.create_default_context()
+                    ctx.check_hostname, ctx.verify_mode = False, ssl.CERT_NONE
+                    _ssl_ctx = ctx
+                    continue
             if odstep is not None:
                 time.sleep(odstep); continue
             raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
@@ -98,10 +98,34 @@ def _data(s, koniec=False):
     return f"{rok}-{mm:02d}-{dd:02d}"
 
 
-# ── HTTP: throttling, ciasteczka sesji (paginacja), awaryjny kontekst SSL ────────────────
+# ── HTTP: throttling, ciasteczka sesji (paginacja), jawny opt-in TLS ────────────────────
 _jar = http.cookiejar.CookieJar()
-_ssl_ctx = ssl.create_default_context()
 _ostatnie = [0.0]
+_transport_tls_verified = True
+
+
+def _dane_z_transportem(dane):
+    """Dodaje do wyniku JSON stan uwierzytelnienia transportu w tym przebiegu."""
+    return {**dane, "transport_tls_verified": _transport_tls_verified}
+
+
+def _uwaga_o_transporcie():
+    if _transport_tls_verified:
+        return ""
+    return ("UWAGA: transport TLS nie został zweryfikowany (CBOSA_INSECURE_TLS=1). "
+            "Treść nie jest uwierzytelniona i przed cytowaniem wymaga sprawdzenia "
+            "w innym źródle.")
+
+
+def _drukuj_uwage_o_transporcie():
+    uwaga = _uwaga_o_transporcie()
+    if uwaga:
+        print(uwaga + "\n")
+
+
+def _z_uwaga_o_transporcie(komunikat):
+    uwaga = _uwaga_o_transporcie()
+    return f"{uwaga}\n{komunikat}" if uwaga else komunikat
 
 
 def _fetch(path, data=None):
@@ -111,9 +135,10 @@ def _fetch(path, data=None):
 
     CBOSA miewa kilkunastosekundowe okna, w których ucina połączenia bez odpowiedzi — stąd
     łącznie ~26 s ponawiania (za krótkie okno ponowień = fałszywy raport „skill nie działa").
-    CBOSA serwuje niekompletny łańcuch certyfikatów — na systemach, gdzie weryfikacja pada,
-    silnik przechodzi (tylko dla tego hosta) na kontekst bez weryfikacji łańcucha (dane publiczne)."""
-    global _ssl_ctx
+    CBOSA może serwować łańcuch certyfikatów, którego część systemów nie potrafi zweryfikować.
+    Domyślnie taki błąd daje UNKNOWN. Dopiero CBOSA_INSECURE_TLS=1 pozwala ponowić żądanie bez
+    weryfikacji; wynik jawnie niesie wtedy stan nieuwierzytelnionego transportu."""
+    global _transport_tls_verified
     url = BASE + path
     body = urllib.parse.urlencode(data).encode("utf-8") if data is not None else None
     headers = {
@@ -123,59 +148,68 @@ def _fetch(path, data=None):
     }
     if body is not None:
         headers["Content-Type"] = "application/x-www-form-urlencoded"
-    # odstęp przed kolejną próbą; None = ostatnia próba (dalej już błąd)
+    # Kontekst jest lokalny dla jednego pobrania. Jawny opt-in nie zatruwa kolejnych
+    # wywołań _fetch w tym samym procesie ustawieniem CERT_NONE.
+    ssl_ctx = ssl.create_default_context()
+    insecure_tls = False
+    # odstęp przed kolejną próbą; None = ostatnia zwykła próba (dalej już błąd)
     for odstep in (2, 4, 8, 12, None):
-        czekaj = 0.5 - (time.time() - _ostatnie[0])
-        if czekaj > 0:
-            time.sleep(czekaj)
-        _ostatnie[0] = time.time()
-        opener = urllib.request.build_opener(
-            urllib.request.HTTPSHandler(context=_ssl_ctx),
-            urllib.request.HTTPCookieProcessor(_jar))
-        req = urllib.request.Request(url, data=body, headers=headers)
-        try:
-            with opener.open(req, timeout=40) as r:
-                return r.read().decode("utf-8", "replace")
-        except urllib.error.HTTPError as e:
-            if e.code >= 500 and odstep is not None:
-                time.sleep(odstep); continue
-            if e.code in (404, 410) and path.startswith("/doc/"):
-                # CBOSA odpowiada 410 (Gone) dla nieistniejącego doc_id — zweryfikowany brak,
-                # a nie awaria; "spróbuj ponownie" odsyłałoby użytkownika w nieskończoną pętlę
-                sys.exit(f"Nie znaleziono orzeczenia o id {path[len('/doc/'):]!r} w CBOSA "
-                         f"(HTTP {e.code} — zweryfikowany brak). doc_id bierz z komendy "
-                         "szukaj albo sygnatura.")
-            dopisek = "; CBOSA ma codzienne krótkie okno serwisowe ok. 21:00" if e.code >= 500 else ""
-            raise VerificationUnknown(f"HTTP {e.code}: {url}{dopisek}") from e
-        except urllib.error.URLError as e:
-            if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
-                # Cichy downgrade TLS jest tu grozniejszy niz awaria: tresc orzeczenia
-                # trafia do cytatow w pismach procesowych, wiec zgoda na niezweryfikowany
-                # certyfikat oznacza zgode na cytowanie tresci od dowolnego posrednika.
-                # Domyslnie odmawiamy; obnizenie wymaga jawnej, swiadomej decyzji operatora.
-                if os.environ.get("CBOSA_INSECURE_TLS") != "1":
-                    raise VerificationUnknown(
-                        f"blad weryfikacji certyfikatu TLS: {url} ({e.reason}). "
-                        "Tresc z niezweryfikowanego polaczenia nie nadaje sie do cytowania. "
-                        "Jesli swiadomie akceptujesz to ryzyko (np. znany problem po stronie "
-                        "serwera), ustaw CBOSA_INSECURE_TLS=1 dla tego wywolania."
-                    ) from e
-                if _ssl_ctx.verify_mode != ssl.CERT_NONE:
-                    print("UWAGA: CBOSA_INSECURE_TLS=1 — weryfikacja certyfikatu WYLACZONA dla "
-                          f"{url}. Tresc pobrana tym polaczeniem NIE jest uwierzytelniona i nie "
-                          "powinna byc cytowana bez sprawdzenia w innym zrodle.", file=sys.stderr)
-                    ctx = ssl.create_default_context()
-                    ctx.check_hostname, ctx.verify_mode = False, ssl.CERT_NONE
-                    _ssl_ctx = ctx
-                    continue
-            if odstep is not None:
-                time.sleep(odstep); continue
-            raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
-        except Exception as e:  # noqa: BLE001
-            if odstep is not None:
-                time.sleep(odstep); continue
-            raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
-    # wyczerpane próby po przełączeniu kontekstu SSL w ostatnim obiegu — nigdy nie zwracaj None
+        # Wewnętrzna pętla gwarantuje jedną realną, natychmiastową próbę po zmianie
+        # kontekstu, nawet jeśli błąd certyfikatu wystąpił w ostatnim obiegu pętli zewnętrznej.
+        while True:
+            czekaj = 0.5 - (time.time() - _ostatnie[0])
+            if czekaj > 0:
+                time.sleep(czekaj)
+            _ostatnie[0] = time.time()
+            opener = urllib.request.build_opener(
+                urllib.request.HTTPSHandler(context=ssl_ctx),
+                urllib.request.HTTPCookieProcessor(_jar))
+            req = urllib.request.Request(url, data=body, headers=headers)
+            if insecure_tls:
+                _transport_tls_verified = False
+            try:
+                with opener.open(req, timeout=40) as r:
+                    return r.read().decode("utf-8", "replace")
+            except urllib.error.HTTPError as e:
+                if e.code >= 500 and odstep is not None:
+                    time.sleep(odstep)
+                    break
+                if e.code in (404, 410) and path.startswith("/doc/"):
+                    # CBOSA odpowiada 410 (Gone) dla nieistniejącego doc_id — zweryfikowany brak,
+                    # a nie awaria; "spróbuj ponownie" odsyłałoby użytkownika w nieskończoną pętlę
+                    sys.exit(_z_uwaga_o_transporcie(
+                        f"Nie znaleziono orzeczenia o id {path[len('/doc/'):]!r} w CBOSA "
+                        f"(HTTP {e.code} — zweryfikowany brak). doc_id bierz z komendy "
+                        "szukaj albo sygnatura."))
+                dopisek = "; CBOSA ma codzienne krótkie okno serwisowe ok. 21:00" if e.code >= 500 else ""
+                raise VerificationUnknown(f"HTTP {e.code}: {url}{dopisek}") from e
+            except urllib.error.URLError as e:
+                if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
+                    # Domyślnie odmawiamy; obniżenie wymaga jawnej decyzji operatora.
+                    if os.environ.get("CBOSA_INSECURE_TLS") != "1":
+                        raise VerificationUnknown(
+                            f"blad weryfikacji certyfikatu TLS: {url} ({e.reason}). "
+                            "Tresc z niezweryfikowanego polaczenia nie nadaje sie do cytowania. "
+                            "Jesli swiadomie akceptujesz to ryzyko (np. znany problem po stronie "
+                            "serwera), ustaw CBOSA_INSECURE_TLS=1 dla tego wywolania."
+                        ) from e
+                    if not insecure_tls:
+                        print("UWAGA: CBOSA_INSECURE_TLS=1 — weryfikacja certyfikatu WYLACZONA dla "
+                              f"{url}. Tresc pobrana tym polaczeniem NIE jest uwierzytelniona i nie "
+                              "powinna byc cytowana bez sprawdzenia w innym zrodle.", file=sys.stderr)
+                        ssl_ctx = ssl.create_default_context()
+                        ssl_ctx.check_hostname, ssl_ctx.verify_mode = False, ssl.CERT_NONE
+                        insecure_tls = True
+                        continue
+                if odstep is not None:
+                    time.sleep(odstep)
+                    break
+                raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
+            except Exception as e:  # noqa: BLE001
+                if odstep is not None:
+                    time.sleep(odstep)
+                    break
+                raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
     raise VerificationUnknown(f"nie udało się pobrać {url} po kilku próbach")
 
 
@@ -345,11 +379,15 @@ def cmd_szukaj(a):
             sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}\nPopraw parametry i ponów "
                      "(daty w formacie RRRR-MM-DD).")
     if a.json:
-        print(json.dumps({"total": total, "strona": strona, "komunikat": komunikat, "wyniki": pozycje},
+        print(json.dumps(_dane_z_transportem(
+                         {"total": total, "strona": strona, "komunikat": komunikat,
+                          "wyniki": pozycje}),
                          ensure_ascii=False, indent=2)); return
     if total == 0 or not pozycje:
-        sys.exit("Brak wyników (zweryfikowane zero). Uwaga: wyszukiwarka CBOSA wymaga dokładnych "
-                 "wartości — spróbuj prostszej frazy, bez --sad, albo sprawdź sygnaturę/symbol.")
+        sys.exit(_z_uwaga_o_transporcie(
+            "Brak wyników (zweryfikowane zero). Uwaga: wyszukiwarka CBOSA wymaga dokładnych "
+            "wartości — spróbuj prostszej frazy, bez --sad, albo sprawdź sygnaturę/symbol."))
+    _drukuj_uwage_o_transporcie()
     _drukuj_liste(total, pozycje, strona)
 
 
@@ -359,12 +397,13 @@ def cmd_orzeczenie(a):
         sys.exit(f"Nieprawidłowy doc_id: {a.doc_id!r} (identyfikator ze strony wyników, np. 8889489BE0).")
     d = _orzeczenie(_fetch(f"/doc/{doc_id}"), doc_id)
     if a.json:
-        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+        print(json.dumps(_dane_z_transportem(d), ensure_ascii=False, indent=2)); return
     if not d.get("tytul") and not d.get("metadane"):
         # strona pobrana, ale nierozpoznana (przebudowa HTML? strona błędu z HTTP 200?) —
         # UNKNOWN z podpowiedzią; częściowy parse obejrzysz przez --json
         raise VerificationUnknown(f"nie udało się rozpoznać strony orzeczenia {doc_id} — "
                                   f"sprawdź w przeglądarce: {d['url']}")
+    _drukuj_uwage_o_transporcie()
     print(f"# {d.get('tytul', doc_id)}   [{doc_id}]")
     for k in ("Data orzeczenia", "Sąd", "Sędziowie", "Symbol z opisem", "Hasła tematyczne",
               "Skarżony organ", "Treść wyniku", "Powołane przepisy", "Sygn. powiązane"):
@@ -409,13 +448,16 @@ def cmd_sygnatura(a):
         if komunikat:
             sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}")
     if a.json:
-        print(json.dumps({"total": total, "komunikat": komunikat, "wyniki": pozycje},
+        print(json.dumps(_dane_z_transportem(
+                         {"total": total, "komunikat": komunikat, "wyniki": pozycje}),
                          ensure_ascii=False, indent=2)); return
     glowne = [p for p in pozycje if not p["powiazane"]]
     if not glowne:
-        sys.exit(f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w CBOSA.\n"
-                 "Sygnatury sądów administracyjnych mają formę np. \"II FSK 2870/18\" (NSA) "
-                 "albo \"I SA/Bk 226/18\" (WSA). SN/TK/sądy powszechne/KIO → skill prawo-pl-saos.")
+        sys.exit(_z_uwaga_o_transporcie(
+            f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w CBOSA.\n"
+            "Sygnatury sądów administracyjnych mają formę np. \"II FSK 2870/18\" (NSA) "
+            "albo \"I SA/Bk 226/18\" (WSA). SN/TK/sądy powszechne/KIO → skill prawo-pl-saos."))
+    _drukuj_uwage_o_transporcie()
     print(f"Sygnatura {sig!r}: dopasowań {total}\n")
     for p in pozycje:
         prefiks = "  ↳ powiązane: " if p["powiazane"] else "  "
@@ -424,6 +466,8 @@ def cmd_sygnatura(a):
 
 
 def main():
+    global _transport_tls_verified
+    _transport_tls_verified = True
     ap = argparse.ArgumentParser(
         description="CBOSA (read-only, scraping — brak oficjalnego API). "
                     "Orzecznictwo sądów administracyjnych: NSA + 16 WSA.")

--- a/tools/test_cbosa.py
+++ b/tools/test_cbosa.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 """Offline unit tests for cbosa.py pure functions (no network). Run: python3 tools/test_cbosa.py"""
 import os
+import io
+import json
 import sys
 import importlib.util
 import pathlib
 import ssl
 import unittest
 import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -373,32 +376,131 @@ class TestZgodaNaObnizenieTls(unittest.TestCase):
 
     def setUp(self):
         cbosa._ostatnie[0] = 0.0
-        self._ctx = cbosa._ssl_ctx
+        cbosa._transport_tls_verified = True
 
     def tearDown(self):
-        cbosa._ssl_ctx = self._ctx
+        cbosa._transport_tls_verified = True
 
-    def _padnij_na_certyfikacie(self):
-        blad = urllib.error.URLError(ssl.SSLCertVerificationError("certificate verify failed"))
-        opener = mock.Mock()
-        opener.open.side_effect = blad
-        return mock.patch.object(cbosa.urllib.request, "build_opener", return_value=opener)
+    class _Odpowiedz:
+        def __init__(self, body=b"<html>OK</html>"):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return self.body
+
+    def _transport(self, zachowanie):
+        """Buduje opener zależny od kontekstu HTTPS i zapisuje kontekst każdej próby."""
+        proby = []
+
+        def build_opener(*handlers):
+            https = next(h for h in handlers if isinstance(h, cbosa.urllib.request.HTTPSHandler))
+            context = https._context
+
+            class _Opener:
+                def open(self, req, timeout=None):
+                    proby.append(context)
+                    return zachowanie(len(proby), context)
+
+            return _Opener()
+
+        return proby, mock.patch.object(cbosa.urllib.request, "build_opener",
+                                        side_effect=build_opener)
+
+    @staticmethod
+    def _blad_certyfikatu():
+        return urllib.error.URLError(ssl.SSLCertVerificationError("certificate verify failed"))
 
     def test_bez_zgody_konczy_sie_unknown(self):
         srodowisko = {k: v for k, v in os.environ.items() if k != "CBOSA_INSECURE_TLS"}
-        with mock.patch.dict(os.environ, srodowisko, clear=True), self._padnij_na_certyfikacie():
+        proby, transport = self._transport(lambda nr, ctx: (_ for _ in ()).throw(
+            self._blad_certyfikatu()))
+        with mock.patch.dict(os.environ, srodowisko, clear=True), transport:
             with self.assertRaises(cbosa.VerificationUnknown) as ctx:
                 cbosa._fetch("/doc/testowy")
         komunikat = str(ctx.exception)
         self.assertIn("certyfikat", komunikat.lower())
         self.assertIn("CBOSA_INSECURE_TLS", komunikat)
+        self.assertEqual(len(proby), 1)
 
     def test_bez_zgody_nie_dotyka_kontekstu_ssl(self):
         srodowisko = {k: v for k, v in os.environ.items() if k != "CBOSA_INSECURE_TLS"}
-        with mock.patch.dict(os.environ, srodowisko, clear=True), self._padnij_na_certyfikacie():
+        proby, transport = self._transport(lambda nr, ctx: (_ for _ in ()).throw(
+            self._blad_certyfikatu()))
+        with mock.patch.dict(os.environ, srodowisko, clear=True), transport:
             with self.assertRaises(cbosa.VerificationUnknown):
                 cbosa._fetch("/doc/testowy")
-        self.assertNotEqual(cbosa._ssl_ctx.verify_mode, ssl.CERT_NONE)
+        self.assertTrue(proby)
+        self.assertTrue(all(ctx.verify_mode != ssl.CERT_NONE for ctx in proby))
+
+    def test_opt_in_przelacza_kontekst_i_realnie_ponawia(self):
+        def zachowanie(nr, context):
+            if context.verify_mode != ssl.CERT_NONE:
+                raise self._blad_certyfikatu()
+            return self._Odpowiedz()
+
+        proby, transport = self._transport(zachowanie)
+        with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
+                transport, mock.patch.object(cbosa.time, "sleep"), redirect_stderr(io.StringIO()):
+            html = cbosa._fetch("/doc/testowy")
+        self.assertIn("OK", html)
+        self.assertEqual(len(proby), 2)
+        self.assertNotEqual(proby[0].verify_mode, ssl.CERT_NONE)
+        self.assertEqual(proby[1].verify_mode, ssl.CERT_NONE)
+        self.assertIsNot(proby[0], proby[1])
+        self.assertFalse(cbosa._transport_tls_verified)
+
+    def test_blad_certyfikatu_w_ostatnim_obiegu_ma_dodatkowa_probe(self):
+        def zachowanie(nr, context):
+            if nr < 5:
+                raise OSError("Remote end closed connection without response")
+            if nr == 5:
+                raise self._blad_certyfikatu()
+            return self._Odpowiedz()
+
+        proby, transport = self._transport(zachowanie)
+        with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
+                transport, mock.patch.object(cbosa.time, "sleep"), redirect_stderr(io.StringIO()):
+            html = cbosa._fetch("/doc/testowy")
+        self.assertIn("OK", html)
+        self.assertEqual(len(proby), 6)
+        self.assertTrue(all(ctx.verify_mode != ssl.CERT_NONE for ctx in proby[:5]))
+        self.assertEqual(proby[5].verify_mode, ssl.CERT_NONE)
+
+    def test_json_niesie_znacznik_nieuwierzytelnionego_transportu(self):
+        body = TestOrzeczenie.HTML.encode("utf-8")
+
+        def zachowanie(nr, context):
+            if context.verify_mode != ssl.CERT_NONE:
+                raise self._blad_certyfikatu()
+            return self._Odpowiedz(body)
+
+        proby, transport = self._transport(zachowanie)
+        args = mock.Mock(doc_id="8889489BE0", json=True, fragment=None)
+        stdout = io.StringIO()
+        with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
+                transport, mock.patch.object(cbosa.time, "sleep"), \
+                redirect_stderr(io.StringIO()), redirect_stdout(stdout):
+            cbosa.cmd_orzeczenie(args)
+        wynik = json.loads(stdout.getvalue())
+        self.assertFalse(wynik["transport_tls_verified"])
+        self.assertEqual(len(proby), 2)
+
+    def test_tekst_ma_adnotacje_przy_tresci(self):
+        cbosa._transport_tls_verified = False
+        args = mock.Mock(doc_id="8889489BE0", json=False, fragment=None)
+        stdout = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value=TestOrzeczenie.HTML), \
+                redirect_stdout(stdout):
+            cbosa.cmd_orzeczenie(args)
+        wynik = stdout.getvalue()
+        self.assertIn("transport TLS nie został zweryfikowany", wynik)
+        self.assertLess(wynik.index("transport TLS"), wynik.index("# II FSK"))
 
 
 if __name__ == "__main__":

--- a/tools/test_cbosa.py
+++ b/tools/test_cbosa.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Offline unit tests for cbosa.py pure functions (no network). Run: python3 tools/test_cbosa.py"""
+import os
 import sys
 import importlib.util
 import pathlib
+import ssl
 import unittest
 import urllib.error
 from unittest import mock
@@ -364,6 +366,39 @@ class CbosaVerificationContractTests(unittest.TestCase):
                 mock.patch.object(cbosa.time, "sleep"):
             with self.assertRaises(cbosa.VerificationUnknown):
                 cbosa._fetch("/cbo/search")
+
+
+class TestZgodaNaObnizenieTls(unittest.TestCase):
+    """Downgrade TLS wymaga jawnej zgody: tresc CBOSA trafia do cytatow w pismach."""
+
+    def setUp(self):
+        cbosa._ostatnie[0] = 0.0
+        self._ctx = cbosa._ssl_ctx
+
+    def tearDown(self):
+        cbosa._ssl_ctx = self._ctx
+
+    def _padnij_na_certyfikacie(self):
+        blad = urllib.error.URLError(ssl.SSLCertVerificationError("certificate verify failed"))
+        opener = mock.Mock()
+        opener.open.side_effect = blad
+        return mock.patch.object(cbosa.urllib.request, "build_opener", return_value=opener)
+
+    def test_bez_zgody_konczy_sie_unknown(self):
+        srodowisko = {k: v for k, v in os.environ.items() if k != "CBOSA_INSECURE_TLS"}
+        with mock.patch.dict(os.environ, srodowisko, clear=True), self._padnij_na_certyfikacie():
+            with self.assertRaises(cbosa.VerificationUnknown) as ctx:
+                cbosa._fetch("/doc/testowy")
+        komunikat = str(ctx.exception)
+        self.assertIn("certyfikat", komunikat.lower())
+        self.assertIn("CBOSA_INSECURE_TLS", komunikat)
+
+    def test_bez_zgody_nie_dotyka_kontekstu_ssl(self):
+        srodowisko = {k: v for k, v in os.environ.items() if k != "CBOSA_INSECURE_TLS"}
+        with mock.patch.dict(os.environ, srodowisko, clear=True), self._padnij_na_certyfikacie():
+            with self.assertRaises(cbosa.VerificationUnknown):
+                cbosa._fetch("/doc/testowy")
+        self.assertNotEqual(cbosa._ssl_ctx.verify_mode, ssl.CERT_NONE)
 
 
 if __name__ == "__main__":

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -195,22 +195,44 @@ class EurlexVerificationContractTests(unittest.TestCase):
 class TestWymusHttps(unittest.TestCase):
     """CELLAR nazywa zasoby przez http:// URI, ale pobierac mamy po https."""
 
-    def test_podnosi_schemat_dla_europa_eu(self):
-        self.assertEqual(
-            eurlex._wymus_https("http://publications.europa.eu/resource/celex/32016R0679"),
-            "https://publications.europa.eu/resource/celex/32016R0679")
+    def test_dziewiec_przypadkow_url(self):
+        cases = [
+            ("http://publications.europa.eu/resource/celex/X?x=1#f",
+             "https://publications.europa.eu/resource/celex/X?x=1#f"),
+            ("http://notreally-europa.eu/resource/celex/X",
+             "http://notreally-europa.eu/resource/celex/X"),
+            ("http://publications.europa.eu@notreally-europa.eu/resource/celex/X",
+             "http://publications.europa.eu@notreally-europa.eu/resource/celex/X"),
+            ("http://PUBLICATIONS.EUROPA.EU/resource/celex/X",
+             "https://PUBLICATIONS.EUROPA.EU/resource/celex/X"),
+            ("HTTP://publications.europa.eu/resource/celex/X",
+             "https://publications.europa.eu/resource/celex/X"),
+            ("http://publications.europa.eu./resource/celex/X",
+             "https://publications.europa.eu./resource/celex/X"),
+            ("http://publications.europa.eu:443/resource/celex/X",
+             "https://publications.europa.eu:443/resource/celex/X"),
+            ("http://publications.europa.eu:8080/resource/celex/X",
+             "https://publications.europa.eu:8080/resource/celex/X"),
+            ("http://api.publications.europa.eu/resource/celex/X",
+             "https://api.publications.europa.eu/resource/celex/X"),
+        ]
+        for url, expected in cases:
+            with self.subTest(url=url):
+                self.assertEqual(eurlex._wymus_https(url), expected)
 
-    def test_nie_rusza_juz_bezpiecznego_adresu(self):
-        url = "https://publications.europa.eu/webapi/rdf/sparql"
-        self.assertEqual(eurlex._wymus_https(url), url)
-
-    def test_nie_rusza_obcego_hosta(self):
-        url = "http://www.w3.org/2001/XMLSchema#string"
-        self.assertEqual(eurlex._wymus_https(url), url)
-
-    def test_nie_daje_sie_nabrac_na_podobna_domene(self):
+    def test_nie_daje_sie_nabrac_na_nadhosta(self):
         url = "http://publications.europa.eu.evil.example/resource/celex/X"
         self.assertEqual(eurlex._wymus_https(url), url)
+
+    def test_http_przekazuje_request_z_podniesionym_url(self):
+        odpowiedz = mock.MagicMock()
+        odpowiedz.__enter__.return_value = odpowiedz
+        odpowiedz.read.return_value = b"OK"
+        odpowiedz.headers.get.return_value = "text/plain"
+        with mock.patch.object(eurlex.urllib.request, "urlopen", return_value=odpowiedz) as urlopen:
+            eurlex._http("http://publications.europa.eu/resource/celex/X")
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://publications.europa.eu/resource/celex/X")
 
     def test_uri_przestrzeni_nazw_zostaja_http(self):
         # Zmiana ich postaci zerwalaby dopasowanie w zapytaniach SPARQL.

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -192,5 +192,31 @@ class EurlexVerificationContractTests(unittest.TestCase):
         self.assertIn("skonsolidowany 32016R0679", out[0])
 
 
+class TestWymusHttps(unittest.TestCase):
+    """CELLAR nazywa zasoby przez http:// URI, ale pobierac mamy po https."""
+
+    def test_podnosi_schemat_dla_europa_eu(self):
+        self.assertEqual(
+            eurlex._wymus_https("http://publications.europa.eu/resource/celex/32016R0679"),
+            "https://publications.europa.eu/resource/celex/32016R0679")
+
+    def test_nie_rusza_juz_bezpiecznego_adresu(self):
+        url = "https://publications.europa.eu/webapi/rdf/sparql"
+        self.assertEqual(eurlex._wymus_https(url), url)
+
+    def test_nie_rusza_obcego_hosta(self):
+        url = "http://www.w3.org/2001/XMLSchema#string"
+        self.assertEqual(eurlex._wymus_https(url), url)
+
+    def test_nie_daje_sie_nabrac_na_podobna_domene(self):
+        url = "http://publications.europa.eu.evil.example/resource/celex/X"
+        self.assertEqual(eurlex._wymus_https(url), url)
+
+    def test_uri_przestrzeni_nazw_zostaja_http(self):
+        # Zmiana ich postaci zerwalaby dopasowanie w zapytaniach SPARQL.
+        for stala in (eurlex.CDM, eurlex.LANG_AUTH, eurlex.TYPE_AUTH, eurlex.XSD_STR):
+            self.assertTrue(stala.startswith("http://"), stala)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

Two transport paths could deliver legal text over a channel that is neither
encrypted nor authenticated. Both feed citations that end up in court filings,
so content substituted in transit is a realistic risk rather than a theoretical
one.

**EUR-Lex fetched act text over HTTP.** CELLAR names resources with `http://`
URIs and returns manifestation addresses in the same form from SPARQL. That is
correct as an *identifier*, but `cmd_tekst` built the download URL from the same
constant, so the act text itself travelled unencrypted.

**CBOSA silently disabled certificate verification.** On
`SSLCertVerificationError` the client switched to an unverified context and
retried, without asking and without leaving a trace in the output. The rationale
is documented and real - CBOSA serves an incomplete certificate chain - but a
silent downgrade means the tool can quote content from any intermediary while
the operator believes the source was verified. Checked today: the certificate is
currently valid (Asseco Data Systems, until 2026-11-25), so on most systems this
path is dormant rather than in use.

## Fix

**Scheme is raised in `_http()`, not at the constant.** That also covers PDF
manifestation URLs coming back from SPARQL, which carry the same `http://` form.
The host is parsed and matched on a label boundary after normalising case and a
trailing dot, so `notreally-europa.eu` and user-info tricks like
`publications.europa.eu@evil.tld` are not upgraded, while
`PUBLICATIONS.EUROPA.EU`, a trailing-dot host and non-default ports are. Port and
the rest of the URL are preserved. Namespace constants (`CDM`, `LANG_AUTH`,
`TYPE_AUTH`, `XSD_STR`) are deliberately left as `http://` - changing them would
break matching inside SPARQL queries.

**The CBOSA downgrade is preserved but requires `CBOSA_INSECURE_TLS=1`.**
Without it the failure surfaces as `VerificationUnknown` with a message naming
the variable, so the existing `found / verified_absent / unknown` contract keeps
its meaning. With it, the switch now guarantees one further attempt - previously
a certificate error on the *final* retry set `CERT_NONE`, printed the warning and
then fell out of the loop, so the warning claimed a downgrade that never happened
while the global context stayed unverified for the rest of the process.

**Transport state is part of the data, not just a warning.** With
`--json` redirected to a file, stderr is detached and nothing recorded that the
transport was unauthenticated. Every JSON result now carries
`transport_tls_verified`, and text output carries a visible note.

Docs in three places still described the old automatic downgrade, and `SKILL.md`
did not mention the variable at all; both are updated.

## Testing

- `tools/test_eurlex.py` - 25 tests, including all nine host cases and a check
  that `_http` passes the already-upgraded URL to `Request`
- `tools/test_cbosa.py` - 47 tests, including the opt-in path, the retry after
  the switch, the final-attempt case, and that the result carries the transport
  marker
- `tools/validate.py` clean
- live: EUR-Lex text fetch for CELEX 32016R0679 works over https

## Notes

**Versions are intentionally untouched.** This repo bumps all seven plugins in
lockstep at release time and the previous contribution followed the same
convention, so the release bump is left to you. Happy to add it if you prefer it
inside the PR.

One open question: `transport_tls_verified` is my guess at a name that fits the
existing JSON shape - rename freely if something else matches the house style.
