### PR TITLE
feat: --strict mode for all engines, verification before output, helpers pinned to the installed package

### DIFF
--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/SKILL.md
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/SKILL.md
@@ -47,11 +47,19 @@ bez klucza API). Skrypt leży **obok tego pliku SKILL.md** — NIE zakładaj, ż
 `${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-EURLEX="${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex/scripts/eurlex.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  EURLEX="${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex/scripts/eurlex.py"
+else
+  EURLEX="${SKILL_DIR}/scripts/eurlex.py"
+fi
 [ -f "$EURLEX" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $EURLEX" >&2; exit 1; }
 python3 "$EURLEX" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/eurlex.py` oznacza `python3 "$EURLEX"`, jeśli nie jesteś
 w katalogu skilla.)

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/SKILL.md
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/SKILL.md
@@ -44,11 +44,12 @@ Urzędu Publikacji UE, które zasila EUR-Lex (SPARQL + REST, bez rejestracji i k
 Wszystko robi helper `scripts/eurlex.py` (tylko biblioteka standardowa Pythona — bez instalacji,
 bez klucza API). Skrypt leży **obok tego pliku SKILL.md** — NIE zakładaj, że to `~/.claude/skills/`
 (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude Code:
-`${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex`). Gdy nie znasz ścieżki, najpierw ją ustal:
+`${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-EURLEX=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name eurlex.py -path "*prawo-eu-eurlex*" 2>/dev/null | head -1)
-[ -n "$EURLEX" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py -o /tmp/eurlex.py && EURLEX=/tmp/eurlex.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+EURLEX="${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex/scripts/eurlex.py"
+[ -f "$EURLEX" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $EURLEX" >&2; exit 1; }
 python3 "$EURLEX" <komenda> [...]
 ```
 
@@ -79,7 +80,7 @@ wersje skonsolidowane `02016R0679-20160504`, sprostowania `32016R0679R(01)`, tra
   `--jezyk eng` — inna wersja językowa; `--pdf ŚCIEŻKA` zapisuje urzędowy PDF.
 - **odniesienia** — nowelizacje, sprostowania, podstawa prawna:
   `python3 scripts/eurlex.py odniesienia 32016R0679`
-- każda komenda przyjmuje `--json` (surowa odpowiedź do dalszego przetwarzania; działa przed komendą i po niej).
+- każda komenda przyjmuje `--json` oraz `--strict` (blokuje wynik bez zweryfikowanej aktualności lub kompletności); obie flagi działają przed komendą i po niej.
 
 Narzędzie samo ostrzega: na akcie bazowym podpowiada najnowszą wersję skonsolidowaną; na wersji
 skonsolidowanej przypomina o jej dokumentacyjnym charakterze i o nowszych wersjach. Nie ignoruj

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -14,6 +14,7 @@ Komendy:
   skonsolidowany <CELEX>         wersje skonsolidowane aktu (odpowiednik tekstu jednolitego)
   odniesienia <CELEX>            nowelizacje, sprostowania, podstawa prawna
 Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
 
 CELEX np.: 32016R0679 (RODO), 02016R0679-20160504 (wersja skonsolidowana), reg/2016/679 (ELI).
 """
@@ -237,7 +238,7 @@ SELECT DISTINCT ?celex WHERE {{
     return [c for c in (_v(b, "celex") for b in rows) if re.search(r"-\d{8}$", c)]
 
 
-def _ostrzezenia_konsolidacja(celex):
+def _ostrzezenia_konsolidacja(celex, strict=False):
     """Ostrzeżenia o wersjach skonsolidowanych dla aktu/wersji (lista linii).
 
     To informacja POBOCZNA przy tekście/metadanych — awaria SPARQL nie może odebrać
@@ -246,6 +247,8 @@ def _ostrzezenia_konsolidacja(celex):
     try:
         kons = _konsolidacje(celex)
     except VerificationUnknown as e:
+        if strict:
+            raise
         return [f"UWAGA: nie udało się zweryfikować, czy akt {celex} ma wersje skonsolidowane "
                 f"({e}) — sprawdź komendą: skonsolidowany {celex}, zanim zacytujesz."]
     out = []
@@ -340,7 +343,7 @@ SELECT ?type ?date ?inf ?eli ?eiv ?eov ?title WHERE {{
     if zb["eli"]:
         print(f"  ELI:     {zb['eli'][0]}")
     print(f"  Tekst:   python3 {sys.argv[0]} tekst {celex} --jezyk pol --fragment \"art. N\"")
-    for w in _ostrzezenia_konsolidacja(celex):
+    for w in _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False)):
         print(w)
 
 
@@ -395,7 +398,7 @@ def cmd_tekst(a):
         with open(a.pdf, "wb") as f:
             f.write(data)
         print(f"Zapisano PDF ({len(data)} B): {a.pdf}\n(źródło: {pdf_url}, język {lang3})")
-        for w in _ostrzezenia_konsolidacja(celex):
+        for w in _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False)):
             print(w)
         return
     raw, _ = _http(url, headers={"Accept": "application/xhtml+xml", "Accept-Language": lang3})
@@ -403,7 +406,7 @@ def cmd_tekst(a):
     if not txt:
         sys.exit(f"Pusty tekst XHTML dla {celex} (język {lang3}) — spróbuj --pdf albo inny --jezyk.")
     print(f"# CELEX {celex} ({lang3}) — tekst z CELLAR (XHTML→tekst; do dosłownego cytatu zweryfikuj z PDF)\n")
-    ostrz = _ostrzezenia_konsolidacja(celex)
+    ostrz = _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False))
     for w in ostrz:
         print(w)
     if ostrz:
@@ -464,6 +467,8 @@ def main():
         description="CELLAR/EUR-Lex (read-only, bez klucza). Źródło pierwotne prawa UE.")
     ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     s = sub.add_parser("szukaj"); s.add_argument("fraza", nargs="?")
@@ -483,11 +488,13 @@ def main():
     t.add_argument("--fragment", help='wytnij tylko jednostki z frazą, np. "art. 6" albo "profilowanie"')
     t.set_defaults(func=cmd_tekst)
 
-    # --json działa też PO komendzie (modele piszą flagi właśnie tam); SUPPRESS sprawia,
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
     # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
     for p in sub.choices.values():
         p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
                        help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
 
     a = ap.parse_args()
     try:

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -325,6 +325,8 @@ SELECT ?type ?date ?inf ?eli ?eiv ?eov ?title WHERE {{
               ?exp cdm:expression_uses_language <{LANG_AUTH}{lang}> .
               ?exp cdm:expression_title ?title }}
 }}""")
+    strict = getattr(a, "strict", False)
+    ostrz = _ostrzezenia_konsolidacja(celex, True) if strict else None
     if a.json:
         print(json.dumps(rows, ensure_ascii=False, indent=2)); return
     if not rows:
@@ -348,7 +350,7 @@ SELECT ?type ?date ?inf ?eli ?eiv ?eov ?title WHERE {{
     if zb["eli"]:
         print(f"  ELI:     {zb['eli'][0]}")
     print(f"  Tekst:   python3 {sys.argv[0]} tekst {celex} --jezyk pol --fragment \"art. N\"")
-    for w in _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False)):
+    for w in (ostrz if ostrz is not None else _ostrzezenia_konsolidacja(celex)):
         print(w)
 
 
@@ -393,6 +395,8 @@ def cmd_tekst(a):
     lang3 = lang.lower()
     url = CELLAR + urllib.parse.quote(celex, safe="/")
     if a.pdf:
+        strict = getattr(a, "strict", False)
+        ostrz = _ostrzezenia_konsolidacja(celex, True) if strict else None
         try:
             pdf_url = _pdf_url(celex, lang)
         except VerificationUnknown as e:
@@ -403,15 +407,15 @@ def cmd_tekst(a):
         with open(a.pdf, "wb") as f:
             f.write(data)
         print(f"Zapisano PDF ({len(data)} B): {a.pdf}\n(źródło: {pdf_url}, język {lang3})")
-        for w in _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False)):
+        for w in (ostrz if ostrz is not None else _ostrzezenia_konsolidacja(celex)):
             print(w)
         return
     raw, _ = _http(url, headers={"Accept": "application/xhtml+xml", "Accept-Language": lang3})
     txt = html_to_text(raw.decode("utf-8", "replace"))
     if not txt:
         sys.exit(f"Pusty tekst XHTML dla {celex} (język {lang3}) — spróbuj --pdf albo inny --jezyk.")
-    print(f"# CELEX {celex} ({lang3}) — tekst z CELLAR (XHTML→tekst; do dosłownego cytatu zweryfikuj z PDF)\n")
     ostrz = _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False))
+    print(f"# CELEX {celex} ({lang3}) — tekst z CELLAR (XHTML→tekst; do dosłownego cytatu zweryfikuj z PDF)\n")
     for w in ostrz:
         print(w)
     if ostrz:

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -261,8 +261,14 @@ def _ostrzezenia_konsolidacja(celex, strict=False):
         out.append("UWAGA: wersja skonsolidowana ma charakter DOKUMENTACYJNY (nie jest autentyczna) — "
                    "do urzędowego cytatu wskaż akt bazowy + zmiany.")
         if kons and kons[0] > celex:
+            if strict:
+                sys.exit(f"BŁĄD: istnieje nowsza wersja skonsolidowana: {kons[0]}. "
+                         "Tryb strict blokuje starszą treść.")
             out.append(f"UWAGA: istnieje NOWSZA wersja skonsolidowana: {kons[0]} — używaj jej.")
     elif kons:
+        if strict:
+            sys.exit(f"BŁĄD: istnieje nowsza wersja skonsolidowana: {kons[0]}. "
+                     "Tryb strict blokuje treść aktu bazowego.")
         out.append(f"UWAGA: akt ma wersje skonsolidowane — do analizy aktualnego stanu użyj najnowszej: "
                    f"{kons[0]} (pełna lista: skonsolidowany {celex}).")
     return out
@@ -327,10 +333,10 @@ SELECT ?type ?date ?inf ?eli ?eiv ?eov ?title WHERE {{
 }}""")
     strict = getattr(a, "strict", False)
     ostrz = _ostrzezenia_konsolidacja(celex, True) if strict else None
-    if a.json:
-        print(json.dumps(rows, ensure_ascii=False, indent=2)); return
     if not rows:
         sys.exit(f"Nie znaleziono aktu o CELEX {celex} w CELLAR.")
+    if a.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2)); return
     zb = {k: sorted({_v(b, k) for b in rows if _v(b, k)}) for k in
           ("type", "date", "inf", "eli", "eiv", "eov", "title")}
     print(f"Akt: CELEX {celex}")

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -28,6 +28,7 @@ CDM = "http://publications.europa.eu/ontology/cdm#"
 LANG_AUTH = "http://publications.europa.eu/resource/authority/language/"
 TYPE_AUTH = "http://publications.europa.eu/resource/authority/resource-type/"
 XSD_STR = "http://www.w3.org/2001/XMLSchema#string"
+CONTENT_HOSTS = ("publications.europa.eu", "data.europa.eu")
 
 JEZYKI = {"pl": "POL", "pol": "POL", "en": "ENG", "eng": "ENG", "de": "DEU", "deu": "DEU",
           "fr": "FRA", "fra": "FRA", "es": "SPA", "spa": "SPA", "it": "ITA", "ita": "ITA",
@@ -68,9 +69,9 @@ def _wymus_https(url):
     """
     parsed = urllib.parse.urlsplit(url)
     host = (parsed.hostname or "").lower().rstrip(".")
-    cellar_host = "publications.europa.eu"
-    if parsed.scheme.lower() == "http" and (
-            host == cellar_host or host.endswith("." + cellar_host)):
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
         # Zmieniamy wyłącznie schemat. Oryginalna pisownia hosta, user-info, port,
         # ścieżka, parametry, query i fragment pozostają bajt w bajt bez zmian.
         return "https" + url[len(parsed.scheme):]
@@ -78,13 +79,17 @@ def _wymus_https(url):
 
 
 class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
-    """CELLAR odpowiada 303 z Location w formie http:// nawet na żądanie https —
-    bez podniesienia schematu także w celu przekierowania treść aktu i tak
-    popłynęłaby czystym HTTP, z pominięciem _wymus_https na URL wejściowym.
-    Adres cellar po https serwuje treść wprost (200), więc pętla nie grozi."""
+    """Podnosi przekierowania HTTP dla dozwolonych hostów treści, inne odrzuca.
+
+    CELLAR odpowiada 303 z Location w formie http:// nawet na żądanie https. Bez
+    kontroli celu przekierowania treść aktu mogłaby popłynąć czystym HTTP."""
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
-        return super().redirect_request(req, fp, code, msg, headers, _wymus_https(newurl))
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
 
 
 _opener = urllib.request.build_opener(_PrzekierowaniaHttps())

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
@@ -44,11 +44,19 @@ Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/cbosa.py`) 
 Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-CBOSA="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa/scripts/cbosa.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  CBOSA="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa/scripts/cbosa.py"
+else
+  CBOSA="${SKILL_DIR}/scripts/cbosa.py"
+fi
 [ -f "$CBOSA" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $CBOSA" >&2; exit 1; }
 python3 "$CBOSA" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/cbosa.py` oznacza `python3 "$CBOSA"`, jeśli nie jesteś w katalogu skilla.)
 

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
@@ -41,11 +41,12 @@ administracyjnego; SAOS (skill prawo-pl-saos) sądów administracyjnych praktycz
 Wszystko robi helper `scripts/cbosa.py` (tylko biblioteka standardowa Pythona — bez instalacji).
 Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/cbosa.py`) — NIE zakładaj, że to
 `~/.claude/skills/prawo-pl-cbosa` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
-Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa`). Gdy nie znasz ścieżki, najpierw ją ustal:
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-CBOSA=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name cbosa.py -path "*prawo-pl-cbosa*" 2>/dev/null | head -1)
-[ -n "$CBOSA" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py -o /tmp/cbosa.py && CBOSA=/tmp/cbosa.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+CBOSA="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa/scripts/cbosa.py"
+[ -f "$CBOSA" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $CBOSA" >&2; exit 1; }
 python3 "$CBOSA" <komenda> [...]
 ```
 
@@ -67,7 +68,7 @@ python3 "$CBOSA" <komenda> [...]
   `--fragment "interpretacja"` (wycina okna wokół frazy).
 - **sygnatura** — szybkie odszukanie po sygnaturze:
   `python3 scripts/cbosa.py sygnatura II FSK 2870/18`
-- każda komenda przyjmuje `--json` (sparsowane dane jako JSON; działa przed komendą i po niej).
+- każda komenda przyjmuje `--json` oraz `--strict` (blokuje wynik bez zweryfikowanej aktualności lub kompletności); obie flagi działają przed komendą i po niej.
 
 Typowy przepływ: `szukaj` (zawęź `--sad`/`--od`/`--symbol`) → wybierz doc_id → `orzeczenie <doc_id>`
 → w razie potrzeby skacz po sygnaturach powiązanych (WSA ↔ NSA w tej samej sprawie).

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
@@ -17,7 +17,8 @@ Komendy:
   orzeczenie <doc_id> [--fragment "<fraza>"]   pełne orzeczenie: metadane, sentencja, uzasadnienie
   sygnatura <sygnatura...>                      znajdź orzeczenie po sygnaturze
 Globalnie: --json  (zrzut sparsowanych danych jako JSON zamiast podsumowania; działa przed
-komendą i po niej)
+                    komendą i po niej)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
 """
 import sys, os, json, re, time, argparse, ssl, calendar, html as html_mod
 import urllib.request, urllib.parse, urllib.error, http.cookiejar
@@ -473,6 +474,8 @@ def main():
                     "Orzecznictwo sądów administracyjnych: NSA + 16 WSA.")
     ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     ap.add_argument("--json", action="store_true", help="zrzut sparsowanych danych jako JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     s = sub.add_parser("szukaj")
@@ -496,11 +499,13 @@ def main():
     sy.add_argument("sygnatura", nargs="+")
     sy.set_defaults(func=cmd_sygnatura)
 
-    # --json działa też PO komendzie (modele piszą flagi właśnie tam); SUPPRESS sprawia,
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
     # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
     for p in sub.choices.values():
         p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
                        help="zrzut sparsowanych danych jako JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
 
     a = ap.parse_args()
     try:

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
@@ -25,10 +25,32 @@ import urllib.request, urllib.parse, urllib.error, http.cookiejar
 
 __version__ = "1.6.6"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
 BASE = "https://orzeczenia.nsa.gov.pl"
+CONTENT_HOSTS = ("orzeczenia.nsa.gov.pl",)
 
 
 class VerificationUnknown(RuntimeError):
     """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści CBOSA, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
 
 # Miasta WSA (klucz bez diakrytyków) → końcówka pełnej nazwy z formularza CBOSA.
 # Wartości pola 'sad' to PEŁNE nazwy sądów — wartość spoza listy CBOSA po cichu zwraca 0 wyników.
@@ -129,6 +151,12 @@ def _z_uwaga_o_transporcie(komunikat):
     return f"{uwaga}\n{komunikat}" if uwaga else komunikat
 
 
+def _sprawdz_transport_strict(a):
+    if getattr(a, "strict", False) and not _transport_tls_verified:
+        raise VerificationUnknown(
+            "tryb strict odrzuca wynik pobrany bez weryfikacji certyfikatu TLS")
+
+
 def _fetch(path, data=None):
     """GET/POST strony CBOSA (HTML). Throttling >=0,5 s; ponowienia z rosnącym odstępem.
     Zwraca pobrany HTML jako FOUND; UNKNOWN przekazuje przez VerificationUnknown.
@@ -163,6 +191,7 @@ def _fetch(path, data=None):
                 time.sleep(czekaj)
             _ostatnie[0] = time.time()
             opener = urllib.request.build_opener(
+                _PrzekierowaniaHttps(),
                 urllib.request.HTTPSHandler(context=ssl_ctx),
                 urllib.request.HTTPCookieProcessor(_jar))
             req = urllib.request.Request(url, data=body, headers=headers)
@@ -375,19 +404,20 @@ def cmd_szukaj(a):
         sys.exit("Podaj kryterium: frazę albo --sad / --sygnatura / --rodzaj / --symbol / --sedzia / zakres dat.")
     strona = max(1, a.strona)
     total, pozycje, komunikat = _szukaj(_formularz(a), strona)
+    _sprawdz_transport_strict(a)
     if total is None and not pozycje:
         if komunikat:  # formularz odrzucił zapytanie (np. zła data) — to błąd wejścia, nie serwera
             sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}\nPopraw parametry i ponów "
                      "(daty w formacie RRRR-MM-DD).")
+    if total == 0 or not pozycje:
+        sys.exit(_z_uwaga_o_transporcie(
+            "Brak wyników (zweryfikowane zero). Uwaga: wyszukiwarka CBOSA wymaga dokładnych "
+            "wartości — spróbuj prostszej frazy, bez --sad, albo sprawdź sygnaturę/symbol."))
     if a.json:
         print(json.dumps(_dane_z_transportem(
                          {"total": total, "strona": strona, "komunikat": komunikat,
                           "wyniki": pozycje}),
                          ensure_ascii=False, indent=2)); return
-    if total == 0 or not pozycje:
-        sys.exit(_z_uwaga_o_transporcie(
-            "Brak wyników (zweryfikowane zero). Uwaga: wyszukiwarka CBOSA wymaga dokładnych "
-            "wartości — spróbuj prostszej frazy, bez --sad, albo sprawdź sygnaturę/symbol."))
     _drukuj_uwage_o_transporcie()
     _drukuj_liste(total, pozycje, strona)
 
@@ -397,13 +427,14 @@ def cmd_orzeczenie(a):
     if not re.fullmatch(r"[A-F0-9]{6,}", doc_id):
         sys.exit(f"Nieprawidłowy doc_id: {a.doc_id!r} (identyfikator ze strony wyników, np. 8889489BE0).")
     d = _orzeczenie(_fetch(f"/doc/{doc_id}"), doc_id)
-    if a.json:
-        print(json.dumps(_dane_z_transportem(d), ensure_ascii=False, indent=2)); return
+    _sprawdz_transport_strict(a)
     if not d.get("tytul") and not d.get("metadane"):
         # strona pobrana, ale nierozpoznana (przebudowa HTML? strona błędu z HTTP 200?) —
-        # UNKNOWN z podpowiedzią; częściowy parse obejrzysz przez --json
+        # UNKNOWN z podpowiedzią; także --json nie może emitować pozornie poprawnego wyniku
         raise VerificationUnknown(f"nie udało się rozpoznać strony orzeczenia {doc_id} — "
                                   f"sprawdź w przeglądarce: {d['url']}")
+    if a.json:
+        print(json.dumps(_dane_z_transportem(d), ensure_ascii=False, indent=2)); return
     _drukuj_uwage_o_transporcie()
     print(f"# {d.get('tytul', doc_id)}   [{doc_id}]")
     for k in ("Data orzeczenia", "Sąd", "Sędziowie", "Symbol z opisem", "Hasła tematyczne",
@@ -445,19 +476,20 @@ def cmd_sygnatura(a):
             "sygnatura": sig, "sad": "dowolny", "rodzaj": "dowolny", "symbole": "",
             "odDaty": "", "doDaty": "", "sedziowie": "", "funkcja": "", "submit": "Szukaj"}
     total, pozycje, komunikat = _szukaj(form)
+    _sprawdz_transport_strict(a)
     if total is None and not pozycje:
         if komunikat:
             sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}")
-    if a.json:
-        print(json.dumps(_dane_z_transportem(
-                         {"total": total, "komunikat": komunikat, "wyniki": pozycje}),
-                         ensure_ascii=False, indent=2)); return
     glowne = [p for p in pozycje if not p["powiazane"]]
     if not glowne:
         sys.exit(_z_uwaga_o_transporcie(
             f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w CBOSA.\n"
             "Sygnatury sądów administracyjnych mają formę np. \"II FSK 2870/18\" (NSA) "
             "albo \"I SA/Bk 226/18\" (WSA). SN/TK/sądy powszechne/KIO → skill prawo-pl-saos."))
+    if a.json:
+        print(json.dumps(_dane_z_transportem(
+                         {"total": total, "komunikat": komunikat, "wyniki": pozycje}),
+                         ensure_ascii=False, indent=2)); return
     _drukuj_uwage_o_transporcie()
     print(f"Sygnatura {sig!r}: dopasowań {total}\n")
     for p in pozycje:

--- a/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/SKILL.md
+++ b/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/SKILL.md
@@ -37,11 +37,12 @@ podatki i opłaty lokalne, plany miejscowe (MPZP), statuty, organizacja szkół,
 Wszystko robi helper `scripts/edzienniki.py` (tylko biblioteka standardowa Pythona — bez instalacji).
 Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/edzienniki.py`) — NIE zakładaj, że
 to `~/.claude/skills/prawo-pl-edzienniki` (skill zainstalowany jako plugin leży w katalogu pluginów;
-w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki`). Gdy nie znasz ścieżki, ustal ją:
+w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-EDZ=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name edzienniki.py -path "*prawo-pl-edzienniki*" 2>/dev/null | head -1)
-[ -n "$EDZ" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/scripts/edzienniki.py -o /tmp/edzienniki.py && EDZ=/tmp/edzienniki.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+EDZ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki/scripts/edzienniki.py"
+[ -f "$EDZ" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $EDZ" >&2; exit 1; }
 python3 "$EDZ" <komenda> [...]
 ```
 

--- a/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/SKILL.md
+++ b/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/SKILL.md
@@ -40,11 +40,19 @@ to `~/.claude/skills/prawo-pl-edzienniki` (skill zainstalowany jako plugin leży
 w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-EDZ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki/scripts/edzienniki.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  EDZ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki/scripts/edzienniki.py"
+else
+  EDZ="${SKILL_DIR}/scripts/edzienniki.py"
+fi
 [ -f "$EDZ" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $EDZ" >&2; exit 1; }
 python3 "$EDZ" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/edzienniki.py` oznacza `python3 "$EDZ"`, jeśli nie jesteś w katalogu skilla.)
 

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/SKILL.md
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/SKILL.md
@@ -47,11 +47,12 @@ Używaj go, zanim podasz brzmienie przepisu, sygnaturę albo stwierdzisz, że co
 Wszystko robi helper `scripts/eli.py` (tylko biblioteka standardowa Pythona — bez instalacji).
 Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/eli.py`) — NIE zakładaj, że to
 `~/.claude/skills/prawo-pl-eli` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
-Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli`). Gdy nie znasz ścieżki, najpierw ją ustal:
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-ELI=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name eli.py -path "*prawo-pl-eli*" 2>/dev/null | head -1)
-[ -n "$ELI" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py -o /tmp/eli.py && ELI=/tmp/eli.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+ELI="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli/scripts/eli.py"
+[ -f "$ELI" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $ELI" >&2; exit 1; }
 python3 "$ELI" <komenda> [...]
 ```
 
@@ -85,7 +86,7 @@ Sygnaturę można podać w wielu formach: `DU 2000 1037`, `DU/2024/18`, `"Dz.U. 
   `python3 scripts/eli.py struktura DU 2024 18 --filtr "Art. 299"` (opcje: `--filtr`, `--poziom N`)
 - **odniesienia** — powiązania: nowelizacje, podstawa prawna, tekst jednolity, akty wykonawcze:
   `python3 scripts/eli.py odniesienia DU 2024 18`
-- każda komenda przyjmuje `--json` (surowa odpowiedź API do dalszego przetwarzania; działa przed komendą i po niej).
+- każda komenda przyjmuje `--json` oraz `--strict` (blokuje wynik bez zweryfikowanej aktualności lub kompletności); obie flagi działają przed komendą i po niej.
 
 Narzędzie samo ostrzega: `tekst` na akcie, który ma tekst jednolity, każe cytować z najnowszego t.j.;
 na tekście jednolitym wypisuje „Nowelizacje po tekście jednolitym". Gdy `text.html` świeżego t.j. jest

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/SKILL.md
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/SKILL.md
@@ -50,11 +50,19 @@ Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/eli.py`) �
 Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-ELI="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli/scripts/eli.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  ELI="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli/scripts/eli.py"
+else
+  ELI="${SKILL_DIR}/scripts/eli.py"
+fi
 [ -f "$ELI" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $ELI" >&2; exit 1; }
 python3 "$ELI" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/eli.py` oznacza `python3 "$ELI"`, jeśli nie jesteś w katalogu skilla.)
 

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -15,6 +15,7 @@ Komendy:
   odniesienia <sygnatura...>     nowelizacje, tekst jednolity, podstawa prawna
   tj <sygnatura...>              znajduje AKTUALNY TEKST JEDNOLITY dla aktu i podaje jego sygnaturę
 Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
 """
 import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
 from html.parser import HTMLParser
@@ -391,6 +392,8 @@ def cmd_tekst(a):
     try:
         refs = _get(path + "/references", soft=True)
     except VerificationUnknown as e:
+        if getattr(a, "strict", False):
+            raise
         refs = None
         ostrz = [f"UWAGA: nie udało się zweryfikować aktualności aktu {label} ({e}) — "
                  "sprawdź nowelizacje i teksty jednolite ręcznie, zanim zacytujesz."]
@@ -559,6 +562,8 @@ def cmd_tj(a):
             try:
                 base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
             except VerificationUnknown as e:
+                if getattr(a, "strict", False):
+                    raise
                 print(f"UWAGA: nie udało się sprawdzić, czy istnieje nowszy tekst jednolity ({e}) — "
                       "zweryfikuj ręcznie, zanim zacytujesz.")
                 return
@@ -574,6 +579,8 @@ def main():
     ap = argparse.ArgumentParser(description="API ELI Sejmu (read-only). Źródło pierwotne prawa polskiego.")
     ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     s = sub.add_parser("szukaj"); s.add_argument("fraza", nargs="?", default=None); s.add_argument("--typ"); s.add_argument("--rok")
@@ -593,11 +600,13 @@ def main():
     st.add_argument("--poziom", type=int, help="maks. głębokość drzewa (domyślnie 3; z --filtr bez limitu)")
     st.set_defaults(func=cmd_struktura)
 
-    # --json działa też PO komendzie (modele piszą flagi właśnie tam); SUPPRESS sprawia,
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
     # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
     for p in sub.choices.values():
         p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
                        help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
 
     a = ap.parse_args()
     try:

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -559,23 +559,27 @@ def cmd_tj(a):
     if base_key:
         items = d[base_key] if isinstance(d[base_key], list) else [d[base_key]]
         base = next((r.get("act") for r in items if isinstance(r, dict) and isinstance(r.get("act"), dict)), None)
-        print(f"{label} SAM JEST tekstem jednolitym" + (f" (dla: {base.get('displayAddress','')} — {base.get('title','')[:90]})" if base else "") + ".")
-        for w in _ostrzezenia(d):
-            print(w)
         # sprawdź na akcie bazowym, czy nie ma już NOWSZEGO tekstu jednolitego
         m = re.match(r"^/acts/(DU|MP)/(\d+)/(\d+)$", path)
+        kontrola = None
         if base and base.get("ELI") and m:
             try:
                 base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
             except VerificationUnknown as e:
                 if getattr(a, "strict", False):
                     raise
-                print(f"UWAGA: nie udało się sprawdzić, czy istnieje nowszy tekst jednolity ({e}) — "
-                      "zweryfikuj ręcznie, zanim zacytujesz.")
-                return
-            newer = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
-            if newer and _eli_rok_poz(newer[0]) > (int(m.group(2)), int(m.group(3))):
-                print(f"UWAGA: istnieje NOWSZY tekst jednolity: {newer[0].get('displayAddress') or newer[0].get('ELI','')} — cytuj z niego.")
+                kontrola = (f"UWAGA: nie udało się sprawdzić, czy istnieje nowszy tekst jednolity ({e}) — "
+                            "zweryfikuj ręcznie, zanim zacytujesz.")
+            else:
+                newer = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
+                if newer and _eli_rok_poz(newer[0]) > (int(m.group(2)), int(m.group(3))):
+                    kontrola = (f"UWAGA: istnieje NOWSZY tekst jednolity: "
+                                f"{newer[0].get('displayAddress') or newer[0].get('ELI','')} — cytuj z niego.")
+        print(f"{label} SAM JEST tekstem jednolitym" + (f" (dla: {base.get('displayAddress','')} — {base.get('title','')[:90]})" if base else "") + ".")
+        for w in _ostrzezenia(d):
+            print(w)
+        if kontrola:
+            print(kontrola)
         return
     print(f"Dla {label} brak tekstu jednolitego w odniesieniach — akt może nie mieć t.j. (cytuj z aktu, "
           f"ale sprawdź „Akty zmieniające\" w: odniesienia {label}).")

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -433,8 +433,14 @@ def cmd_tekst(a):
                      f"Pobierz urzędowy PDF: tekst {label} --pdf plik.pdf")
         act, txt = fb
         addr = act.get("displayAddress") or act.get("ELI", "")
-        sig = (act.get("ELI") or "").replace("/", " ")
-        ostrz = [f"UWAGA: text.html dla {label} jest PUSTE w API — poniżej tekst z innego t.j.: {addr}.",
+        actual_eli = act.get("ELI") or ""
+        if getattr(a, "strict", False):
+            sys.exit(f"BŁĄD: strict zabrania zwrócenia starszego tekstu jednolitego {actual_eli or addr} "
+                     f"zamiast pustego text.html dla {label}. Pobierz urzędowy PDF: "
+                     f"tekst {label} --pdf plik.pdf")
+        sig = actual_eli.replace("/", " ")
+        ostrz = [f"ELI_TEXT_SOURCE_FALLBACK={actual_eli}",
+                 f"UWAGA: text.html dla {label} jest PUSTE w API — poniżej tekst z innego t.j.: {addr}.",
                  f"Nałóż zmiany pomiędzy nimi: odniesienia {sig} (sekcja „Nowelizacje po tekście jednolitym\");"
                  f" do dosłownego cytatu: tekst {label} --pdf plik.pdf"] + ostrz
         label = f"{label} (tekst z: {addr})"

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -22,6 +22,7 @@ from html.parser import HTMLParser
 
 __version__ = "1.6.6"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
 BASE = "https://api.sejm.gov.pl/eli"
+CONTENT_HOSTS = ("api.sejm.gov.pl",)
 
 
 class VerificationUnknown(RuntimeError):
@@ -31,6 +32,30 @@ class VerificationUnknown(RuntimeError):
 def _nie_zweryfikowano(co, blad):
     sys.exit(f"BŁĄD: nie udało się zweryfikować {co} ({blad}). "
              "Spróbuj ponownie za chwilę.")
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści ELI, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
 
 
 def _get(path, params=None, soft=False):
@@ -50,7 +75,7 @@ def _get(path, params=None, soft=False):
     raw, ctype = None, ""
     for attempt in (1, 2):
         try:
-            with urllib.request.urlopen(req, timeout=30) as r:
+            with _opener.open(req, timeout=30) as r:
                 ctype = r.headers.get("Content-Type", "")
                 raw = r.read().decode("utf-8", "replace")
             break
@@ -85,7 +110,7 @@ def _get(path, params=None, soft=False):
 def _get_bytes(url):
     req = urllib.request.Request(url, headers={"User-Agent": f"eli-skill/{__version__}"})
     try:
-        with urllib.request.urlopen(req, timeout=60) as r:
+        with _opener.open(req, timeout=60) as r:
             return r.read()
     except Exception as e:
         sys.exit(f"BŁĄD pobierania: {url} ({e})")
@@ -344,9 +369,9 @@ def cmd_szukaj(a):
     if a.obowiazujace:
         params["inForce"] = 1
     d = _get("/acts/search", params)
+    d = _expect_dict(d, "wyniki wyszukiwania")
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    d = _expect_dict(d, "wyniki wyszukiwania")
     items = d.get("items", [])
     print(f"Znaleziono: {d.get('count', '?')} (pokazuję {len(items)}, offset {a.offset})\n")
     for it in items:
@@ -360,9 +385,9 @@ def cmd_szukaj(a):
 def cmd_meta(a):
     path, label = act_path(a.sygnatura)
     d = _get(path)
+    d = _expect_dict(d, "metadane aktu")
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    d = _expect_dict(d, "metadane aktu")
     print(f"Akt: {label}")
     print(f"  Tytuł:   {d.get('title','').strip()}")
     print(f"  Adres:   {d.get('displayAddress','')}")
@@ -399,6 +424,13 @@ def cmd_tekst(a):
                  "sprawdź nowelizacje i teksty jednolite ręcznie, zanim zacytujesz."]
     else:
         ostrz = _ostrzezenia(refs) if isinstance(refs, dict) else []
+        tj = _tj_acts(refs) if isinstance(refs, dict) else []
+        m = re.match(r"^/acts/(?:DU|MP)/(\d+)/(\d+)$", path)
+        nowszy_tj = tj and m and _eli_rok_poz(tj[0]) > (int(m.group(1)), int(m.group(2)))
+        if getattr(a, "strict", False) and nowszy_tj:
+            aktualny = tj[0].get("displayAddress") or tj[0].get("ELI", "")
+            sys.exit(f"BŁĄD: istnieje nowszy tekst jednolity: {aktualny}. "
+                     "Tryb strict blokuje starszą treść.")
     if a.pdf:
         # pobierz urzędowy PDF (preferuj tekst jednolity, typ 'U'/'T', inaczej oryginał 'O')
         meta = _expect_dict(_get(path), "metadane aktu")
@@ -475,11 +507,11 @@ def cmd_tekst(a):
 def cmd_struktura(a):
     path, label = act_path(a.sygnatura)
     d = _get(path + "/struct")
-    if a.json:
-        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     nodes = d if isinstance(d, list) else [d] if isinstance(d, dict) else None
     if not nodes:
         sys.exit("Brak struktury dla tego aktu (API udostępnia /struct głównie dla tekstów jednolitych i starszych aktów).")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     filtr = (a.filtr or "").lower()
     poziom = a.poziom if a.poziom is not None else (None if filtr else 3)
     print(f"Struktura: {label}  (frazę z 'title' podaj w: tekst {label} --fragment \"...\")\n")
@@ -522,11 +554,10 @@ def _fmt_ref(ref):
 def cmd_odniesienia(a):
     path, label = act_path(a.sygnatura)
     d = _get(path + "/references")
+    d = _expect_dict(d, "odniesienia aktu")
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
     print(f"Odniesienia dla: {label}\n")
-    if not isinstance(d, dict):
-        print(d); return
     for kind, lst in d.items():
         items = lst if isinstance(lst, list) else [lst]
         print(f"## {kind}  ({len(items)})")
@@ -538,12 +569,12 @@ def cmd_odniesienia(a):
 def cmd_tj(a):
     path, label = act_path(a.sygnatura)
     d = _get(path + "/references")
-    if a.json:
-        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     d = _expect_dict(d, "odniesienia aktu")
     # akt bazowy: kategoria 'Inf. o tekście jednolitym' listuje obwieszczenia z t.j.
     tj = _tj_acts(d)
     if tj:
+        if a.json:
+            print(json.dumps(d, ensure_ascii=False, indent=2)); return
         print(f"TEKSTY JEDNOLITE dla {label} (najnowszy pierwszy):")
         for i, act in enumerate(tj):
             marker = "  ← AKTUALNY" if i == 0 else ""
@@ -573,14 +604,22 @@ def cmd_tj(a):
             else:
                 newer = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
                 if newer and _eli_rok_poz(newer[0]) > (int(m.group(2)), int(m.group(3))):
+                    if getattr(a, "strict", False):
+                        aktualny = newer[0].get("displayAddress") or newer[0].get("ELI", "")
+                        sys.exit(f"BŁĄD: istnieje nowszy tekst jednolity: {aktualny}. "
+                                 "Tryb strict blokuje starszy wynik.")
                     kontrola = (f"UWAGA: istnieje NOWSZY tekst jednolity: "
                                 f"{newer[0].get('displayAddress') or newer[0].get('ELI','')} — cytuj z niego.")
+        if a.json:
+            print(json.dumps(d, ensure_ascii=False, indent=2)); return
         print(f"{label} SAM JEST tekstem jednolitym" + (f" (dla: {base.get('displayAddress','')} — {base.get('title','')[:90]})" if base else "") + ".")
         for w in _ostrzezenia(d):
             print(w)
         if kontrola:
             print(kontrola)
         return
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     print(f"Dla {label} brak tekstu jednolitego w odniesieniach — akt może nie mieć t.j. (cytuj z aktu, "
           f"ale sprawdź „Akty zmieniające\" w: odniesienia {label}).")
 

--- a/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/SKILL.md
+++ b/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/SKILL.md
@@ -46,11 +46,19 @@ leży w katalogu pluginów; w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-p
 Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-REJ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  REJ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py"
+else
+  REJ="${SKILL_DIR}/scripts/rejestrumow.py"
+fi
 [ -f "$REJ" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $REJ" >&2; exit 1; }
 python3 "$REJ" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/rejestrumow.py` oznacza `python3 "$REJ"`, jeśli nie
 jesteś w katalogu skilla.)

--- a/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/SKILL.md
+++ b/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/SKILL.md
@@ -43,11 +43,12 @@ Wszystko robi helper `scripts/rejestrumow.py` (tylko biblioteka standardowa Pyth
 instalacji). Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/rejestrumow.py`)
 — NIE zakładaj, że to `~/.claude/skills/prawo-pl-rejestr-umow` (skill zainstalowany jako plugin
 leży w katalogu pluginów; w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-rejestr-umow`).
-Gdy nie znasz ścieżki, najpierw ją ustal:
+Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-REJ=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name rejestrumow.py -path "*prawo-pl-rejestr-umow*" 2>/dev/null | head -1)
-[ -n "$REJ" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py -o /tmp/rejestrumow.py && REJ=/tmp/rejestrumow.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+REJ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py"
+[ -f "$REJ" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $REJ" >&2; exit 1; }
 python3 "$REJ" <komenda> [...]
 ```
 

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/SKILL.md
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/SKILL.md
@@ -39,11 +39,12 @@ orzeczniczą** albo poprzeć argument w piśmie procesowym judykaturą.
 Wszystko robi helper `scripts/saos.py` (tylko biblioteka standardowa Pythona — bez instalacji).
 Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/saos.py`) — NIE zakładaj, że to
 `~/.claude/skills/prawo-pl-saos` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
-Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos`). Gdy nie znasz ścieżki, najpierw ją ustal:
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-SAOS=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name saos.py -path "*prawo-pl-saos*" 2>/dev/null | head -1)
-[ -n "$SAOS" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py -o /tmp/saos.py && SAOS=/tmp/saos.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+SAOS="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos/scripts/saos.py"
+[ -f "$SAOS" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $SAOS" >&2; exit 1; }
 python3 "$SAOS" <komenda> [...]
 ```
 
@@ -63,7 +64,7 @@ python3 "$SAOS" <komenda> [...]
   uzasadnienia. Do długich uzasadnień: `--fragment "rękojmia"` (wycina okna wokół frazy).
 - **sygnatura** — szybkie odszukanie po numerze sprawy:
   `python3 scripts/saos.py sygnatura III CSK 203/09`
-- każda komenda przyjmuje `--json` (surowa odpowiedź API; działa przed komendą i po niej).
+- każda komenda przyjmuje `--json` oraz `--strict` (blokuje wynik bez zweryfikowanej aktualności lub kompletności); obie flagi działają przed komendą i po niej.
 
 Typowy przepływ: `szukaj` (zawęź `--sad`/`--przepis`/`--haslo`) → wybierz ID → `orzeczenie <id>`
 → w razie potrzeby skacz po `referencedCourtCases` do powołanych orzeczeń.

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/SKILL.md
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/SKILL.md
@@ -42,11 +42,19 @@ Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/saos.py`) �
 Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-SAOS="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos/scripts/saos.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SAOS="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos/scripts/saos.py"
+else
+  SAOS="${SKILL_DIR}/scripts/saos.py"
+fi
 [ -f "$SAOS" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $SAOS" >&2; exit 1; }
 python3 "$SAOS" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/saos.py` oznacza `python3 "$SAOS"`, jeśli nie jesteś w katalogu skilla.)
 

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
@@ -18,6 +18,7 @@ Komendy:
   orzeczenie <id> [--fragment "<fraza>"]   pełne orzeczenie: metadane, powołane przepisy/orzeczenia, treść
   sygnatura <sygnatura...>                  znajdź orzeczenie po numerze sprawy (caseNumber)
 Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
 """
 import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
 from html.parser import HTMLParser
@@ -414,6 +415,8 @@ def main():
     ap = argparse.ArgumentParser(description="API SAOS (read-only). Baza orzecznictwa polskiego: SN/TK/sądy powszechne/KIO.")
     ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     s = sub.add_parser("szukaj")
@@ -439,11 +442,13 @@ def main():
     sy.add_argument("sygnatura", nargs="+")
     sy.set_defaults(func=cmd_sygnatura)
 
-    # --json działa też PO komendzie (modele piszą flagi właśnie tam); SUPPRESS sprawia,
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
     # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
     for p in sub.choices.values():
         p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
                        help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
 
     a = ap.parse_args()
     try:

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
@@ -25,10 +25,35 @@ from html.parser import HTMLParser
 
 __version__ = "1.6.6"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
 BASE = "https://www.saos.org.pl/api"
+CONTENT_HOSTS = ("saos.org.pl",)
 
 
 class VerificationUnknown(RuntimeError):
     """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści SAOS, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
 
 # Aliasy typów sądów (courtType w API SAOS)
 SADY = {
@@ -80,6 +105,18 @@ def _ostrzezenie_zasiegu(ct, od=None):
     return tekst
 
 
+def _sprawdz_zasieg_strict(a, ct):
+    """Blokuje zakres sięgający poza znany koniec zamkniętego zbioru SAOS."""
+    if not getattr(a, "strict", False) or ct not in ZASIEG:
+        return
+    ostatni_rok = ZASIEG[ct][0]
+    rok_do = int(a.do[:4]) if a.do and re.match(r"^\d{4}", a.do) else None
+    if rok_do is None or rok_do > ostatni_rok:
+        raise VerificationUnknown(
+            f"zbiór {CT_PL.get(ct, ct)} kończy się na {ostatni_rok} r., "
+            "a żądany zakres wykracza poza znaną kompletność SAOS")
+
+
 def _get(path, params=None, soft=False):
     """GET z jednym ponowieniem.
 
@@ -95,7 +132,7 @@ def _get(path, params=None, soft=False):
     raw = None
     for attempt in (1, 2):
         try:
-            with urllib.request.urlopen(req, timeout=40) as r:
+            with _opener.open(req, timeout=40) as r:
                 raw = r.read().decode("utf-8", "replace")
             if "Przerwa techniczna" in raw:
                 # SAOS bywa w oknie serwisowym — zwraca stronę HTML zamiast JSON (HTTP 200)
@@ -281,6 +318,7 @@ def _wiersz(it):
 
 def cmd_szukaj(a):
     ct = _court_type(a.sad)
+    _sprawdz_zasieg_strict(a, ct)
     params = {
         "all": a.fraza,
         "caseNumber": a.sygnatura,
@@ -392,8 +430,6 @@ def cmd_sygnatura(a):
     d = _get("/search/judgments", {"caseNumber": sig, "pageSize": 20, "pageNumber": 0,
                                    "sortingField": "JUDGMENT_DATE", "sortingDirection": "DESC"})
     d = _expect_search(d, f"orzeczenia o sygnaturze {sig!r}")
-    if a.json:
-        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     items = d.get("items", [])
     total = (d.get("info") or {}).get("totalResults", 0)
     if not items:
@@ -402,6 +438,8 @@ def cmd_sygnatura(a):
                  "sygnatury sądów administracyjnych (NSA/WSA) szukaj skillem prawo-pl-cbosa.\n"
                  "Granice zbiorów: SN kończy się na 2016 r., TK na 2015 r., KIO na 2018 r. "
                  "(sądy powszechne są na bieżąco) — nowszej sygnatury z tych sądów SAOS nie ma.")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     print(f"Sygnatura {sig!r}: dopasowań {total}\n")
     for it in items:
         cn = _case_numbers(it)

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/SKILL.md
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/SKILL.md
@@ -37,11 +37,12 @@ zgłaszania naruszeń, powierzenia przetwarzania.
 Wszystko robi helper `scripts/uodo.py` (tylko biblioteka standardowa Pythona — bez instalacji).
 Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/uodo.py`) — NIE zakładaj, że to
 `~/.claude/skills/prawo-pl-uodo` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
-Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo`). Gdy nie znasz ścieżki, najpierw ją ustal:
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-UODO=$(find "$HOME/.claude" "$HOME/.agents" /mnt /sessions -maxdepth 10 -name uodo.py -path "*prawo-pl-uodo*" 2>/dev/null | head -1)
-[ -n "$UODO" ] || { curl -fsSL https://raw.githubusercontent.com/jamarpl21/prawo-pl-eli/main/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py -o /tmp/uodo.py && UODO=/tmp/uodo.py; }
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
+UODO="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo/scripts/uodo.py"
+[ -f "$UODO" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $UODO" >&2; exit 1; }
 python3 "$UODO" <komenda> [...]
 ```
 
@@ -65,7 +66,7 @@ python3 "$UODO" <komenda> [...]
   `python3 scripts/uodo.py decyzja DKN.5131.9.2025`
   Pokazuje metadane (status, daty ogłoszenia/publikacji), przedmiot i pełną treść.
   Do długich decyzji: `--fragment "pieniężn"` (wycina okna wokół frazy; też podawaj rdzeń).
-- każda komenda przyjmuje `--json` (surowa odpowiedź API; działa przed komendą i po niej).
+- każda komenda przyjmuje `--json` oraz `--strict` (blokuje wynik bez zweryfikowanej aktualności lub kompletności); obie flagi działają przed komendą i po niej.
 
 Typowy przepływ: `szukaj "<rdzeń frazy>"` → wybierz sygnaturę → `decyzja <sygnatura>`
 → do sądowej kontroli tej decyzji: skill prawo-pl-cbosa (`szukaj "<sygnatura decyzji>"`).

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/SKILL.md
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/SKILL.md
@@ -40,11 +40,19 @@ Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/uodo.py`) �
 Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
 
 ```
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "BŁĄD: CLAUDE_PLUGIN_ROOT nie jest ustawiony" >&2; exit 1; }
-UODO="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo/scripts/uodo.py"
+# Podstaw dokładną bezwzględną ścieżkę bieżącego SKILL.md z lokalizatora skilla.
+SKILL_MD="/bezwzględna/ścieżka/do/bieżącego/SKILL.md"
+SKILL_DIR="${SKILL_MD%/SKILL.md}"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  UODO="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo/scripts/uodo.py"
+else
+  UODO="${SKILL_DIR}/scripts/uodo.py"
+fi
 [ -f "$UODO" ] || { echo "BŁĄD: brak helpera bieżącego pakietu: $UODO" >&2; exit 1; }
 python3 "$UODO" <komenda> [...]
 ```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
 
 (W przykładach niżej `python3 scripts/uodo.py` oznacza `python3 "$UODO"`, jeśli nie jesteś w katalogu skilla.)
 

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py
@@ -22,7 +22,32 @@ import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
 
 __version__ = "1.6.6"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
 BASE = "https://orzeczenia.uodo.gov.pl/api"
+CONTENT_HOSTS = ("orzeczenia.uodo.gov.pl",)
 POLA = "id,refid,refname,title,dates,kind"  # domyślne pola listy wyników
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści UODO, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
 
 
 def _get(path, params=None, raw=False):
@@ -37,7 +62,7 @@ def _get(path, params=None, raw=False):
         "Accept": "text/plain" if raw else "application/json"})
     for attempt in (1, 2):
         try:
-            with urllib.request.urlopen(req, timeout=40) as r:
+            with _opener.open(req, timeout=40) as r:
                 tresc = r.read().decode("utf-8", "replace")
             break
         except urllib.error.HTTPError as e:
@@ -69,6 +94,18 @@ def _pl(v):
     if isinstance(v, dict):
         return v.get("pl") or next(iter(v.values()), "")
     return v or ""
+
+
+def _expect_list(d, what):
+    if not isinstance(d, list):
+        sys.exit(f"BŁĄD: API UODO zwróciło nieoczekiwaną odpowiedź ({what}).")
+    return d
+
+
+def _expect_dict(d, what):
+    if not isinstance(d, dict):
+        sys.exit(f"BŁĄD: API UODO zwróciło nieoczekiwaną odpowiedź ({what}).")
+    return d
 
 
 def _daty(item):
@@ -121,11 +158,11 @@ def _wiersz(item):
 
 
 def cmd_najnowsze(a):
-    d = _szukaj(_timespan(None, None), limit=a.limit)
+    d = _expect_list(_szukaj(_timespan(None, None), limit=a.limit), "najnowsze dokumenty")
+    if not d:
+        sys.exit("Brak wyników — spróbuj ponownie za chwilę.")
     if a.json:
         print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    if not isinstance(d, list) or not d:
-        sys.exit("Brak wyników — spróbuj ponownie za chwilę.")
     print(f"Ostatnio opublikowane w portalu orzeczeń UODO ({len(d)}):\n")
     for it in d:
         _wiersz(it)
@@ -145,15 +182,14 @@ def cmd_szukaj(a):
         print(f"UWAGA: API UODO stosuje JEDEN warunek na zapytanie — używam: {warunki[0]!r} "
               f"(pomijam: {', '.join(repr(w) for w in warunki[1:])}).\n", file=sys.stderr)
     d = _szukaj(_timespan(a.od, a.do), warunki[0] if warunki else None, a.limit, a.strona)
-    if a.json:
-        print(json.dumps(d, ensure_ascii=False, indent=2)); return
-    if not isinstance(d, list):
-        sys.exit("BŁĄD: API UODO zwróciło nieoczekiwaną odpowiedź.")
+    d = _expect_list(d, "wyniki wyszukiwania")
     if not d:
         sys.exit("Brak wyników. Fraza działa jak regex (bez rozróżniania wielkości liter) i szuka "
                  "DOSŁOWNIE — a tytuły i treści są po polsku ODMIENIONE ('nałożenie kary "
                  "pieniężnej', nie 'kara pieniężna'). Podaj RDZEŃ bez końcówki: 'pieniężn', "
                  "'biometr', 'monitoring'. To NIE dowód, że takich decyzji nie ma.")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
     print(f"Znaleziono: {len(d)}  (strona {a.strona}, po {a.limit}; sortowanie od najnowszych)\n")
     for it in d:
         _wiersz(it)
@@ -163,10 +199,15 @@ def cmd_szukaj(a):
 
 def cmd_decyzja(a):
     refid = _refid(a.id)
-    meta = _get(f"/documents/public/items/{urllib.parse.quote(refid, safe=':')}/meta.json")
+    meta = _expect_dict(
+        _get(f"/documents/public/items/{urllib.parse.quote(refid, safe=':')}/meta.json"),
+        "metadane decyzji")
+    txt = _get(f"/documents/public/items/{urllib.parse.quote(refid + ':0', safe=':')}/body.txt",
+               params={"lang": "pl"}, raw=True).strip()
+    if getattr(a, "strict", False) and not txt:
+        sys.exit("BŁĄD: tryb strict blokuje decyzję bez zweryfikowanej pełnej treści.")
     if a.json:
-        meta["_body"] = _get(f"/documents/public/items/{urllib.parse.quote(refid + ':0', safe=':')}/body.txt",
-                             params={"lang": "pl"}, raw=True)
+        meta["_body"] = txt
         print(json.dumps(meta, ensure_ascii=False, indent=2)); return
     refname = meta.get("refname", a.id)
     daty = _daty(meta)
@@ -181,8 +222,6 @@ def cmd_decyzja(a):
     tytul = _pl(meta.get("title"))
     if tytul:
         print(f"\n## Przedmiot\n{tytul.strip()}")
-    txt = _get(f"/documents/public/items/{urllib.parse.quote(refid + ':0', safe=':')}/body.txt",
-               params={"lang": "pl"}, raw=True).strip()
     print(f"\n## Treść decyzji ({len(txt)} znaków)")
     if not txt:
         print("(brak treści w API — zob. portal wyżej)")

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py
@@ -16,6 +16,7 @@ Komendy:
          [--warunek "indeks:operator:wartość"] [--limit N] [--strona N]
   decyzja <sygnatura|URN> [--fragment "<fraza>"]  metadane + pełna treść decyzji
 Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
 """
 import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
 
@@ -226,6 +227,8 @@ def main():
                     "decyzje Prezesa UODO i powiązane orzeczenia sądów.")
     ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     n = sub.add_parser("najnowsze")
@@ -249,11 +252,13 @@ def main():
     d.add_argument("--fragment", help='wytnij okna wokół frazy w treści — podawaj RDZEŃ, np. "pieniężn"')
     d.set_defaults(func=cmd_decyzja)
 
-    # --json działa też PO komendzie (modele piszą flagi właśnie tam); SUPPRESS sprawia,
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
     # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
     for p in sub.choices.values():
         p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
                        help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
 
     a = ap.parse_args()
     a.func(a)

--- a/tools/test_cbosa.py
+++ b/tools/test_cbosa.py
@@ -320,6 +320,15 @@ class TestFlagaJson(unittest.TestCase):
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
 
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
 
 class CbosaVerificationContractTests(unittest.TestCase):
     """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""

--- a/tools/test_cbosa.py
+++ b/tools/test_cbosa.py
@@ -379,6 +379,57 @@ class CbosaVerificationContractTests(unittest.TestCase):
             with self.assertRaises(cbosa.VerificationUnknown):
                 cbosa._fetch("/cbo/search")
 
+    def test_t11_strict_blokuje_niezweryfikowany_transport_i_stdout_jest_pusty(self):
+        def fake_fetch(path, data=None):
+            cbosa._transport_tls_verified = False
+            return TestOrzeczenie.HTML
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", side_effect=fake_fetch), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "orzeczenie", "8889489BE0", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                cbosa.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t12_json_strict_nie_emituje_wyniku_gdy_kontrola_nie_przeszla(self):
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_szukaj", side_effect=cbosa.VerificationUnknown("timeout")), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "szukaj", "RODO", "--json", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                cbosa.main()
+        self.assertEqual(out.getvalue(), "")
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value="<html><body>Błąd</body></html>"), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "orzeczenie", "DEADBEEF", "--json", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                cbosa.main()
+        self.assertEqual(out.getvalue(), "")
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_szukaj", return_value=(0, [], "Nie znaleziono")), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "sygnatura", "II", "FSK", "1/24",
+                                                       "--json", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                cbosa.main()
+        self.assertEqual(out.getvalue(), "")
+
+
+class TestT13PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = cbosa.urllib.request.Request("https://orzeczenia.nsa.gov.pl/doc/8889489BE0")
+        handler = cbosa._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://orzeczenia.nsa.gov.pl/doc/8889489BE0")
+        self.assertEqual(nowy.full_url, "https://orzeczenia.nsa.gov.pl/doc/8889489BE0")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/doc/1")
+
 
 class TestZgodaNaObnizenieTls(unittest.TestCase):
     """Downgrade TLS wymaga jawnej zgody: tresc CBOSA trafia do cytatow w pismach."""
@@ -490,7 +541,7 @@ class TestZgodaNaObnizenieTls(unittest.TestCase):
             return self._Odpowiedz(body)
 
         proby, transport = self._transport(zachowanie)
-        args = mock.Mock(doc_id="8889489BE0", json=True, fragment=None)
+        args = mock.Mock(doc_id="8889489BE0", json=True, strict=False, fragment=None)
         stdout = io.StringIO()
         with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
                 transport, mock.patch.object(cbosa.time, "sleep"), \
@@ -502,7 +553,7 @@ class TestZgodaNaObnizenieTls(unittest.TestCase):
 
     def test_tekst_ma_adnotacje_przy_tresci(self):
         cbosa._transport_tls_verified = False
-        args = mock.Mock(doc_id="8889489BE0", json=False, fragment=None)
+        args = mock.Mock(doc_id="8889489BE0", json=False, strict=False, fragment=None)
         stdout = io.StringIO()
         with mock.patch.object(cbosa, "_fetch", return_value=TestOrzeczenie.HTML), \
                 redirect_stdout(stdout):

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -377,6 +377,23 @@ class EliVerificationContractTests(unittest.TestCase):
                 eli.cmd_tekst(args)
         self.assertNotIn("Treść przepisu", out.getvalue())
 
+    def test_strict_nie_wypisuje_tj_przed_kontrola_aktualnosci(self):
+        refs = {"Tekst jednolity dla aktu": [
+            {"act": {"ELI": "DU/1964/296", "displayAddress": "Dz.U. 1964 poz. 296"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path == "/acts/DU/2024/1568/references":
+                return refs
+            raise eli.VerificationUnknown("timeout")
+
+        args = argparse.Namespace(sygnatura=["DU", "2024", "1568"], json=False, strict=True)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(eli.VerificationUnknown, "timeout"):
+                eli.cmd_tj(args)
+        self.assertEqual(out.getvalue(), "")
+
     def test_fallback_pomija_kandydata_z_awaria(self):
         # awaria transportu na JEDNYM kandydacie t.j. nie zabija pętli zapasowej
         refs = {"Inf. o tekście jednolitym": [

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -301,6 +301,15 @@ class TestFlagaJson(unittest.TestCase):
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
 
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
 
 class _Response:
     def __init__(self, body, content_type="application/json"):
@@ -353,6 +362,20 @@ class EliVerificationContractTests(unittest.TestCase):
             eli.cmd_tekst(args)
         self.assertIn("Art. 1. Treść przepisu.", out.getvalue())
         self.assertIn("nie udało się zweryfikować aktualności", out.getvalue())
+
+    def test_strict_blokuje_tekst_przy_awarii_odniesien(self):
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                raise eli.VerificationUnknown("timeout")
+            return "<html><body><p>Art. 1. Treść przepisu.</p></body></html>"
+        args = argparse.Namespace(sygnatura=["DU", "2024", "18"], json=False,
+                                  strict=True, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(eli.VerificationUnknown, "timeout"):
+                eli.cmd_tekst(args)
+        self.assertNotIn("Treść przepisu", out.getvalue())
 
     def test_fallback_pomija_kandydata_z_awaria(self):
         # awaria transportu na JEDNYM kandydacie t.j. nie zabija pętli zapasowej

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -403,6 +403,50 @@ class EliVerificationContractTests(unittest.TestCase):
             with self.assertRaises(eli.VerificationUnknown):
                 eli._tj_z_tekstem("/acts/DU/2024/18", refs)
 
+    def test_domyslnie_starszy_tj_ma_maszynowy_znacznik(self):
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return refs
+            if path == "/acts/DU/2026/468/text.html":
+                return ""
+            if path == "/acts/DU/2024/1568/text.html":
+                return "<p>Art. 1. Starsza treść.</p>"
+            raise AssertionError(path)
+
+        args = argparse.Namespace(sygnatura=["DU", "2026", "468"], json=False,
+                                  strict=False, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            eli.cmd_tekst(args)
+        self.assertIn("ELI_TEXT_SOURCE_FALLBACK=DU/2024/1568", out.getvalue())
+        self.assertIn("Art. 1. Starsza treść.", out.getvalue())
+
+    def test_strict_blokuje_starszy_tj(self):
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return refs
+            if path == "/acts/DU/2026/468/text.html":
+                return ""
+            if path == "/acts/DU/2024/1568/text.html":
+                return "<p>Art. 1. Starsza treść.</p>"
+            raise AssertionError(path)
+
+        args = argparse.Namespace(sygnatura=["DU", "2026", "468"], json=False,
+                                  strict=True, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(SystemExit, "strict zabrania.*DU/2024/1568"):
+                eli.cmd_tekst(args)
+        self.assertNotIn("Starsza treść", out.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -330,21 +330,21 @@ class EliVerificationContractTests(unittest.TestCase):
     """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
 
     def test_soft_transport_error_is_unknown(self):
-        with mock.patch.object(eli.urllib.request, "urlopen", side_effect=urllib.error.URLError("offline")), \
+        with mock.patch.object(eli._opener, "open", side_effect=urllib.error.URLError("offline")), \
                 mock.patch.object(eli.time, "sleep"):
             with self.assertRaises(eli.VerificationUnknown):
                 eli._get("/acts/test/references", soft=True)
 
     def test_successful_empty_json_is_verified_absent(self):
         response = _Response(b"[]")
-        with mock.patch.object(eli.urllib.request, "urlopen", return_value=response):
+        with mock.patch.object(eli._opener, "open", return_value=response):
             self.assertEqual(eli._get("/acts/search", soft=True), [])
 
     def test_soft_404_is_verified_absent(self):
         # API ELI odpowiada 404 wyłącznie dla nieistniejącego zasobu — to zweryfikowany
         # brak (None), nie awaria; "spróbuj ponownie" byłoby tu fałszywym komunikatem
         err = urllib.error.HTTPError("u", 404, "Not Found", {}, None)
-        with mock.patch.object(eli.urllib.request, "urlopen", side_effect=err), \
+        with mock.patch.object(eli._opener, "open", side_effect=err), \
                 mock.patch.object(eli.time, "sleep"):
             self.assertIsNone(eli._get("/acts/DU/2024/999999/references", soft=True))
 
@@ -463,6 +463,91 @@ class EliVerificationContractTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "strict zabrania.*DU/2024/1568"):
                 eli.cmd_tekst(args)
         self.assertNotIn("Starsza treść", out.getvalue())
+
+    def test_t01_strict_blokuje_poprawnie_wykryty_nowszy_tj_i_stdout_jest_pusty(self):
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/500", "displayAddress": "Dz.U. 2026 poz. 500"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return refs
+            return "<p>Art. 1. Starsza, ale niepusta treść.</p>"
+
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2024", "18", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eli.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t02_json_strict_nie_emituje_danych_gdy_kontrola_nie_przeszla(self):
+        komendy = [
+            ["szukaj", "kodeks"],
+            ["meta", "DU", "2024", "18"],
+            ["tekst", "DU", "2024", "18"],
+            ["struktura", "DU", "2024", "18"],
+            ["odniesienia", "DU", "2024", "18"],
+            ["tj", "DU", "2024", "18"],
+        ]
+        for komenda in komendy:
+            with self.subTest(komenda=komenda):
+                out = io.StringIO()
+                with mock.patch.object(eli, "_get", side_effect=eli.VerificationUnknown("timeout")), \
+                        mock.patch.object(sys, "argv", ["eli.py", *komenda, "--json", "--strict"]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        eli.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+
+    def test_t02b_tj_json_strict_kontroluje_nowszy_tj_przed_emisja(self):
+        refs_tj = {"Tekst jednolity dla aktu": [
+            {"act": {"ELI": "DU/1964/296", "displayAddress": "Dz.U. 1964 poz. 296"}}]}
+        refs_bazowe = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/500", "displayAddress": "Dz.U. 2026 poz. 500"}},
+            {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}},
+        ]}
+
+        def fake_get(path, params=None, soft=False):
+            if path == "/acts/DU/2024/1568/references":
+                return refs_tj
+            if path == "/acts/DU/1964/296/references":
+                return refs_bazowe
+            raise AssertionError(path)
+
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tj", "DU", "2024", "1568",
+                                                       "--json", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eli.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+
+class TestT03PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = eli.urllib.request.Request("https://api.sejm.gov.pl/eli/acts/DU/2024/18")
+        handler = eli._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://api.sejm.gov.pl/eli/acts/DU/2024/18/text.pdf")
+        self.assertEqual(nowy.full_url,
+                         "https://api.sejm.gov.pl/eli/acts/DU/2024/18/text.pdf")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/akt.pdf")
+
+
+class TestT04RecznaInstalacjaSkilli(unittest.TestCase):
+    def test_wszystkie_skille_maja_lokalny_fallback_bez_sieci_i_find(self):
+        for skill in ROOT.glob("plugins/*/skills/*/SKILL.md"):
+            text = skill.read_text(encoding="utf-8")
+            with self.subTest(skill=skill):
+                self.assertIn('SKILL_DIR="${SKILL_MD%/SKILL.md}"', text)
+                self.assertIn("Nie pobieraj helpera z sieci", text)
+                self.assertIn("nie szukaj go przez `find`", text)
 
 
 if __name__ == "__main__":

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -220,8 +220,44 @@ class EurlexVerificationContractTests(unittest.TestCase):
                 eurlex.cmd_tekst(args)
         self.assertEqual(out.getvalue(), "")
 
+    def test_t05_strict_blokuje_poprawnie_wykryta_nowsza_konsolidacje(self):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_http",
+                               return_value=(b"<p>Artykul 1. Starsza tresc.</p>", "text/html")), \
+                mock.patch.object(eurlex, "_konsolidacje",
+                                  return_value=["02016R0679-20250504", "02016R0679-20160504"]), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "tekst", "02016R0679-20160504", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eurlex.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
 
-class TestWymusHttps(unittest.TestCase):
+    def test_t06_json_strict_nie_emituje_danych_gdy_kontrola_nie_przeszla(self):
+        komendy = [
+            ["szukaj", "dane"],
+            ["meta", "32016R0679"],
+            ["tekst", "32016R0679"],
+            ["skonsolidowany", "32016R0679"],
+            ["odniesienia", "32016R0679"],
+        ]
+        for komenda in komendy:
+            with self.subTest(komenda=komenda):
+                out = io.StringIO()
+                with mock.patch.object(eurlex, "_http",
+                                       return_value=(b"<p>Artykul 1. Tresc.</p>", "text/html")), \
+                        mock.patch.object(eurlex, "_sparql",
+                                          side_effect=eurlex.VerificationUnknown("timeout")), \
+                        mock.patch.object(sys, "argv",
+                                          ["eurlex.py", *komenda, "--json", "--strict"]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        eurlex.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+
+
+class TestT07WymusHttps(unittest.TestCase):
     """CELLAR nazywa zasoby przez http:// URI, ale pobierac mamy po https."""
 
     def test_dziewiec_przypadkow_url(self):

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Offline unit tests for eurlex.py pure functions (no network). Run: python3 tools/test_eurlex.py"""
 import argparse
+import contextlib
+import io
 import sys
 import importlib.util
 import pathlib
@@ -205,6 +207,18 @@ class EurlexVerificationContractTests(unittest.TestCase):
                                side_effect=eurlex.VerificationUnknown("timeout")):
             with self.assertRaisesRegex(eurlex.VerificationUnknown, "timeout"):
                 eurlex._ostrzezenia_konsolidacja("32016R0679", strict=True)
+
+    def test_strict_nie_wypisuje_tekstu_przed_kontrola_konsolidacji(self):
+        args = argparse.Namespace(celex=["32016R0679"], jezyk="pol", json=False,
+                                  strict=True, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_http", return_value=(b"<p>Artykul 1. Tresc.</p>", "text/html")), \
+                mock.patch.object(eurlex, "_konsolidacje",
+                                  side_effect=eurlex.VerificationUnknown("timeout")), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(eurlex.VerificationUnknown, "timeout"):
+                eurlex.cmd_tekst(args)
+        self.assertEqual(out.getvalue(), "")
 
 
 class TestWymusHttps(unittest.TestCase):

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -239,6 +239,17 @@ class TestWymusHttps(unittest.TestCase):
         url = "http://publications.europa.eu.evil.example/resource/celex/X"
         self.assertEqual(eurlex._wymus_https(url), url)
 
+    def test_data_europa_i_poddomena_sa_na_bialej_liscie(self):
+        cases = [
+            ("http://data.europa.eu/eli/reg/2016/679/oj",
+             "https://data.europa.eu/eli/reg/2016/679/oj"),
+            ("http://api.data.europa.eu/eli/reg/2016/679/oj",
+             "https://api.data.europa.eu/eli/reg/2016/679/oj"),
+        ]
+        for url, expected in cases:
+            with self.subTest(url=url):
+                self.assertEqual(eurlex._wymus_https(url), expected)
+
     def test_http_przekazuje_request_z_podniesionym_url(self):
         odpowiedz = mock.MagicMock()
         odpowiedz.__enter__.return_value = odpowiedz
@@ -259,11 +270,18 @@ class TestWymusHttps(unittest.TestCase):
         self.assertEqual(nowy.full_url,
                          "https://publications.europa.eu/resource/cellar/abc.0018.03/DOC_1")
 
-    def test_przekierowanie_na_obcy_host_zostaje_bez_zmian(self):
+    def test_przekierowanie_303_na_http_data_europa_jest_podnoszone(self):
         req = eurlex.urllib.request.Request("https://publications.europa.eu/resource/celex/X")
         nowy = eurlex._PrzekierowaniaHttps().redirect_request(
             req, None, 303, "See Other", {}, "http://data.europa.eu/eli/reg/2016/679/oj")
-        self.assertEqual(nowy.full_url, "http://data.europa.eu/eli/reg/2016/679/oj")
+        self.assertEqual(nowy.full_url, "https://data.europa.eu/eli/reg/2016/679/oj")
+
+    def test_przekierowanie_na_obcy_host_po_http_jest_odrzucone(self):
+        req = eurlex.urllib.request.Request("https://publications.europa.eu/resource/celex/X")
+        with self.assertRaisesRegex(eurlex.urllib.error.URLError,
+                                    "odrzucono przekierowanie.*niezaufany host"):
+            eurlex._PrzekierowaniaHttps().redirect_request(
+                req, None, 303, "See Other", {}, "http://example.test/legal-content")
 
     def test_uri_przestrzeni_nazw_zostaja_http(self):
         # Zmiana ich postaci zerwalaby dopasowanie w zapytaniach SPARQL.

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -161,6 +161,15 @@ class TestFlagaJson(unittest.TestCase):
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
 
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
 
 class EurlexVerificationContractTests(unittest.TestCase):
     """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
@@ -190,6 +199,12 @@ class EurlexVerificationContractTests(unittest.TestCase):
         self.assertEqual(len(out), 1)
         self.assertIn("nie udało się zweryfikować", out[0])
         self.assertIn("skonsolidowany 32016R0679", out[0])
+
+    def test_strict_blokuje_wynik_przy_awarii_kontroli_konsolidacji(self):
+        with mock.patch.object(eurlex, "_konsolidacje",
+                               side_effect=eurlex.VerificationUnknown("timeout")):
+            with self.assertRaisesRegex(eurlex.VerificationUnknown, "timeout"):
+                eurlex._ostrzezenia_konsolidacja("32016R0679", strict=True)
 
 
 class TestWymusHttps(unittest.TestCase):

--- a/tools/test_saos.py
+++ b/tools/test_saos.py
@@ -198,6 +198,15 @@ class TestFlagaJson(unittest.TestCase):
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
 
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
 
 class _Response:
     headers = {"Content-Type": "application/json"}

--- a/tools/test_saos.py
+++ b/tools/test_saos.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Offline unit tests for saos.py pure functions (no network). Run: python3 tools/test_saos.py"""
 import argparse
+import contextlib
+import io
 import sys
 import importlib.util
 import pathlib
@@ -228,14 +230,14 @@ class SaosVerificationContractTests(unittest.TestCase):
     """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
 
     def test_soft_transport_error_is_unknown(self):
-        with mock.patch.object(saos.urllib.request, "urlopen", side_effect=urllib.error.URLError("offline")), \
+        with mock.patch.object(saos._opener, "open", side_effect=urllib.error.URLError("offline")), \
                 mock.patch.object(saos.time, "sleep"):
             with self.assertRaises(saos.VerificationUnknown):
                 saos._get("/search/judgments", soft=True)
 
     def test_successful_zero_results_is_verified_absent(self):
         response = _Response(b'{"items": [], "info": {"totalResults": 0}}')
-        with mock.patch.object(saos.urllib.request, "urlopen", return_value=response):
+        with mock.patch.object(saos._opener, "open", return_value=response):
             result = saos._get("/search/judgments", soft=True)
         self.assertEqual(result["items"], [])
         self.assertEqual(result["info"]["totalResults"], 0)
@@ -246,6 +248,46 @@ class SaosVerificationContractTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "nie udało się zweryfikować") as caught:
                 saos.cmd_sygnatura(args)
         self.assertNotIn("Nie znaleziono orzeczenia", str(caught.exception))
+
+    def test_t08_strict_blokuje_zakres_poza_zamknietym_zbiorem_i_stdout_jest_pusty(self):
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv",
+                               ["saos.py", "szukaj", "--sad", "SN", "--od", "2024-01-01", "--strict"]), \
+                mock.patch.object(saos, "_get") as get, contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                saos.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+        get.assert_not_called()
+
+    def test_t09_json_strict_nie_emituje_wyniku_gdy_kontrola_nie_przeszla(self):
+        przypadki = [
+            (["szukaj", "--sad", "SN", "--od", "2024-01-01"], None),
+            (["orzeczenie", "123"], {"message": "maintenance"}),
+            (["sygnatura", "III", "CSK", "203/09"],
+             {"items": [], "info": {"totalResults": 0}}),
+        ]
+        for komenda, odpowiedz in przypadki:
+            with self.subTest(komenda=komenda):
+                out = io.StringIO()
+                with mock.patch.object(saos, "_get", return_value=odpowiedz), \
+                        mock.patch.object(sys, "argv", ["saos.py", *komenda, "--json", "--strict"]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        saos.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+
+
+class TestT10PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = saos.urllib.request.Request("https://www.saos.org.pl/api/search/judgments")
+        handler = saos._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://www.saos.org.pl/api/judgments/123")
+        self.assertEqual(nowy.full_url, "https://www.saos.org.pl/api/judgments/123")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/judgment")
 
 
 if __name__ == "__main__":

--- a/tools/test_uodo.py
+++ b/tools/test_uodo.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Offline unit tests for uodo.py pure functions (no network). Run: python3 tools/test_uodo.py"""
+import contextlib
+import io
 import sys
 import importlib.util
 import pathlib
 import unittest
+import urllib.error
+from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location(
@@ -120,6 +124,66 @@ class TestFlagaJson(unittest.TestCase):
 
     def test_bez_strict(self):
         self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
+
+class UodoStrictContractTests(unittest.TestCase):
+    META = {"refname": "DKN.1.1.2025", "title": {"pl": "Przedmiot"}}
+
+    def test_t14_strict_blokuje_brak_pelnej_tresci_i_stdout_jest_pusty(self):
+        out = io.StringIO()
+        with mock.patch.object(uodo, "_get", side_effect=[dict(self.META), ""]), \
+                mock.patch.object(sys, "argv", ["uodo.py", "decyzja", "DKN.1.1.2025", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                uodo.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_awaria_pobrania_tresci_nie_zostawia_czesciowego_stdout(self):
+        out = io.StringIO()
+        with mock.patch.object(uodo, "_get", side_effect=[dict(self.META), SystemExit("awaria body.txt")]), \
+                mock.patch.object(sys, "argv", ["uodo.py", "decyzja", "DKN.1.1.2025"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                uodo.main()
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t15_json_strict_nie_emituje_wyniku_gdy_kontrola_nie_przeszla(self):
+        out = io.StringIO()
+        with mock.patch.object(uodo, "_szukaj", return_value={"error": "maintenance"}), \
+                mock.patch.object(sys, "argv", ["uodo.py", "najnowsze", "--json", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                uodo.main()
+        self.assertEqual(out.getvalue(), "")
+
+        out = io.StringIO()
+        with mock.patch.object(uodo, "_szukaj", return_value={"error": "maintenance"}), \
+                mock.patch.object(sys, "argv", ["uodo.py", "szukaj", "biometr", "--json", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                uodo.main()
+        self.assertEqual(out.getvalue(), "")
+
+        out = io.StringIO()
+        with mock.patch.object(uodo, "_get", side_effect=[dict(self.META), SystemExit("awaria body.txt")]), \
+                mock.patch.object(sys, "argv", ["uodo.py", "decyzja", "DKN.1.1.2025",
+                                                       "--json", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                uodo.main()
+        self.assertEqual(out.getvalue(), "")
+
+
+class TestT16PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = uodo.urllib.request.Request("https://orzeczenia.uodo.gov.pl/api/documents/public")
+        handler = uodo._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://orzeczenia.uodo.gov.pl/api/body.txt")
+        self.assertEqual(nowy.full_url, "https://orzeczenia.uodo.gov.pl/api/body.txt")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/body.txt")
 
 
 if __name__ == "__main__":

--- a/tools/test_uodo.py
+++ b/tools/test_uodo.py
@@ -112,6 +112,15 @@ class TestFlagaJson(unittest.TestCase):
     def test_bez_flagi(self):
         self.assertFalse(self._parsuj(self.ARGV)["json"])
 
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #5 (v1.6.5) and #6 (v1.6.6). Same concern as both: a tool whose output
lands in court filings must never present an unverified result as a verified one.
Those two PRs fixed the transport and the found/verified_absent/unknown contract.
This one closes the remaining path: **the caller has no way to demand that an
unverified result be refused rather than printed with a warning.**

## What this adds

**1. A global `--strict` flag in all five engines.** Semantics: any result whose
currency or completeness could not be verified exits non-zero instead of returning
content. It is built on the existing `VerificationUnknown` / `soft` distinction rather
than beside it. Default mode is unchanged — that is the research mode.

The clearest example of what this is for, run against the live service:

```
saos szukaj --sad SN --od 2024-01-01            → exit 0, "Znaleziono: 0"
saos szukaj --sad SN --od 2024-01-01 --strict   → exit 1, empty stdout,
        "zbiór Sąd Najwyższy kończy się na 2016 r."
```

Without the flag, "no results" for Supreme Court judgments from 2024 reads as
"there are none", when the truth is that the SAOS collection ends in 2016. That is a
false negative someone can build an argument on.

**2. `--strict` is enforced before output, not after it.** Several commands printed
`json.dumps(...)` and returned before reaching their verification step — `cmd_tj`
in `eli.py` was the clearest case (emit at the top, currency check further down).
Every `--json` path in all five engines now verifies first.

**3. Redirect handling extended to all engines.** #6 added a controlled
`HTTPRedirectHandler` to EUR-Lex only. ELI (including PDF download), SAOS, CBOSA and
UODO still followed https→http redirects with the default handler. Each engine now
has one, with its own content-host list: hosts on the list are upgraded to HTTPS,
foreign hosts over plain http are rejected rather than silently followed.

**4. `data.europa.eu` added to the CELLAR content-host allowlist.** After #6, a 303 to
`http://data.europa.eu/eli/...` still travelled in cleartext, because `_wymus_https`
matched only `publications.europa.eu`. The SPARQL namespace constants (CDM, LANG_AUTH,
TYPE_AUTH, XSD_STR) deliberately stay `http://` — upgrading those would break query
matching, so the scheme is still raised only immediately before a network request.

**5. Helpers are pinned to the installed package.** Every `SKILL.md` told the agent to
`find` a helper across `$HOME/.claude`, `$HOME/.agents`, `/mnt` and `/sessions` taking
`head -1`, and to `curl` the script from branch `main` into `/tmp` if that failed. Two
separate problems: executable code fetched from a moving branch, and `head -1` picking
up an arbitrary copy — in our case a stale worktree, which reported a different version
than the one actually installed. Both are gone. `CLAUDE_PLUGIN_ROOT` is used when set,
otherwise the helper is resolved relative to the current `SKILL.md`, which keeps the
manual/dev installation from README working. Nothing is downloaded.

**6. In strict, detected staleness blocks too.** Previously only a *failed* currency
check blocked. A *successful* check that found a newer consolidated text (`eli.py`)
or a newer consolidated version (`eurlex.py`) still printed the older content and
exited 0. From the user's point of view the outcome is identical — an outdated
provision quoted in a filing — so strict now refuses both.

## Tests

258 pass. New tests assert the *effect*, not the flag: non-zero exit **and** empty
stdout, and in the SAOS case also that no request was issued before the block
(`get.assert_not_called()`). Every engine has one for strict, one for `--json --strict`,
and one for redirect handling. One existing test changed deliberately:
`test_przekierowanie_na_obcy_host_zostaje_bez_zmian` encoded the old behaviour that
point 4 changes.

## Not in scope

Two findings from the same audit are deliberately left out, to keep this reviewable:
CLI-level process tests (every current test imports the helper and patches functions;
none runs the CLI as a process and asserts exit codes), and provenance in machine
output (fetch time, engine version, checks performed). Happy to follow up on either.

**No version bumps**, per the lockstep convention you applied on #5 and #6.

## Open questions

- Should `--strict` also be settable by environment variable? An agent framework can
  set an env var globally but cannot easily append a flag to every documented command.
- CBOSA: `CBOSA_INSECURE_TLS=1` is deliberately left as-is per your #6 comment. Strict
  now refuses content fetched through it. Is refusing the right call, or would you
  rather strict simply never allow the downgrade to be attempted?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
