### PR TITLE
REVIEW-ONLY 1/2: przegląd całości kodu (nie mergować)

### DIFF
--- a/plugins/prawo-pl-edzienniki/.claude-plugin/plugin.json
+++ b/plugins/prawo-pl-edzienniki/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-pl-edzienniki",
+  "description": "Prawo miejscowe z API ELI 16 wojewódzkich dzienników urzędowych: uchwały rad gmin/powiatów/sejmików (podatki i opłaty lokalne, plany miejscowe MPZP, statuty), rozporządzenia wojewody. Wyszukiwanie po tytule i roczniku, metadane, pełna treść i urzędowy PDF. Read-only, bez klucza. Prawo krajowe (Dz.U./M.P.): prawo-pl-eli.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-pl-edzienniki/.codex-plugin/plugin.json
+++ b/plugins/prawo-pl-edzienniki/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prawo-pl-edzienniki",
+  "version": "2.0.0",
+  "description": "Prawo miejscowe z API ELI 16 wojewódzkich dzienników urzędowych: uchwały rad gmin/powiatów/sejmików, rozporządzenia wojewody, plany miejscowe, podatki lokalne. Wyszukiwanie po tytule i roczniku, metadane, pełna treść i urzędowy PDF. Read-only, bez klucza.",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": ["prawo", "polish-law", "prawo-miejscowe", "local-law", "dzienniki-wojewodzkie", "eli", "gmina", "legal"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo PL — prawo miejscowe (e-Dzienniki)",
+    "shortDescription": "Prawo miejscowe z 16 wojewódzkich dzienników urzędowych (API ELI).",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/SKILL.md
+++ b/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: prawo-pl-edzienniki
+version: 2.0.0
+description: >-
+  Odpytuje API ELI 16 WOJEWÓDZKICH DZIENNIKÓW URZĘDOWYCH — PRAWO MIEJSCOWE: uchwały rad gmin,
+  powiatów i sejmików województw, rozporządzenia i zarządzenia wojewody, akty prawa miejscowego.
+  Używaj przy KAŻDYM pytaniu o prawo konkretnej gminy/powiatu/województwa: „uchwała rady
+  gminy/miasta…", „miejscowy plan zagospodarowania przestrzennego (MPZP)", „podatek od
+  nieruchomości / opłata targowa / opłata za śmieci w gminie X", „statut gminy/powiatu",
+  „strefa płatnego parkowania", „regulamin utrzymania czystości", „uchwała krajobrazowa",
+  „sieć szkół", „rozporządzenie wojewody". Wyszukiwanie po tytule i roczniku, metadane z datą
+  ogłoszenia i powiązaniami (sprostowania, rozstrzygnięcia nadzorcze), pełna treść z urzędowego
+  PDF (pdftotext) i sam PDF. Read-only, bez klucza. Prawo KRAJOWE (ustawy, Dz.U./M.P.)
+  → skill prawo-pl-eli. Polish LOCAL law from the 16 voivodeship official journals (ELI APIs).
+---
+
+# Prawo miejscowe z API wojewódzkich dzienników urzędowych
+
+Skill do **prawa miejscowego**: aktów publikowanych w **wojewódzkich dziennikach urzędowych** —
+uchwał rad gmin/powiatów/sejmików, rozporządzeń i zarządzeń wojewody, porozumień, obwieszczeń
+(w tym wyroków WSA uchylających akty miejscowe). Tych aktów NIE ma w Dz.U./M.P. — każde z 16
+województw prowadzi własny e-Dziennik z API zgodnym z ELI (ten sam wzorzec co API Sejmu, ale na
+osobnym hoście). Używaj go, gdy pytanie dotyczy **konkretnej gminy, powiatu lub województwa**:
+podatki i opłaty lokalne, plany miejscowe (MPZP), statuty, organizacja szkół, strefy parkowania.
+
+## Podział ról (który skill do czego)
+
+1. **Prawo miejscowe (ta gmina/powiat/województwo) → ten skill.**
+2. **Prawo krajowe → prawo-pl-eli** (ustawy, rozporządzenia, kodeksy z Dz.U./M.P.). Upoważnienie
+   ustawowe do uchwały (np. art. 5 u.p.o.l. dla stawek podatku od nieruchomości) cytuj z ELI.
+3. **Kontrola sądowa aktów miejscowych** (skargi na uchwały, rozstrzygnięcia nadzorcze) →
+   orzecznictwo WSA/NSA w skillu **prawo-pl-cbosa**.
+4. **Delegując research subagentowi**, wpisz: „akty prawa miejscowego pobieraj przez
+   `scripts/edzienniki.py` (skill prawo-pl-edzienniki); ustawy przez `scripts/eli.py` (prawo-pl-eli)".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/edzienniki.py` (tylko biblioteka standardowa Pythona — bez instalacji).
+Do PEŁNEJ treści aktu helper używa `pdftotext` (pakiet poppler) z PATH — **zalecane: poppler/pdftotext**
+(macOS `brew install poppler`, Debian/Ubuntu `apt install poppler-utils`); bez niego tekst jest tylko
+z `text.html` (zwykle **wyłącznie 1. strona aktu**) albo z PDF pobranego przez `--pdf`.
+Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/edzienniki.py`) — NIE zakładaj, że
+to `~/.claude/skills/prawo-pl-edzienniki` (skill zainstalowany jako plugin leży w katalogu pluginów;
+w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+EDZ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-edzienniki/scripts/edzienniki.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$EDZ" ] || EDZ="<katalog skilla>/scripts/edzienniki.py"
+[ -f "$EDZ" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $EDZ" >&2; exit 1; }
+python3 "$EDZ" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/edzienniki.py` oznacza `python3 "$EDZ"`, jeśli nie jesteś w katalogu skilla.)
+
+### Komendy
+
+- **dzienniki** — lista 16 dzienników z kodami i hostami; z `--woj` roczniki i liczba aktów:
+  `python3 scripts/edzienniki.py dzienniki --woj DS`
+  Kody = sufiks publishera ELI: `DS` dolnośląskie, `KP` kujawsko-pomorskie, `LB` lubelskie,
+  `LS` lubuskie, `LD` łódzkie, `MP` małopolskie, `MZ` mazowieckie, `OP` opolskie,
+  `PK` podkarpackie, `PL` podlaskie, `PM` pomorskie, `SL` śląskie, `SK` świętokrzyskie,
+  `WM` warmińsko-mazurskie, `WP` wielkopolskie, `ZP` zachodniopomorskie (można też podać nazwę).
+- **szukaj** — akty województwa po frazie z TYTUŁU (nazwa gminy, przedmiot uchwały):
+  `python3 scripts/edzienniki.py szukaj --woj DS "plan zagospodarowania" --rok 2026 --limit 5`
+  Filtr jest LOKALNY (API dzienników ignoruje filtry serwerowe — silnik pobiera rocznik i sam
+  filtruje; bez rozróżniania diakrytyków). Bez `--rok`: do 3 najnowszych roczników. W tytule
+  uchwał zwykle jest nazwa organu — szukaj po nazwie gminy: `szukaj --woj MP "Kraków"`.
+  UWAGA: wynik to JEDNA strona (domyślnie 10 NAJNOWSZYCH pozycji z trafień) — gdy nagłówek
+  liczy więcej trafień, obejrzyj resztę przez `--strona 2..N` albo `--limit <liczba trafień>`.
+  „Nie ma w pierwszej dziesiątce" NIE znaczy „akt nie istnieje" — przed wnioskiem o braku
+  aktu przejrzyj WSZYSTKIE trafienia (najprościej: `--limit` ≥ liczba trafień z nagłówka).
+  Wiersz trafienia podaje **datę aktu** („z dnia…") i **datę ogłoszenia** w dzienniku oraz status
+  „wg listy rocznika" (z `--strict` status jest weryfikowany w rekordzie aktu). Nagłówek mówi, które
+  roczniki FAKTYCZNIE przeszukano i czy lista rocznika była pełna.
+- **akt** — metadane: typ, organ, **Data aktu** (uchwalenia) i **Ogłoszony** (publikacja w dzienniku —
+  od niej liczy się vacatio legis), status, hasła, linki PDF/HTML oraz **Powiązania** z rejestru
+  dziennika: sprostowania, uchylenia, rozstrzygnięcia nadzorcze (nieważność w całości/części):
+  `python3 scripts/edzienniki.py akt DS 2026 3299`
+- **tekst** — treść aktu z **urzędowego PDF** (`pdftotext -layout`, nagłówki/stopki stron usunięte,
+  zawinięte linie scalone); `--fragment "§ 2"` / `"art. 5"` zwraca **całą jednostkę** (do następnego §;
+  każde wystąpienie, np. § 2 uchwały i § 2 statutu w załączniku), inna fraza — okna rozszerzone do
+  granic akapitu; `--pdf` zapisuje urzędowy PDF:
+  `python3 scripts/edzienniki.py tekst DS 2026 3299 --fragment "§ 2"`
+  Bez `pdftotext` na PATH: tekst z `text.html` z głośnym ostrzeżeniem (zwykle tylko 1. strona —
+  „nie znaleziono frazy" NIE jest wtedy dowodem braku przepisu) — pobierz PDF przez `--pdf`.
+- każda komenda przyjmuje `--json` oraz `--strict`; obie flagi działają przed komendą i po niej.
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”).
+
+### Co dokładnie sprawdza `--strict` (kod wyjścia ≠ 0 = wynik NIEZWERYFIKOWANY)
+
+- `szukaj`: rocznik bez listy aktów (nieoczekiwana odpowiedź) → blokada; lista rocznika **krótsza niż
+  `totalCount`** (po ponowieniu z innym limitem) → blokada — brakowałoby najnowszych pozycji i statusów;
+  status wyświetlanych wierszy (do 20) jest pobierany z rekordu aktu i oznaczony „zweryfikowany".
+- `tekst`: tekst z `text.html` (brak `pdftotext` → tylko 1. strona) → blokada; znaki zastępcze U+FFFD
+  (uszkodzona konwersja, np. host podlaski) → blokada; brak oznaczeń `§`/`Art.` → blokada tylko dla
+  `text.html` albo gdy tekst z PDF jest krótszy niż 300 znaków (skan/pusta ekstrakcja) — akt narracyjny
+  z PDF (rozstrzygnięcie nadzorcze, obwieszczenie) przechodzi z ostrzeżeniem. Poprawny tekst z PDF
+  nigdy nie jest blokowany.
+- `akt`: powiązania z rejestru dziennika są best-effort — ich brak to ostrzeżenie, nie blokada.
+
+Typowy przepływ: ustal województwo → `szukaj --woj <kod> "<gmina lub przedmiot>"` →
+`akt <woj> <rok> <poz>` → `tekst … --fragment` albo `--pdf` do dosłownego cytatu.
+
+## Zasady (ważne — dlaczego)
+
+1. **Sygnatura aktu miejscowego** = dziennik + rocznik + pozycja (np. „Dz. Urz. Woj. Doln.
+   z 2026 r. poz. 3299") — podawaj ją przy cytacie razem z organem i datą uchwały.
+2. **Sprawdzaj status i wejście w życie w TREŚCI aktu** — pola `inForce`/`entryIntoForce` w API
+   bywają niewypełnione; akty miejscowe wchodzą w życie zwykle 14 dni od **ogłoszenia** (art. 4
+   ustawy o ogłaszaniu aktów normatywnych) — liczonego od daty „Ogłoszony" z `akt` (publikacja
+   w dzienniku), NIE od „Data aktu" (uchwalenia); uchwały podatkowe od 1 stycznia itd.
+3. **Uchwała może być uchylona** rozstrzygnięciem nadzorczym wojewody albo wyrokiem WSA, a jej
+   treść **sprostowana** obwieszczeniem — `akt` pokazuje te powiązania z rejestru dziennika
+   („Powiązania:"); przy sprawie spornej sprawdź też orzecznictwo (skill prawo-pl-cbosa).
+4. **Cytuj z tekstu PDF** — `tekst` czyta urzędowy PDF przez `pdftotext` (nagłówek wyniku: „tekst
+   z urzędowego PDF"). `text.html` na hostach dzienników to zwykle **tylko 1. strona aktu** (bez
+   dalszych §, stawek, załączników), a na hoście podlaskim bywa uszkodzony (znaki U+FFFD, brak „§",
+   zlepione wyrazy) — silnik to wykrywa i ostrzega; do dosłownego cytatu z takiego wyniku użyj
+   `tekst … --pdf`.
+5. **mazowieckie (MZ)** bywa nieosiągalne spoza Polski (CDN) — silnik zgłosi to czytelnie;
+   wtedy wskaż użytkownikowi UI: https://edziennik.mazowieckie.pl/ **Małopolskie (MP), lubuskie (LS)
+   i łódzkie (LD)** wysyłają niepełny łańcuch certyfikatów TLS — silnik dociąga certyfikat pośredni
+   (AIA) i weryfikuje pełny łańcuch sam; gdy to zawiedzie, komunikat mówi o łańcuchu (to nie jest
+   blokada geograficzna).
+6. Pełna tabela hostów, endpointy i pułapki API: `references/api.md`.
+
+## Czego ten skill NIE obejmuje
+
+- **prawa krajowego** (ustawy, rozporządzenia, kodeksy → skill **prawo-pl-eli**, Dz.U./M.P.),
+- **dzienników resortowych** (ministerstw) i Dziennika Urzędowego UE (→ **prawo-eu-eurlex**),
+- **orzecznictwa** (kontrola aktów miejscowych → **prawo-pl-cbosa**; SN/TK → **prawo-pl-saos**),
+- uchwał NIEpublikowanych w dzienniku (część uchwał „zwykłych" jest tylko w BIP gminy — powiedz
+  to wprost i wskaż BIP, nie udawaj, że dziennik je pokryje).
+
+## Przykładowy przepływ
+
+Pytanie: „jaka jest stawka podatku od nieruchomości w Ząbkowicach Śląskich na 2026 r.?"
+1. Województwo: dolnośląskie → kod `DS`.
+2. `szukaj --woj DS "Ząbkowic Śląskich podatku od nieruchomości" --rok 2025` (uchwały podatkowe
+   na 2026 r. są ogłaszane pod koniec 2025 r.; jeśli pusto — sama nazwa gminy).
+3. `akt DS 2025 <poz>` → metadane (data ogłoszenia, sprostowania); `tekst DS 2025 <poz> --fragment "§ 1"`
+   → cały § 1 ze stawkami (z PDF; `--fragment "od gruntów"` = okno wokół frazy).
+4. (opcjonalnie) upoważnienie ustawowe: skill prawo-pl-eli, art. 5 ustawy o podatkach i opłatach
+   lokalnych. W odpowiedzi: stawka + „Dz. Urz. Woj. Doln. z 2025 r. poz. X" + data uchwały.

--- a/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/references/api.md
+++ b/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/references/api.md
@@ -1,0 +1,126 @@
+# API ELI wojewódzkich dzienników urzędowych — referencja
+
+Każde z 16 województw prowadzi własny **e-Dziennik** (oprogramowanie ABC PRO) z API zgodnym z ELI —
+ten sam wzorzec co `api.sejm.gov.pl/eli`, ale **na osobnym hoście** i z okrojonym zestawem endpointów.
+Prefiks ścieżki: **`/api/eli`**. Bez klucza, wszystko GET (read-only). Zakres: akty prawa miejscowego
+(uchwały rad gmin/powiatów/sejmików, rozporządzenia wojewody, zarządzenia, obwieszczenia, wyroki WSA
+dot. aktów miejscowych). Obsługa: `scripts/edzienniki.py`.
+
+## Hosty (zweryfikowane 2026-07)
+
+| Kod | Województwo | Host | Publisher |
+|---|---|---|---|
+| DS | dolnośląskie | edzienniki.duw.pl | POL_WOJ_DS |
+| KP | kujawsko-pomorskie | edzienniki.bydgoszcz.uw.gov.pl | POL_WOJ_KP |
+| LB | lubelskie | edziennik.lublin.uw.gov.pl | POL_WOJ_LB |
+| LS | lubuskie | dzienniki.luw.pl | POL_WOJ_LS |
+| LD | łódzkie | dziennik.lodzkie.eu | POL_WOJ_LD |
+| MP | małopolskie | edziennik.malopolska.uw.gov.pl | POL_WOJ_MP |
+| MZ | mazowieckie | edziennik.mazowieckie.pl | POL_WOJ_MZ |
+| OP | opolskie | duwo.opole.uw.gov.pl | POL_WOJ_OP |
+| PK | podkarpackie | edziennik.rzeszow.uw.gov.pl | POL_WOJ_PK |
+| PL | podlaskie | edziennik.bialystok.uw.gov.pl | POL_WOJ_PL |
+| PM | pomorskie | edziennik.gdansk.uw.gov.pl | POL_WOJ_PM |
+| SL | śląskie | dzienniki.slask.eu | POL_WOJ_SL |
+| SK | świętokrzyskie | edziennik.kielce.uw.gov.pl | POL_WOJ_SK |
+| WM | warmińsko-mazurskie | edzienniki.olsztyn.uw.gov.pl | POL_WOJ_WM |
+| WP | wielkopolskie | edziennik.poznan.uw.gov.pl | POL_WOJ_WP |
+| ZP | zachodniopomorskie | e-dziennik.szczecin.uw.gov.pl | POL_WOJ_ZP |
+
+## Endpointy (identyczne na każdym hoście)
+
+| Ścieżka | Zwraca |
+|---|---|
+| `/api/eli/acts` | lista publisherów hosta: `[{code, shortName, name, years[], deedsCount}]` |
+| `/api/eli/acts/{publisher}/{rok}?limit=&offset=` | rocznik: `{items[], offset, count, totalCount}` |
+| `/api/eli/acts/{publisher}/{rok}/{poz}` | metadane aktu (pola niżej) |
+| `/api/eli/acts/{publisher}/{rok}/{poz}/text.pdf` | urzędowy PDF (pełny tekst — jedyne wiarygodne źródło treści) |
+| `/api/eli/acts/{publisher}/{rok}/{poz}/text.html` | tekst HTML — **zwykle tylko 1. strona PDF** (patrz pułapka 9) |
+| `/api/legalact?year={rok}&journal=0&position={poz}` | **rejestr dziennika** (backend UI, poza `/api/eli`): `ActDate`, `PublicationDate`, `ActStatus{IsInvalid, IsPartialInvalid, Description}`, `ActRelations[{RelationType, Description, LegalActsRelated[{Year, Position, LegalActType, ActDate, CaseNumber, Description}]}]` — powiązania: `Uchyla`, `JestSprostowaniemDla`/„Ma sprostowanie", `FullDecision`/„Ma rozstrzygnięcie nadzorcze (nieważność w całości)", częściowa nieważność. Używany przez `akt` (best-effort). |
+
+Pola aktu: `address` (`POL_WOJ_DS202613299`→ w silniku rok/poz), `publisher year volume pos type
+title displayAddress promulgation announcementDate textPDF textHTML changeDate entryIntoForce
+validFrom repealDate expirationDate legalStatusDate inForce releasedBy[] keywords[] status`.
+
+### Semantyka dat — RÓŻNA między endpointami (zweryfikowane 2026-08 na DS, PM, PL, MP)
+
+| Endpoint | `announcementDate` | `promulgation` |
+|---|---|---|
+| `/acts/{pub}/{rok}/{poz}` (rekord aktu) | **data AKTU** („z dnia …", godzina 00:00) | **data OGŁOSZENIA** w dzienniku (ze znacznikiem czasu) — jak w ELI Sejmu |
+| `/acts/{pub}/{rok}` (lista rocznika) | **data OGŁOSZENIA** (znacznik czasu) | **data AKTU** |
+
+Przykład DS 2026/3654: rekord → `announcementDate 2026-08-11`, `promulgation 2026-08-13T10:46`;
+lista → `promulgation 2026-08-11`, `announcementDate 2026-08-13T10:46`; rejestr → `ActDate 2026-08-11`,
+`PublicationDate 2026-08-13T10:46`; nagłówek PDF „Wrocław, dnia 13 sierpnia 2026 r.". Silnik (`_daty`)
+mapuje pola wg endpointu i pilnuje, by ogłoszenie nie poprzedzało daty aktu. Vacatio legis (14 dni)
+liczy się od daty OGŁOSZENIA — `akt` pokazuje obie daty osobno („Data aktu" / „Ogłoszony").
+
+## Różnice vs API ELI Sejmu — PUŁAPKI (zweryfikowane na żywo)
+
+1. **BRAK `/acts/search`** — segment `search` trafia w trasę `{publisher}` i zwraca (HTTP 200!)
+   generyczny obiekt `code: "WDU_D"`. Wyszukiwanie = pobranie rocznika + filtr lokalny.
+2. **Serwerowe filtry są IGNOROWANE** — parametry `title`, `type`, `keyword` na listingu rocznika
+   nie zawężają wyników (zwracają pełny rocznik). `edzienniki.py` pobiera cały rocznik jednym
+   żądaniem **bez parametru `limit`** (serwer zwraca wtedy pełny rocznik, ~3–7 tys. aktów) i filtruje
+   tytuły lokalnie (podłańcuch, bez rozróżniania diakrytyków).
+   **NIE używaj `?limit=100000`** — backend ABC PRO serwuje dla tej wartości NIEAKTUALNĄ kopię listy
+   przy świeżym `totalCount` (2026-08-22: PM 3149 z 3330 pozycji, brak aktów z ostatnich 3 tygodni,
+   unieważniony MPZP nadal „obowiązujący"; DS 3709/3739; PL 3173/3271). `?limit=5000`, `?limit=99999`
+   i brak limitu zwracają komplet. Silnik porównuje `len(items)` z `totalCount`, ponawia z innym
+   limitem, a gdy lista nadal jest krótsza — ostrzega (domyślnie) albo blokuje (`--strict`).
+3. **Nieznany publisher → HTTP 200** z obiektem domyślnym (nigdy 404) — silnik sprawdza `code`.
+4. **4 hosty zwracają klucze PascalCase** (`Items/Title/TotalCount` — starsze wdrożenia: KP, LS,
+   LD, PL) — silnik normalizuje klucze do lowercase.
+5. **Daty** ISO z godziną (`2026-07-10T00:00:00`); wartownik `0001-01-01T00:00:00` = brak danych.
+   Pola `inForce`/`entryIntoForce` bywają **niewypełnione** (inForce=0 przy status „obowiązujący")
+   — nie wnioskuj z nich o obowiązywaniu; miarodajny jest `status` + treść aktu.
+6. **WAF na duwo.opole.uw.gov.pl** — odrzuca (403) gołe klienty HTTP; silnik wysyła nagłówki
+   jak przeglądarka + `Accept: application/json`.
+7. **edziennik.mazowieckie.pl** — za CDN (Akamai); bywa nieosiągalny spoza Polski (TCP wstaje,
+   HTTP nie odpowiada). Silnik ma krótki timeout i czytelny komunikat; UI: https://edziennik.mazowieckie.pl/
+8. Metadane ELI są uboższe niż w Sejmowym ELI: brak `references` (nowelizacje), `texts`, słowników.
+   Powiązania (sprostowania, uchylenia, rozstrzygnięcia nadzorcze, częściowa nieważność) daje za to
+   **rejestr dziennika** `GET /api/legalact?year=&journal=0&position=` (ten sam host, bez klucza,
+   działa też na starszych wdrożeniach) — `akt` pobiera go best-effort i drukuje „Powiązania:".
+   Przykład MP 2025/7877 → `JestSprostowaniemDla` → DZ. URZ. WOJ. 2026.446 (obwieszczenie o sprostowaniu
+   stawki 4,63 zł); PM 2026/3104 → `FullDecision` → 2026.3258 (rozstrzygnięcie nadzorcze, nieważność).
+9. **`text.html` = zwykle tylko PIERWSZA STRONA PDF** (DS, PM, PL, MP — zweryfikowane 2026-08: MP 2025/7877
+   kończy się w pół § 1, bez stawki za budowle i § 2–4; DS 2026/3654 bez 5-stronicowego statutu).
+   Na hoście **podlaskim** (PL) `text.html` jest dodatkowo uszkodzony (80+ znaków U+FFFD, brak „§",
+   zlepione/pominięte wyrazy). Metadane nie podają liczby stron. Jedyne wiarygodne źródło treści to
+   `text.pdf` — silnik czyta go przez `pdftotext -layout` (poppler; brak na PATH → `text.html`
+   z głośnym ostrzeżeniem, `--strict` blokuje), usuwa nagłówek dziennika („DZIENNIK URZĘDOWY … Poz. N"
+   + kolumnę e-podpisu), nagłówki kolejnych stron („Dziennik Urzędowy Województwa … – N – Poz. X"),
+   stopki Legislatora („Id: …. Podpisany", „Strona N") i scala zawinięte linie, tak by jednostki
+   („§ 1.", „1)", „a)") zaczynały linię. Wykrywa U+FFFD i brak oznaczeń jednostek.
+10. **Niepełny łańcuch TLS** — `edziennik.malopolska.uw.gov.pl` (MP), `dzienniki.luw.pl` (LS)
+    i `dziennik.lodzkie.eu` (LD) wysyłają sam certyfikat liścia bez pośredniego (Certum DV TLS G2 R39,
+    home.pl DV TLS G2 R35). Przeglądarki/curl dociągają pośredni przez AIA; urllib kończy
+    `CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate`. Silnik robi to samo biblioteką
+    standardową: czyta liść (połączenie bez weryfikacji służy WYŁĄCZNIE do odczytu certyfikatu), wyciąga
+    z DER adres „CA Issuers" (OID 1.3.6.1.5.5.7.48.2), pobiera pośredni, dokłada do domyślnych CA
+    (`load_verify_locations(cadata=…)`) i ponawia z PEŁNĄ weryfikacją. Treść nigdy nie jest pobierana
+    bez weryfikacji; gdy dociągnięcie zawiedzie, komunikat mówi o niepełnym łańcuchu (nie o geoblokadzie).
+11. **Indeks górny w `text.html`** bywa osobnym akapitem z samą cyfrą przed linią z „m" („2" / „… od 1 m
+    powierzchni") — silnik scala to do „m²"; `<sup>` renderuje w linii.
+
+## Mapowanie komend `edzienniki.py`
+
+`dzienniki [--woj W]`→`/acts`; `szukaj --woj W [FRAZA] [--rok R]`→`/acts/{pub}/{rok}` (bez limitu;
+przy `len(items) < totalCount` ponowienie z `limit=totalCount+500`) + filtr lokalny (bez `--rok`: do
+3 najnowszych roczników — nagłówek podaje faktycznie przeszukane); `--limit`/`--strona` stronicują
+listę PRZEFILTROWANYCH trafień (strony 1..N pokrywają wszystkie policzone trafienia, stopka
+podaje zakres i N); z `--strict` status wyświetlanych wierszy (≤ 20) z `/acts/{pub}/{r}/{p}`;
+`akt W R P`→`/acts/{pub}/{r}/{p}` + `/api/legalact?year=R&journal=0&position=P` (powiązania, best-effort);
+`tekst W R P [--fragment F] [--pdf PLIK]`→`…/text.pdf` + `pdftotext -layout` (tekst; bez pdftotext:
+`…/text.html` z ostrzeżeniem) / `…/text.pdf` (plik). `--fragment "§ N"`/`"art. N"` = cała jednostka
+do następnej; inna fraza = okno ~600 znaków rozszerzone do granic akapitu.
+
+## Wskazówki
+
+- Centralny portal `eli.gov.pl` agreguje dzienniki (w tym Dz.U./M.P.), ale maszynowy dostęp
+  pozostaje per-host — stąd tabela wyżej. Dokument wdrożeniowy: `api.sejm.gov.pl/implementing_eli_pl.html`.
+- Do dosłownego cytatu używaj tekstu z PDF (`tekst` z `pdftotext`, nagłówek „tekst z urzędowego PDF")
+  albo samego PDF (`tekst … --pdf`), jak przy Dz.U. — nigdy z `text.html` (1. strona, bywa uszkodzony).
+- Prawo krajowe (ustawy, rozporządzenia) — **zawsze** skill **prawo-pl-eli** (Dz.U./M.P.),
+  nie dzienniki wojewódzkie; tu jest wyłącznie prawo miejscowe.

--- a/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/scripts/edzienniki.py
+++ b/plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/scripts/edzienniki.py
@@ -1,0 +1,878 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do API ELI WOJEWÓDZKICH DZIENNIKÓW URZĘDOWYCH (16 dzienników, prawo miejscowe).
+Tylko biblioteka standardowa Pythona (urllib/json/re/ssl) — brak zależności pip; do pełnego tekstu
+aktu używa zewnętrznego `pdftotext` (poppler), gdy jest na PATH — bez niego tekst tylko z text.html
+(zwykle TYLKO 1. strona aktu) albo z PDF przez --pdf.
+Operacje WYŁĄCZNIE read-only (GET), bez klucza.
+
+Każde województwo prowadzi własny e-Dziennik z API zgodnym z ELI (ten sam wzorzec co
+api.sejm.gov.pl/eli, prefiks /api/eli), ale na WŁASNYM hoście — silnik zna tabelę 16 hostów.
+Zakres: akty prawa MIEJSCOWEGO (uchwały rad gmin/powiatów/sejmików, rozporządzenia wojewody,
+zarządzenia). Prawo krajowe (Dz.U./M.P.) → skill prawo-pl-eli (scripts/eli.py) — treść ustaw
+i rozporządzeń krajowych zawsze stamtąd.
+
+Komendy:
+  dzienniki [--woj W]                 lista dzienników / roczniki i liczba aktów województwa
+  szukaj --woj W ["<fraza tytułu>"] [--rok RRRR] [--limit N] [--strona N]
+  akt <woj> <rok> <poz>               metadane aktu + powiązania (sprostowania, uchylenia,
+                                      rozstrzygnięcia nadzorcze) z rejestru dziennika
+  tekst <woj> <rok> <poz> [--fragment "<fraza>|§ N|art. N"] [--pdf ŚCIEŻKA]
+Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować jego kompletności:
+                      niepełna lista rocznika, tekst tylko z 1. strony, uszkodzony tekst)
+"""
+import sys, json, re, time, argparse, base64, os, shutil, socket, ssl, subprocess, tempfile
+import urllib.request, urllib.parse, urllib.error
+from html.parser import HTMLParser
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+
+# kod → (województwo, host, publisher ELI). Kody = sufiks publishera (POL_WOJ_XX).
+WOJEWODZTWA = {
+    "DS": ("dolnośląskie", "edzienniki.duw.pl", "POL_WOJ_DS"),
+    "KP": ("kujawsko-pomorskie", "edzienniki.bydgoszcz.uw.gov.pl", "POL_WOJ_KP"),
+    "LB": ("lubelskie", "edziennik.lublin.uw.gov.pl", "POL_WOJ_LB"),
+    "LS": ("lubuskie", "dzienniki.luw.pl", "POL_WOJ_LS"),
+    "LD": ("łódzkie", "dziennik.lodzkie.eu", "POL_WOJ_LD"),
+    "MP": ("małopolskie", "edziennik.malopolska.uw.gov.pl", "POL_WOJ_MP"),
+    "MZ": ("mazowieckie", "edziennik.mazowieckie.pl", "POL_WOJ_MZ"),
+    "OP": ("opolskie", "duwo.opole.uw.gov.pl", "POL_WOJ_OP"),
+    "PK": ("podkarpackie", "edziennik.rzeszow.uw.gov.pl", "POL_WOJ_PK"),
+    "PL": ("podlaskie", "edziennik.bialystok.uw.gov.pl", "POL_WOJ_PL"),
+    "PM": ("pomorskie", "edziennik.gdansk.uw.gov.pl", "POL_WOJ_PM"),
+    "SL": ("śląskie", "dzienniki.slask.eu", "POL_WOJ_SL"),
+    "SK": ("świętokrzyskie", "edziennik.kielce.uw.gov.pl", "POL_WOJ_SK"),
+    "WM": ("warmińsko-mazurskie", "edzienniki.olsztyn.uw.gov.pl", "POL_WOJ_WM"),
+    "WP": ("wielkopolskie", "edziennik.poznan.uw.gov.pl", "POL_WOJ_WP"),
+    "ZP": ("zachodniopomorskie", "e-dziennik.szczecin.uw.gov.pl", "POL_WOJ_ZP"),
+}
+
+_UA = ("Mozilla/5.0 (compatible; prawo-pl-eli-edzienniki/"
+       f"{__version__}; +https://github.com/jamarpl21/prawo-pl-eli)")
+
+
+def _ascii(s):
+    return s.lower().translate(str.maketrans("ąćęłńóśźż", "acelnoszz"))
+
+
+def _woj(s):
+    """Kod (DS) albo nazwa województwa ('dolnośląskie', 'dolnoslaskie', prefiks) → (kod, nazwa, host, publisher).
+    Prefiks pasujący do KILKU województw ('ma' → małopolskie i mazowieckie) = błąd z listą kandydatów,
+    nigdy cichy wybór pierwszego."""
+    if not s:
+        sys.exit("Podaj województwo: --woj <kod|nazwa>, np. --woj DS albo --woj dolnośląskie.\n"
+                 "Kody: " + ", ".join(f"{k}={v[0]}" for k, v in sorted(WOJEWODZTWA.items())))
+    kod = s.strip().upper()
+    if kod in WOJEWODZTWA:
+        return (kod,) + WOJEWODZTWA[kod]
+    szukane = _ascii(s.strip())
+    kandydaci = [(k, v) for k, v in WOJEWODZTWA.items() if _ascii(v[0]).startswith(szukane)]
+    if len(kandydaci) == 1:
+        k, (nazwa, host, pub) = kandydaci[0]
+        return k, nazwa, host, pub
+    if kandydaci:
+        sys.exit(f"Niejednoznaczne województwo {s!r} — pasuje: "
+                 + ", ".join(f"{k}={v[0]}" for k, v in kandydaci) + ". Podaj kod albo pełną nazwę.")
+    sys.exit(f"Nieznane województwo: {s!r}. Kody: "
+             + ", ".join(f"{k}={v[0]}" for k, v in sorted(WOJEWODZTWA.items())))
+
+
+def _norm(obj):
+    """Rekurencyjnie znormalizuj klucze JSON do lowercase — 4 z 16 hostów (starsze wdrożenia
+    ABC PRO) zwracają klucze PascalCase (Title/Items) zamiast camelCase (title/items)."""
+    if isinstance(obj, dict):
+        return {k.lower(): _norm(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_norm(x) for x in obj]
+    return obj
+
+
+# ---------------------------------------------------------------------------------------------
+# TLS: część hostów (MP edziennik.malopolska.uw.gov.pl, LS dzienniki.luw.pl, LD dziennik.lodzkie.eu)
+# wysyła NIEPEŁNY łańcuch certyfikatów (sam liść, bez pośredniego Certum/home.pl). Przeglądarki
+# i curl dociągają pośredni przez AIA (Authority Information Access → „CA Issuers"); urllib nie.
+# Robimy to samo, wyłącznie biblioteką standardową: po CERTIFICATE_VERIFY_FAILED czytamy liść
+# (połączenie bez weryfikacji służy TYLKO do odczytu certyfikatu — żadna treść nie jest nim pobierana),
+# wyciągamy z DER adres http „CA Issuers", pobieramy pośredni, dokładamy do DOMYŚLNYCH CA i ponawiamy
+# z PEŁNĄ weryfikacją. Nigdy nie pobieramy treści przez CERT_NONE.
+# ---------------------------------------------------------------------------------------------
+_SSL_CTX = None                      # kontekst z doładowanym pośrednim (wspólny w procesie)
+_OID_CA_ISSUERS = b"\x06\x08\x2b\x06\x01\x05\x05\x07\x30\x02"   # id-ad-caIssuers 1.3.6.1.5.5.7.48.2
+
+
+def _aia_urls(der):
+    """Adresy http „CA Issuers" z rozszerzenia AIA certyfikatu (DER): po OID caIssuers następuje
+    GeneralName uniformResourceIdentifier (tag 0x86) + długość DER + URL."""
+    urls = []
+    for m in re.finditer(re.escape(_OID_CA_ISSUERS) + rb"\x86", der):
+        i = m.end()
+        if i >= len(der):
+            continue
+        ln = der[i]; i += 1
+        if ln & 0x80:
+            n = ln & 0x7f
+            ln = int.from_bytes(der[i:i + n], "big"); i += n
+        u = der[i:i + ln]
+        if u.startswith(b"http://") and re.search(rb"\.(crt|cer|der|p7c)$", u, re.I):
+            urls.append(u.decode("ascii", "replace"))
+    return urls
+
+
+def _der_do_pem(dane):
+    if dane.lstrip().startswith(b"-----BEGIN"):
+        return dane.decode("ascii", "replace")
+    b = base64.b64encode(dane).decode("ascii")
+    return ("-----BEGIN CERTIFICATE-----\n" + "\n".join(b[i:i + 64] for i in range(0, len(b), 64))
+            + "\n-----END CERTIFICATE-----\n")
+
+
+def _lisc_der(host):
+    """Certyfikat liścia serwera w DER — połączenie bez weryfikacji, tylko handshake + odczyt certu."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    with socket.create_connection((host, 443), timeout=15) as s, \
+            ctx.wrap_socket(s, server_hostname=host) as ss:
+        return ss.getpeercert(binary_form=True)
+
+
+def _ctx_z_aia(host):
+    """Kontekst SSL = domyślne CA + pośredni pobrany z AIA liścia hosta; None, gdy się nie udało."""
+    try:
+        urls = _aia_urls(_lisc_der(host))
+        if not urls:
+            return None
+        ctx = _SSL_CTX or ssl.create_default_context()
+        # Pośredni pochodzi z adresu podanego przez NIEZWERYFIKOWANY liść, więc nie może stać się
+        # kotwicą zaufania: bez PARTIAL_CHAIN OpenSSL wymaga, by łańcuch kończył się na
+        # samopodpisanym korzeniu z domyślnego magazynu — pobrany certyfikat służy tylko do
+        # zbudowania łańcucha (Python ≥3.10 włącza PARTIAL_CHAIN domyślnie).
+        ctx.verify_flags &= ~getattr(ssl, "VERIFY_X509_PARTIAL_CHAIN", 0)
+        for u in urls[:3]:
+            with urllib.request.urlopen(urllib.request.Request(u, headers={"User-Agent": _UA}),
+                                        timeout=15) as r:
+                ctx.load_verify_locations(cadata=_der_do_pem(r.read()))
+        return ctx
+    except Exception:  # noqa: BLE001 — brak pośredniego = komunikat o niepełnym łańcuchu wyżej
+        return None
+
+
+def _blad_certyfikatu(e):
+    r = getattr(e, "reason", e)
+    return isinstance(r, ssl.SSLCertVerificationError) or "CERTIFICATE_VERIFY_FAILED" in str(e)
+
+
+def _fetch(url, host, raw=False, timeout=25, soft=False):
+    """GET url → bajty. soft=True: każdy błąd → None (wywołania pomocnicze, best-effort);
+    domyślnie błąd = komunikat i exit ≠ 0. Obsługuje AIA (niepełny łańcuch TLS) i 1 ponowienie."""
+    global _SSL_CTX
+    req = urllib.request.Request(url, headers={
+        "User-Agent": _UA,
+        "Accept": "application/octet-stream" if raw else "application/json, text/html;q=0.9"})
+    aia_probowane = False
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            with urllib.request.urlopen(req, timeout=timeout, context=_SSL_CTX) as r:
+                return r.read()
+        except urllib.error.HTTPError as e:
+            if e.code >= 500 and attempt == 1:
+                time.sleep(2); continue
+            if soft:
+                return None
+            if e.code == 404:
+                sys.exit(f"BŁĄD HTTP 404 (nie znaleziono): {url}")
+            if e.code == 403:
+                sys.exit(f"BŁĄD HTTP 403: {url}\n"
+                         f"Host {host} odrzucił żądanie (WAF) — sprawdź akt w przeglądarce: https://{host}/")
+            sys.exit(f"BŁĄD HTTP {e.code}: {url}")
+        except Exception as e:  # noqa: BLE001
+            if _blad_certyfikatu(e):
+                if not aia_probowane:
+                    aia_probowane = True
+                    ctx = _ctx_z_aia(host)
+                    if ctx is not None:
+                        _SSL_CTX = ctx
+                        continue
+                if soft:
+                    return None
+                sys.exit(f"BŁĄD TLS: {url}\n"
+                         f"Serwer {host} wysyła niepełny łańcuch certyfikatów po stronie serwera (brak "
+                         "certyfikatu pośredniego) i nie udało się go dociągnąć automatycznie przez AIA "
+                         f"({e}). Host jest osiągalny — to nie jest blokada geograficzna. Obejście: "
+                         "SSL_CERT_FILE z dołożonym certyfikatem pośrednim (Certum/home.pl) albo UI: "
+                         f"https://{host}/")
+            if attempt == 1:
+                time.sleep(2); continue
+            if soft:
+                return None
+            sys.exit(f"BŁĄD sieci: {url} ({e})\n"
+                     f"Uwaga: host {host} bywa niedostępny (np. edziennik.mazowieckie.pl odcina "
+                     f"ruch spoza PL) — sprawdź w przeglądarce: https://{host}/")
+
+
+def _get(host, path, params=None, raw=False):
+    """GET https://{host}/api/eli{path}. Nagłówki jak przeglądarka (WAF na duwo.opole.uw.gov.pl
+    odrzuca gołe klienty); krótki timeout (edziennik.mazowieckie.pl bywa nieosiągalny spoza PL)."""
+    url = f"https://{host}/api/eli{path}"
+    if params:
+        q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "", False)})
+        if q:
+            url += "?" + q
+    # cały rocznik (3–7 tys. aktów) i PDF potrzebują dłuższego timeoutu niż pojedynczy rekord
+    duze = raw or re.fullmatch(r"/acts/[^/]+/\d+", path) is not None
+    dane = _fetch(url, host, raw=raw, timeout=90 if duze else 25)
+    if raw:
+        return dane
+    tekst = dane.decode("utf-8", "replace")
+    try:
+        return _norm(json.loads(tekst))
+    except json.JSONDecodeError:
+        return tekst
+
+
+def _get_rejestr(host, rok, poz):
+    """Rejestr dziennika (backend UI Angulara, ten sam host, bez klucza):
+    GET https://{host}/api/legalact?year={rok}&journal=0&position={poz} → ActDate, PublicationDate,
+    ActStatus{IsInvalid,IsPartialInvalid,Description}, ActRelations[{RelationType, Description,
+    LegalActsRelated[{Year,Position,LegalActType,ActDate,CaseNumber,Description}]}].
+    Best-effort: każdy błąd → None (ostrzeżenie, nie blokada)."""
+    url = f"https://{host}/api/legalact?" + urllib.parse.urlencode(
+        {"year": rok, "journal": 0, "position": poz})
+    dane = _fetch(url, host, timeout=25, soft=True)
+    if not dane:
+        return None
+    try:
+        d = _norm(json.loads(dane.decode("utf-8", "replace")))
+    except json.JSONDecodeError:
+        return None
+    return d if isinstance(d, dict) and ("actrelations" in d or "actstatus" in d) else None
+
+
+def _data(v):
+    """Data ISO z godziną → sama data; sentinel 0001-01-01 → None."""
+    if not v or str(v).startswith("0001-01-01"):
+        return None
+    return str(v)[:10]
+
+
+def _daty(d, lista=False):
+    """→ (data_aktu, data_ogłoszenia). SEMANTYKA PÓL RÓŻNI SIĘ MIĘDZY ENDPOINTAMI (zweryfikowane
+    2026-08 na DS/PM/PL/MP):
+      • /acts/{pub}/{rok}/{poz} (akt): announcementDate = data AKTU („z dnia …"),
+        promulgation = data OGŁOSZENIA w dzienniku (ze znacznikiem czasu) — jak w ELI Sejmu;
+      • /acts/{pub}/{rok} (lista rocznika): ODWROTNIE — promulgation = data aktu,
+        announcementDate = znacznik czasu ogłoszenia.
+    Zabezpieczenie: ogłoszenie nie może poprzedzać daty aktu — gdy wychodzi wcześniej, pola są
+    zamienione (host o innej konwencji) i zamieniamy je z powrotem."""
+    a, p = _data(d.get("announcementdate")), _data(d.get("promulgation"))
+    akt, ogl = (p, a) if lista else (a, p)
+    if akt and ogl and ogl < akt:
+        akt, ogl = ogl, akt
+    return akt, ogl
+
+
+_SUPER = str.maketrans("0123456789", "⁰¹²³⁴⁵⁶⁷⁸⁹")
+
+
+class _Stripper(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.out, self.skip, self.sup = [], 0, 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style"):
+            self.skip += 1
+        if tag == "sup":
+            self.sup += 1
+        if tag in ("p", "br", "div", "tr", "li", "h1", "h2", "h3", "h4"):
+            self.out.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style") and self.skip:
+            self.skip -= 1
+        if tag == "sup" and self.sup:
+            self.sup -= 1
+
+    def handle_data(self, data):
+        if not self.skip:
+            self.out.append(data.translate(_SUPER) if self.sup else data)
+
+
+def _scal_indeksy(t):
+    """text.html z dzienników emituje indeks górny jako OSOBNY akapit z samą cyfrą przed linią z „m":
+    „…czasie\\n2\\nzakończono … od 1 m powierzchni" → „… od 1 m² powierzchni"."""
+    return re.sub(r"\n([23])\s*\n([^\n]*?\d+ ?m)(?=[ ,.;)])",
+                  lambda m: "\n" + m.group(2) + m.group(1).translate(_SUPER), t)
+
+
+def html_to_text(html):
+    p = _Stripper()
+    p.feed(html)
+    t = "".join(p.out).replace("\xa0", " ")
+    t = re.sub(r"[ \t]+", " ", t)
+    t = re.sub(r"\n[ \t]+", "\n", t)
+    t = re.sub(r"[ \t]+\n", "\n", t)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return _scal_indeksy(t).strip()
+
+
+# ---------------------------------------------------------------------------------------------
+# Tekst z urzędowego PDF (pdftotext -layout) — text.html na hostach dzienników zawiera zwykle
+# TYLKO 1. STRONĘ aktu (DS, PM, PL, MP — zweryfikowane 2026-08), a na PL bywa uszkodzony (U+FFFD,
+# brak „§", zlepione wyrazy). Pełny i wiarygodny tekst = PDF.
+# ---------------------------------------------------------------------------------------------
+def _pdftotext_dostepny():
+    return shutil.which("pdftotext")
+
+
+def _pdftotext(dane):
+    """PDF (bajty) → surowy tekst `pdftotext -layout` (strony rozdzielone \\f) albo None."""
+    exe = _pdftotext_dostepny()
+    if not exe:
+        return None
+    fd, sciezka = tempfile.mkstemp(suffix=".pdf")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(dane)
+        r = subprocess.run([exe, "-layout", "-enc", "UTF-8", sciezka, "-"],
+                           capture_output=True, timeout=180)
+    except Exception:  # noqa: BLE001 — pdftotext padł/timeout → jak brak narzędzia
+        return None
+    finally:
+        try:
+            os.unlink(sciezka)
+        except OSError:
+            pass
+    if r.returncode != 0:
+        return None
+    return r.stdout.decode("utf-8", "replace")
+
+
+_RE_POZ = re.compile(r"^\s*Poz\.\s*(\d+)")
+_RE_NAGLOWEK_STRONY = re.compile(r"^\s*Dziennik Urzędowy Województwa\b.*[–-]\s*\d+\s*[–-]")
+_RE_PODPIS_EDZ = re.compile(r"^\s*(Podpisany przez\b|Data:\s*\d|Rodzaj:|Miejsce:)")
+_RE_STOPKA_ID = re.compile(r"^\s*Id:\s*[0-9A-Za-z-]{6,}\.?\s*(Podpisany|Projekt|Uchwalony|Przyjęty)?\.?"
+                           r"\s*(Strona\s+\d+(\s+z\s+\d+)?)?\s*$")
+_RE_STRONA = re.compile(r"^\s*Strona\s+\d+(\s+z\s+\d+)?\s*$")
+_RE_DNIA = re.compile(r"([A-ZŁŚŻ][\w-]+),\s*dnia\s+(\d{1,2}\s+\w+\s+\d{4})\s*r\.")
+# początek jednostki redakcyjnej NA POCZĄTKU LINII („§ 1." / „Art. 5." z kropką — odwołania w zdaniu
+# „§ 3 ust. 2" kropki nie mają) oraz punkt/litera/ustęp/tiret, rozdział, załącznik
+_RE_JEDNOSTKA = re.compile(r"^(§\s*\d+[a-z]?\.|Art\.\s*\d+[a-z]?\.|\d+\.\s|\d+\)\s|[a-z]\)\s|[–-]\s|•\s|"
+                           r"Rozdział\s+\S|ROZDZIAŁ\s+\S|DZIAŁ\s+\S|Dział\s+\S|Załącznik\b|ZAŁĄCZNIK\b)")
+
+
+def _czysc_pdf(surowy):
+    """Tekst z pdftotext -layout → tekst aktu: bez nagłówka dziennika (1. strona: „DZIENNIK
+    URZĘDOWY … Poz. N" + kolumna e-podpisu), bez nagłówków kolejnych stron („Dziennik Urzędowy
+    Województwa … – N – Poz. X"), bez stopek Legislatora („Id: …. Podpisany", „Strona N");
+    zawinięte linie scalone w akapity (jednostka redakcyjna zaczyna linię → działa --fragment "§ N").
+    → (tekst, liczba_stron, nagłówek_dziennika np. „Kraków, dnia 16 grudnia 2025 r., poz. 7877")."""
+    strony = surowy.split("\f")
+    if strony and not strony[-1].strip():
+        strony.pop()
+    linie, naglowek = [], None
+    for nr, strona in enumerate(strony):
+        ls = strona.split("\n")
+        if nr == 0:
+            for i, l in enumerate(ls[:15]):
+                m = _RE_POZ.match(l)
+                if m:
+                    m2 = _RE_DNIA.search("\n".join(ls[:i]))
+                    naglowek = (f"{m2.group(1)}, dnia {m2.group(2)} r., " if m2 else "") + f"poz. {m.group(1)}"
+                    ls = ls[i + 1:]
+                    break
+            ls = [l for j, l in enumerate(ls) if not (j < 8 and _RE_PODPIS_EDZ.match(l))]
+        else:
+            for i, l in enumerate(ls[:3]):
+                if _RE_NAGLOWEK_STRONY.match(l):
+                    del ls[i]
+                    break
+        for l in ls:
+            if _RE_STOPKA_ID.match(l) or _RE_STRONA.match(l):
+                continue
+            linie.append(l)
+    return _scal_linie(linie), len(strony), naglowek
+
+
+def _scal_linie(linie):
+    """Linie -layout → akapity. Nowy akapit: pusta linia przed, początek jednostki redakcyjnej,
+    linia wycentrowana/wyrównana do prawej (wcięcie ≥ 16: tytuły, podpisy) albo wiersz tabeli
+    (≥ 3 spacje między komórkami); pozostałe linie doklejamy do poprzedniej spacją."""
+    akapity, pusta = [], True
+    for l in linie:
+        surowa = l.rstrip()
+        if not surowa.strip():
+            pusta = True
+            continue
+        wciecie = len(surowa) - len(surowa.lstrip(" "))
+        s = re.sub(r"[ \t]{3,}", "  ", surowa.strip())
+        s = re.sub(r"(?<=\S)[ \t](?=\S)", " ", s)
+        tabela = "  " in s
+        if pusta or not akapity or wciecie >= 16 or tabela or _RE_JEDNOSTKA.match(s):
+            akapity.append(s)
+        else:
+            akapity[-1] += " " + s
+        pusta = False
+    return "\n".join(akapity).strip()
+
+
+_RE_MARKER = re.compile(r"(?mi)^\s*(§\s*\d+|art\.\s*\d+)")
+
+
+def _ocena_tekstu(txt, zrodlo):
+    """Sprawdzenie wiarygodności tekstu → (ostrzeżenia[], blokujące_w_strict[]).
+    zrodlo: 'pdf' (pdftotext) albo 'html' (text.html)."""
+    ostrz, blok = [], []
+    n_fffd = txt.count("�")
+    if n_fffd:
+        blok.append(f"tekst zawiera {n_fffd} znaków zastępczych U+FFFD (uszkodzona konwersja po stronie "
+                    "serwera) — cytuj WYŁĄCZNIE z urzędowego PDF")
+    if not _RE_MARKER.search(txt):
+        if zrodlo == "html" or len(txt.strip()) < 300:
+            blok.append("brak oznaczeń jednostek redakcyjnych (§/Art.) — tekst niepełny albo uszkodzony")
+        else:
+            ostrz.append("brak oznaczeń jednostek redakcyjnych (§/Art.) — akt narracyjny (obwieszczenie, "
+                         "rozstrzygnięcie) albo niepełna ekstrakcja; porównaj z PDF")
+    if zrodlo == "html":
+        blok.append("text.html zawiera zwykle tylko PIERWSZĄ STRONĘ aktu — to NIE jest pełny tekst")
+    return ostrz, blok
+
+
+def _fragmenty(txt, fraza, maks=6, okno=600):
+    """Fragmenty wokół frazy → lista (start, end).
+    • fraza = oznaczenie jednostki („§ 4", „§ 4.", „art. 7") → CAŁA jednostka: od jej nagłówka na
+      początku linii do następnej jednostki tego samego typu (każde wystąpienie — np. § 1 uchwały
+      i § 1 statutu w załączniku);
+    • inna fraza → okno ~600 znaków rozszerzone do granic linii/akapitu (nigdy w pół słowa)."""
+    f = fraza.strip()
+    if not f:
+        return []
+    m = re.fullmatch(r"(§|art\.?)\s*(\d+[a-z]?)\.?", f, re.I)
+    if m:
+        nr = re.escape(m.group(2))
+        if m.group(1) == "§":
+            naglowek = re.compile(rf"(?m)^[ \t]*§\s*{nr}\.(?![0-9])")
+            nastepna = re.compile(r"(?m)^[ \t]*(§\s*\d+[a-z]?\.(?![0-9])|Załącznik\b|ZAŁĄCZNIK\b)")
+        else:
+            naglowek = re.compile(rf"(?mi)^[ \t]*art\.\s*{nr}\.(?![0-9])")
+            nastepna = re.compile(r"(?mi)^[ \t]*(art\.\s*\d+[a-z]?\.(?![0-9])|Załącznik\b)")
+        spans = []
+        for mm in naglowek.finditer(txt):
+            n = nastepna.search(txt, mm.end())
+            spans.append((mm.start(), n.start() if n else len(txt)))
+            if len(spans) >= maks:
+                break
+        if spans:
+            return spans
+    low, fl = txt.lower(), f.lower()
+    spans, p = [], low.find(fl)
+    while p != -1 and len(spans) < maks:
+        start = max(0, p - okno // 3)
+        end = min(len(txt), p + len(fl) + okno)
+        start = txt.rfind("\n", 0, start) + 1
+        k = txt.find("\n", end)
+        end = len(txt) if k == -1 else k
+        if spans and start <= spans[-1][1]:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], end))
+        else:
+            spans.append((start, end))
+        p = low.find(fl, p + len(fl))
+    return spans
+
+
+def _stronicuj(trafienia, limit, strona):
+    """Okno paginacji na liście PRZEFILTROWANYCH trafień (nigdy na surowej odpowiedzi API):
+    → (wycinek, indeks startu, liczba stron). Gwarantuje, że strony 1..N pokrywają cały zbiór."""
+    strony = max(1, -(-len(trafienia) // limit))
+    start = (strona - 1) * limit
+    return trafienia[start:start + limit], start, strony
+
+
+def _roczniki(host, publisher):
+    """GET /acts → wpis publishera: lista lat + liczba aktów."""
+    d = _get(host, "/acts")
+    if isinstance(d, list):
+        for wpis in d:
+            if wpis.get("code") == publisher:
+                return wpis
+    return None
+
+
+def _rocznik(host, pub, rok):
+    """Cały rocznik → (odpowiedź, brakuje). BEZ parametru limit — serwer zwraca pełny rocznik.
+    NIE używamy limit=100000: backend ABC PRO serwuje dla tej wartości NIEAKTUALNĄ kopię listy
+    (PM 2026: 3149 z 3330 aktów, stare statusy) przy świeżym totalCount. Gdy lista krótsza niż
+    totalCount → ponowienie z innym limitem; jeśli nadal krótsza → brakuje > 0 (wynik niepełny)."""
+    d = _get(host, f"/acts/{pub}/{rok}")
+    if not isinstance(d, dict):
+        return d, 0
+    items = d.get("items") or []
+    total = int(d.get("totalcount") or 0)
+    if total and len(items) < total:
+        d2 = _get(host, f"/acts/{pub}/{rok}", {"limit": total + 500})
+        if isinstance(d2, dict) and len(d2.get("items") or []) > len(items):
+            d, items = d2, d2.get("items") or []
+    return d, (max(0, total - len(items)) if total else 0)
+
+
+def cmd_dzienniki(a):
+    if not a.woj:
+        if a.json:
+            print(json.dumps({k: {"wojewodztwo": v[0], "host": v[1], "publisher": v[2]}
+                              for k, v in WOJEWODZTWA.items()}, ensure_ascii=False, indent=2)); return
+        print("Wojewódzkie dzienniki urzędowe (API ELI na hoście każdego województwa):\n")
+        for k, (nazwa, host, pub) in sorted(WOJEWODZTWA.items()):
+            dopisek = "  (bywa nieosiągalny spoza PL)" if k == "MZ" else ""
+            print(f"  {k}  {nazwa:22s}  https://{host}/  ({pub}){dopisek}")
+        print("\nRoczniki województwa: dzienniki --woj <kod>;  wyszukiwanie: szukaj --woj <kod> \"<fraza>\"")
+        return
+    kod, nazwa, host, pub = _woj(a.woj)
+    wpis = _roczniki(host, pub)
+    if a.json:
+        print(json.dumps(wpis, ensure_ascii=False, indent=2)); return
+    if not wpis:
+        sys.exit(f"Host {host} nie zwrócił wpisu publishera {pub} — sprawdź https://{host}/")
+    lata = wpis.get("years") or []
+    print(f"# Dziennik Urzędowy — województwo {nazwa}  ({pub}, https://{host}/)")
+    print(f"  Aktów łącznie: {wpis.get('deedscount') or wpis.get('count') or '?'}")
+    if lata:
+        print(f"  Roczniki: {lata[0]}–{lata[-1]}" if len(lata) > 1 else f"  Rocznik: {lata[0]}")
+
+
+def cmd_szukaj(a):
+    kod, nazwa, host, pub = _woj(a.woj)
+    strict = getattr(a, "strict", False)
+    if a.limit < 1 or a.strona < 1:
+        sys.exit("--limit i --strona muszą być ≥ 1.")
+    if a.rok:
+        lata = [a.rok]
+    else:
+        wpis = _roczniki(host, pub)
+        lata = sorted((wpis or {}).get("years") or [], reverse=True)[:3]
+        if not lata:
+            sys.exit(f"Nie udało się pobrać roczników z {host} — podaj --rok RRRR.")
+    # API dzienników IGNORUJE serwerowe filtry (title/type/keyword) — pobieramy cały rocznik
+    # jednym żądaniem (bez limitu; serwer nie stronicuje) i filtrujemy lokalnie po tytule.
+    fraza = _ascii(a.fraza) if a.fraza else None
+    zebrane, total_info, pominiete, niepelne = [], {}, [], {}
+    for rok in lata:
+        d, brakuje = _rocznik(host, pub, rok)
+        if not isinstance(d, dict):
+            # rocznik bez listy aktów = wynik NIEKOMPLETNY: strict blokuje, domyślnie głośno ostrzegamy
+            if strict:
+                sys.exit(f"BŁĄD: {host} zwrócił nieoczekiwaną odpowiedź dla rocznika {rok} — tryb strict "
+                         "nie zwróci niekompletnego wyniku. Spróbuj ponownie albo zawęź: --rok RRRR.")
+            pominiete.append(rok)
+            continue
+        items = d.get("items") or []
+        total = int(d.get("totalcount") or 0) or len(items)
+        if brakuje:
+            if strict:
+                sys.exit(f"BŁĄD: lista rocznika {rok} z {host} jest NIEPEŁNA ({len(items)} z {total} aktów, "
+                         f"brakuje {brakuje} najnowszych) — tryb strict nie zwróci niekompletnego wyniku. "
+                         "Ponów za chwilę albo sprawdź najnowsze pozycje przez akt/tekst.")
+            niepelne[rok] = (len(items), total)
+        trafione = [it for it in items if not fraza or fraza in _ascii(it.get("title") or "")]
+        najnowsza = max((it.get("pos") or 0) for it in items) if items else 0
+        total_info[rok] = {"trafien": len(trafione), "aktow": total, "pobrano": len(items),
+                           "najnowsza_poz": najnowsza, "pelna": not brakuje}
+        zebrane.extend(sorted(trafione, key=lambda it: it.get("pos") or 0, reverse=True))
+        # bez frazy trafienia = cały rocznik — dalsze roczniki pobieramy tylko, gdy okno strony
+        # tego wymaga; Z frazą pobieramy wszystkie żądane roczniki, by licznik trafień był pełny
+        if not fraza and len(zebrane) >= a.strona * a.limit:
+            break
+    przeszukane = list(total_info)
+    nieprzeszukane = [r for r in lata if r not in przeszukane and r not in pominiete]
+    okno, start, strony = _stronicuj(zebrane, a.limit, a.strona)
+    if not zebrane:  # zweryfikowane zero — także z --json komunikat, nie pusty JSON
+        sys.exit(f"Brak wyników w {nazwa} ({', '.join(map(str, przeszukane or lata))}). Filtr frazy działa po "
+                 "TYTULE aktu (podłańcuch, bez diakrytyków) — spróbuj krótszej frazy albo innego "
+                 "roku (--rok)." + (f"\nUWAGA: rocznik(i) {', '.join(map(str, pominiete))} POMINIĘTE "
+                                    f"({host} zwrócił nieoczekiwaną odpowiedź) — to NIE jest pełne zero."
+                                    if pominiete else "")
+                 + (f"\nUWAGA: lista rocznika {', '.join(map(str, niepelne))} NIEPEŁNA — to NIE jest pełne zero."
+                    if niepelne else ""))
+    if not okno:
+        sys.exit(f"Strona {a.strona} poza zakresem: {len(zebrane)} trafień = {strony} "
+                 f"stron(y) przy --limit {a.limit}.")
+    # status w wierszu pochodzi z listy rocznika; w strict weryfikujemy go w rekordzie aktu
+    # (do 20 wyświetlanych wierszy — sekwencyjnie, oszczędnie dla hosta)
+    zweryfikowane = {}
+    if strict:
+        for it in okno[:20]:
+            rec = _get(host, f"/acts/{pub}/{it.get('year')}/{it.get('pos')}")
+            if isinstance(rec, dict) and rec.get("title"):
+                zweryfikowane[(it.get("year"), it.get("pos"))] = rec.get("status") or ""
+    if a.json:
+        for it in okno:
+            k = (it.get("year"), it.get("pos"))
+            if k in zweryfikowane:
+                it["status_zweryfikowany"] = zweryfikowane[k]
+        print(json.dumps({"wojewodztwo": nazwa, "publisher": pub, "lata": lata,
+                          "roczniki_przeszukane": przeszukane, "roczniki_nieprzeszukane": nieprzeszukane,
+                          "roczniki_pominiete": pominiete,
+                          "roczniki_niepelne": {str(r): {"pobrano": n, "aktow": t} for r, (n, t) in niepelne.items()},
+                          "total": {str(r): f"{v['trafien']}/{v['aktow']}" for r, v in total_info.items()},
+                          "roczniki": {str(r): v for r, v in total_info.items()},
+                          "trafien": len(zebrane), "strona": a.strona,
+                          "stron": strony, "items": okno},
+                         ensure_ascii=False, indent=2)); return
+    if pominiete:
+        print(f"UWAGA: rocznik(i) {', '.join(map(str, pominiete))} POMINIĘTE — {host} zwrócił nieoczekiwaną "
+              "odpowiedź; wynik może być niekompletny (ponów albo podaj --rok RRRR).")
+    for r, (n, t) in niepelne.items():
+        print(f"UWAGA: lista rocznika {r} NIEPEŁNA — {host} zwrócił {n} z {t} aktów (brakuje {t - n} "
+              "NAJNOWSZYCH pozycji, statusy mogą być nieaktualne). Wynik NIE jest kompletny — ponów za chwilę "
+              "albo sprawdź najnowsze pozycje bezpośrednio (akt/tekst).")
+    laty = (f"{przeszukane[-1]}–{przeszukane[0]}" if len(przeszukane) > 1 else str(przeszukane[0]))
+    opis = ", ".join(
+        f"{r}: {v['trafien']}/{v['aktow']}" + ("" if v["pelna"] else f" (pobrano {v['pobrano']} — NIEPEŁNA)")
+        for r, v in total_info.items())
+    print(f"Województwo {nazwa}, przeszukane roczniki: {laty} (trafienia/akty wg lat: {opis})")
+    if nieprzeszukane:
+        print(f"  (roczniki {', '.join(map(str, nieprzeszukane))} NIE przeszukane — okno strony wypełnił "
+              f"rocznik {przeszukane[-1]}; starsze: --rok RRRR)")
+    print()
+    for it in okno:
+        adres = it.get("displayaddress") or f"{pub} {it.get('year')} poz. {it.get('pos')}"
+        tytul = re.sub(r"\s+", " ", it.get("title") or "").strip()
+        status = it.get("status") or ""
+        data_aktu, ogl = _daty(it, lista=True)
+        print(f"  [{it.get('year')}/{it.get('pos')}]  {adres}")
+        print(f"    {it.get('type', '?')}: {tytul[:250]}{'…' if len(tytul) > 250 else ''}")
+        k = (it.get("year"), it.get("pos"))
+        if k in zweryfikowane:
+            st_v = zweryfikowane[k]
+            etykieta = "status (zweryfikowany w rekordzie aktu)"
+            if st_v and st_v.lower() != status.lower():
+                status = f"{st_v}  [lista rocznika podawała: {status or '—'}]"
+            elif st_v:
+                status = st_v
+        else:
+            etykieta = "status (wg listy rocznika)"
+        print(f"    {etykieta}: {status or '—'}  · data aktu: {data_aktu or '?'}  · ogłoszono: {ogl or '?'}")
+        print()
+    if strony > 1:
+        print(f"Pokazano {start + 1}–{start + len(okno)} z {len(zebrane)} trafień (roczniki {laty}) — reszta: "
+              f"--strona <1..{strony}> (po {a.limit} na stronę) albo --limit {len(zebrane)}.")
+    pierwsze = okno[0]
+    print(f"Metadane/tekst: akt {kod} {pierwsze.get('year')} {pierwsze.get('pos')}  "
+          f"/ tekst {kod} {pierwsze.get('year')} {pierwsze.get('pos')}")
+
+
+def _powiazania(rej):
+    """ActRelations z rejestru dziennika → lista wierszy tekstu."""
+    wiersze = []
+    for rel in rej.get("actrelations") or []:
+        if not isinstance(rel, dict):
+            continue
+        opis = rel.get("description") or rel.get("relationtype") or "powiązanie"
+        for la in rel.get("legalactsrelated") or []:
+            if not isinstance(la, dict):
+                continue
+            czesci = [la.get("legalacttype") or "akt"]
+            if la.get("casenumber"):
+                czesci.append(f"nr {la['casenumber']}")
+            if _data(la.get("actdate")):
+                czesci.append(f"z {_data(la.get('actdate'))}")
+            adres = la.get("description") or f"{la.get('year')}/{la.get('position')}"
+            wiersze.append(f"{opis}: {' '.join(czesci)} → {adres}  "
+                           f"[rok {la.get('year')} poz. {la.get('position')}]")
+        if not rel.get("legalactsrelated"):
+            wiersze.append(opis)
+    return wiersze
+
+
+def cmd_akt(a):
+    kod, nazwa, host, pub = _woj(a.woj)
+    d = _get(host, f"/acts/{pub}/{a.rok}/{a.poz}")
+    if not isinstance(d, dict) or not d.get("title"):
+        sys.exit(f"Nie znaleziono aktu {pub}/{a.rok}/{a.poz} na {host}.")
+    rej = _get_rejestr(host, a.rok, a.poz)   # best-effort: powiązania + status z rejestru dziennika
+    if a.json:
+        if rej is not None:
+            d["_rejestr_dziennika"] = {"actstatus": rej.get("actstatus"), "actrelations": rej.get("actrelations"),
+                                       "actdate": rej.get("actdate"), "publicationdate": rej.get("publicationdate")}
+        else:
+            d["_rejestr_dziennika"] = None
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    tytul = re.sub(r"\s+", " ", d.get("title") or "").strip()
+    data_aktu, ogl = _daty(d)
+    print(f"# {d.get('displayaddress') or f'{pub} {a.rok} poz. {a.poz}'}")
+    print(f"  Typ:      {d.get('type', '?')}")
+    print(f"  Tytuł:    {tytul}")
+    print(f"  Organ:    {', '.join(d.get('releasedby') or []) or '—'}")
+    print(f"  Data aktu: {data_aktu or '?'}   Ogłoszony (publikacja w dzienniku): {ogl or '?'}   "
+          f"wejście w życie: {_data(d.get('entryintoforce')) or _data(d.get('validfrom')) or '—'}")
+    if rej is not None and _data(rej.get("publicationdate")) and ogl and _data(rej.get("publicationdate")) != ogl:
+        print(f"  (rejestr dziennika podaje datę publikacji {_data(rej.get('publicationdate'))} — rozbieżność z ELI)")
+    # pola inForce/entryIntoForce bywają na hostach wojewódzkich niewypełnione — pokazujemy status
+    st = d.get("status") or ""
+    if st:
+        print(f"  Status:   {st}")
+    if rej is not None:
+        ast = rej.get("actstatus") or {}
+        opis = (ast.get("description") or "").strip() if isinstance(ast, dict) else ""
+        if opis and opis.lower() != st.lower():
+            print(f"  Status (rejestr dziennika): {opis}")
+        if isinstance(ast, dict) and ast.get("ispartialinvalid"):
+            print("  UWAGA: częściowa nieważność aktu (rejestr dziennika) — sprawdź rozstrzygnięcie/wyrok niżej")
+    uch = _data(d.get("repealdate")) or _data(d.get("expirationdate"))
+    if uch:
+        print(f"  Uchylenie/wygaśnięcie: {uch}")
+    kw = d.get("keywords") or []
+    if kw:
+        print(f"  Hasła:    {', '.join(kw)}")
+    if rej is None:
+        print(f"  Powiązania: nie udało się pobrać rejestru dziennika (https://{host}/api/legalact) — "
+              "sprostowania/uchylenia/rozstrzygnięcia nadzorcze sprawdź w późniejszych pozycjach dziennika")
+    else:
+        pw = _powiazania(rej)
+        if pw:
+            print("  Powiązania (rejestr dziennika — sprostowania, uchylenia, rozstrzygnięcia nadzorcze):")
+            for w in pw:
+                print(f"    - {w}")
+        else:
+            print("  Powiązania: brak w rejestrze dziennika (stan na dziś — sprostowania i rozstrzygnięcia "
+                  "pojawiają się pod późniejszymi pozycjami)")
+    print(f"  ELI:      https://{host}/api/eli/acts/{pub}/{a.rok}/{a.poz}")
+    if d.get("texthtml"):
+        print(f"  Tekst HTML: https://{host}/api/eli/acts/{pub}/{a.rok}/{a.poz}/text.html  (zwykle tylko 1. strona)")
+    if d.get("textpdf"):
+        print(f"  Tekst PDF:  https://{host}/api/eli/acts/{pub}/{a.rok}/{a.poz}/text.pdf")
+    print(f"\nTreść: tekst {kod} {a.rok} {a.poz}  [--fragment \"<fraza>|§ N\"] [--pdf plik.pdf]")
+
+
+def cmd_tekst(a):
+    kod, nazwa, host, pub = _woj(a.woj)
+    strict = getattr(a, "strict", False)
+    if a.pdf:
+        dane = _get(host, f"/acts/{pub}/{a.rok}/{a.poz}/text.pdf", raw=True)
+        if not dane.startswith(b"%PDF"):
+            sys.exit(f"Host {host} nie zwrócił PDF dla {pub}/{a.rok}/{a.poz} — sprawdź: akt {kod} {a.rok} {a.poz}")
+        with open(a.pdf, "wb") as f:
+            f.write(dane)
+        print(f"Zapisano urzędowy PDF: {a.pdf} ({len(dane)} bajtów)")
+        return
+    txt, zrodlo, strony, naglowek, uwagi = None, None, 0, None, []
+    if _pdftotext_dostepny():
+        dane = _get(host, f"/acts/{pub}/{a.rok}/{a.poz}/text.pdf", raw=True)
+        if dane.startswith(b"%PDF"):
+            surowy = _pdftotext(dane)
+            if surowy is not None:
+                txt, strony, naglowek = _czysc_pdf(surowy)
+                zrodlo = "pdf"
+            else:
+                uwagi.append("pdftotext nie przetworzył PDF — używam text.html")
+        else:
+            uwagi.append("host nie zwrócił PDF — używam text.html")
+    else:
+        uwagi.append("brak `pdftotext` (poppler) na PATH — używam text.html; zalecane: zainstaluj poppler "
+                     "(macOS: brew install poppler; Debian/Ubuntu: apt install poppler-utils)")
+    if txt is None:
+        surowe = _get(host, f"/acts/{pub}/{a.rok}/{a.poz}/text.html", raw=True).decode("utf-8", "replace")
+        txt = html_to_text(surowe)
+        zrodlo = "html"
+    if not txt.strip():
+        sys.exit(f"Pusty tekst ({zrodlo}) dla {pub}/{a.rok}/{a.poz} — pobierz PDF: tekst {kod} {a.rok} {a.poz} --pdf akt.pdf")
+    ostrz, blok = _ocena_tekstu(txt, zrodlo)
+    if strict and blok:
+        sys.exit("BŁĄD (strict): tekst NIEZWERYFIKOWANY — " + "; ".join(blok)
+                 + f".\nPobierz urzędowy PDF: tekst {kod} {a.rok} {a.poz} --pdf akt.pdf"
+                 + ("" if zrodlo == "pdf" else " (z `pdftotext` na PATH silnik czyta PDF sam)."))
+    if a.json:
+        print(json.dumps({"publisher": pub, "rok": a.rok, "poz": a.poz, "zrodlo": zrodlo, "strony": strony,
+                          "naglowek_dziennika": naglowek, "uwagi": uwagi + ostrz,
+                          "niezweryfikowany": blok, "tekst": txt},
+                         ensure_ascii=False, indent=2)); return
+    if zrodlo == "pdf":
+        print(f"# {pub} {a.rok} poz. {a.poz}  (tekst z urzędowego PDF przez pdftotext, {strony} str., "
+              f"{len(txt)} znaków{'; nagłówek dziennika: ' + naglowek if naglowek else ''})")
+    else:
+        print(f"# {pub} {a.rok} poz. {a.poz}  (tekst z text.html, {len(txt)} znaków)")
+        print(f"UWAGA: text.html zawiera zwykle tylko PIERWSZĄ STRONĘ aktu — to NIE jest pełny tekst; "
+              f"pobierz PDF: tekst {kod} {a.rok} {a.poz} --pdf akt.pdf")
+    for u in uwagi + ostrz + [b for b in blok if not b.startswith("text.html")]:
+        print(f"UWAGA: {u}")
+    print()
+    if a.fragment:
+        spans = _fragmenty(txt, a.fragment)
+        if not spans:
+            if zrodlo == "pdf":
+                sys.exit(f"Nie znaleziono frazy {a.fragment!r} w tekście PDF ({strony} str., {len(txt)} znaków). "
+                         "Spróbuj inną frazą.")
+            sys.exit(f"Nie znaleziono frazy {a.fragment!r} w text.html ({len(txt)} znaków) — to zwykle TYLKO "
+                     f"1. strona aktu, treść jest dłuższa; sprawdź PDF: tekst {kod} {a.rok} {a.poz} --pdf akt.pdf")
+        for i, (s, e) in enumerate(spans):
+            if i:
+                print("\n[...]\n")
+            print(txt[s:e].strip())
+        jednostka = re.fullmatch(r"(§|art\.?)\s*\d+[a-z]?\.?", a.fragment.strip(), re.I)
+        if jednostka and spans and re.match(r"[ \t]*(§|[Aa]rt\.)", txt[spans[0][0]:spans[0][0] + 6]):
+            print(f"\n(jednostka {a.fragment.strip()}: {len(spans)} wystąpień, każde w całości do następnej "
+                  "jednostki — pominięto resztę; pełna treść: bez --fragment)")
+        else:
+            print(f"\n(okna: {len(spans)}, rozszerzone do granic akapitu — pominięto resztę; "
+                  "pełna treść: bez --fragment)")
+        return
+    if len(txt) > 40000:
+        print(f"(UWAGA: długi akt {len(txt)} znaków — do wycinka użyj --fragment \"<fraza>\" albo \"§ N\")\n")
+    print(txt)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="API ELI wojewódzkich dzienników urzędowych (read-only, bez klucza): "
+                    "prawo miejscowe 16 województw. Prawo krajowe (Dz.U./M.P.): scripts/eli.py.")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować kompletności wyniku")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    dz = sub.add_parser("dzienniki")
+    dz.add_argument("--woj", help="kod (DS) albo nazwa województwa — pokaże roczniki i liczbę aktów")
+    dz.set_defaults(func=cmd_dzienniki)
+
+    s = sub.add_parser("szukaj")
+    s.add_argument("fraza", nargs="?", default=None,
+                   help="fraza z TYTUŁU aktu (podłańcuch, bez rozróżniania diakrytyków)")
+    s.add_argument("--woj", required=True, help="kod (DS) albo nazwa województwa")
+    s.add_argument("--rok", type=int, help="rocznik (bez --rok: do 3 najnowszych roczników)")
+    s.add_argument("--limit", type=int, default=10, help="ile trafień pokazać na stronę")
+    s.add_argument("--strona", type=int, default=1,
+                   help="strona przefiltrowanych trafień (1..N — N podaje stopka wyniku)")
+    s.set_defaults(func=cmd_szukaj)
+
+    ak = sub.add_parser("akt")
+    ak.add_argument("woj", help="kod (DS) albo nazwa województwa")
+    ak.add_argument("rok", type=int)
+    ak.add_argument("poz", type=int)
+    ak.set_defaults(func=cmd_akt)
+
+    t = sub.add_parser("tekst")
+    t.add_argument("woj", help="kod (DS) albo nazwa województwa")
+    t.add_argument("rok", type=int)
+    t.add_argument("poz", type=int)
+    t.add_argument("--fragment", help='cała jednostka ("§ 3", "art. 5") albo okna wokół frazy')
+    t.add_argument("--pdf", help="zapisz urzędowy PDF do pliku")
+    t.set_defaults(func=cmd_tekst)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować kompletności wyniku")
+
+    a = ap.parse_args()
+    a.func(a)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/prawo-pl-eli/.claude-plugin/plugin.json
+++ b/plugins/prawo-pl-eli/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-pl-eli",
+  "description": "Polskie prawo z oficjalnego API ELI Sejmu (Dz.U./Monitor Polski) do każdego pytania z prawa polskiego oraz pracy nad umowami i pismami procesowymi: wyszukiwanie aktów, pojedyncze artykuły, tekst jednolity, nowelizacje i podstawa prawna. Read-only — źródło pierwotne zamiast cytowania przepisów z pamięci lub portali.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-pl-eli/.codex-plugin/plugin.json
+++ b/plugins/prawo-pl-eli/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "prawo-pl-eli",
+  "version": "2.0.0",
+  "description": "Polskie prawo z oficjalnego API ELI Sejmu (Dz.U./Monitor Polski) do każdego pytania z prawa polskiego oraz pracy nad umowami i pismami procesowymi: wyszukiwanie aktów, pojedyncze artykuły, tekst jednolity, nowelizacje i podstawa prawna. Read-only.",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": [
+    "prawo",
+    "polish-law",
+    "sejm",
+    "eli",
+    "dziennik-ustaw",
+    "legal"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo PL — ELI Sejm",
+    "shortDescription": "Polskie prawo z oficjalnego API ELI Sejmu (Dz.U./M.P.).",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/SKILL.md
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: prawo-pl-eli
+version: 2.0.0
+description: >-
+  Odpytuje OFICJALNE API ELI Sejmu (api.sejm.gov.pl/eli) — źródło pierwotne prawa polskiego
+  (Dziennik Ustaw, Monitor Polski): wyszukiwanie aktów, TEKST JEDNOLITY, pojedyncze artykuły,
+  metadane, nowelizacje, podstawa prawna, sygnatury Dz.U./M.P. Używaj przy KAŻDYM pytaniu
+  z prawa polskiego — TAKŻE gdy przepis nie jest jeszcze znany (ustalenie podstawy prawnej:
+  właściwość sądu, wyłączenie sędziego, przekazanie sprawy, przesłanki wniosku lub pozwu,
+  terminy) — oraz ZAWSZE przy TWORZENIU lub ANALIZIE UMÓW i PISM PROCESOWYCH. Wywołuj PRZED
+  wyszukiwaniem w internecie: treść polskiego przepisu cytuj WYŁĄCZNIE z ELI, nigdy z pamięci
+  ani z portali (arslege, lexlege, infor, LEX); internet służy tylko do orzecznictwa i doktryny.
+  Wyzwalaj też przy: „co mówi ustawa o…", „art. X ustawy…", „Dz.U. {rok} poz. {nr}", „tekst
+  jednolity", „czy przepis obowiązuje", „czy był nowelizowany". Polish primary law (statutes,
+  codes, regulations) from the official Sejm ELI API — always use for Polish law questions
+  BEFORE web search.
+---
+
+# Prawo polskie z oficjalnego API ELI Sejmu
+
+Skill do pracy z prawem polskim — przy **każdym pytaniu prawnym** oraz przy **tworzeniu i analizie umów
+i pism procesowych**: wszędzie tam, gdzie trzeba przywołać przepis, zweryfikować podstawę prawną, termin
+lub procedurę. Cytowanie przepisów z pamięci albo z nieoficjalnych portali jest zawodne (zmiany,
+nowelizacje, błędne sygnatury) — ten skill sięga do **źródła pierwotnego**: oficjalnego API ELI Sejmu
+(`https://api.sejm.gov.pl/eli`), czyli Dziennika Ustaw (DU) i Monitora Polskiego (MP).
+Używaj go, zanim podasz brzmienie przepisu, sygnaturę albo stwierdzisz, że coś „obowiązuje".
+
+## Kolejność źródeł (przepis ≠ internet)
+
+1. **Treść przepisu — wyłącznie z ELI.** Nigdy nie cytuj brzmienia polskiego przepisu z pamięci ani
+   z portali (arslege.pl, lexlege.pl, infor.pl, LEX itp.). Jeśli wynik wyszukiwania internetowego
+   podał brzmienie przepisu — zweryfikuj je przez `eli.py`, zanim go użyjesz w odpowiedzi.
+2. **Internet — tylko do orzecznictwa, doktryny i identyfikacji aktów.** Komentarze, wyroki, nazwy
+   ustaw — tak; po identyfikacji wróć do ELI po tekst przepisu.
+3. **Pytanie bez wskazanego przepisu** („czy jest podstawa, by…", „czy mogę wnieść o…", „jaki mam
+   termin na…") to też zadanie dla tego skilla — nie zaczynaj od wyszukiwarki. Najpierw ustal
+   WŁAŚCIWĄ PROCEDURĘ z rodzaju sprawy (pozew/pozwany → k.p.c.; oskarżony/akt oskarżenia → k.p.k.;
+   decyzja organu → k.p.a.; podatki → Ordynacja podatkowa), pobierz kandydackie przepisy z ELI
+   (`struktura --filtr`, `tekst --fragment`), dopiero potem ewentualnie internet po orzecznictwo.
+   Pomylenie procedury (np. art. 37 k.p.k. w sprawie cywilnej zamiast art. 44¹ k.p.c.) to typowy
+   skutek zaczynania od wyszukiwarki — portale rankują pod hasła, nie pod rodzaj sprawy.
+4. **Delegując research subagentowi**, wpisz do jego promptu: „treść polskich przepisów pobieraj
+   wyłącznie przez `scripts/eli.py` (skill prawo-pl-eli); internet tylko do orzecznictwa i doktryny".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/eli.py` (tylko biblioteka standardowa Pythona — bez instalacji; opcjonalnie
+program `pdftotext` z pakietu poppler w PATH — potrzebny TYLKO do aktów, dla których API nie ma HTML, np.
+Konstytucja i świeże teksty jednolite; bez niego działa `--pdf`).
+Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/eli.py`) — NIE zakładaj, że to
+`~/.claude/skills/prawo-pl-eli` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+ELI="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-eli/scripts/eli.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$ELI" ] || ELI="<katalog skilla>/scripts/eli.py"
+[ -f "$ELI" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $ELI" >&2; exit 1; }
+python3 "$ELI" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/eli.py` oznacza `python3 "$ELI"`, jeśli nie jesteś w katalogu skilla.)
+
+Sygnaturę można podać w wielu formach: `DU 2000 1037`, `DU/2024/18`, `"Dz.U. 2024 poz. 18"`,
+`"Dz.U. 1997 nr 78 poz. 483"`, `WDU20240000018`, albo `DU/2000/1037` (ELI).
+
+### Komendy
+
+- **szukaj** — znajdź akt po tytule/typie/roku/haśle:
+  `python3 scripts/eli.py szukaj "Kodeks spółek handlowych" --typ Ustawa --limit 5`
+  (opcje: `--typ`, `--rok`, `--wyd DU|MP`, `--haslo`, `--obowiazujace`, `--limit`, `--offset`)
+- **meta** — metadane aktu (tytuł, typ, status, daty, czy obowiązuje, hasła, ELI, pliki tekstu):
+  `python3 scripts/eli.py meta DU 2000 1037`
+  Daty są rozdzielone, bo API ma dwa różne pola: **„Data aktu"** (`announcementDate` = data wydania,
+  „z dnia …" w tytule) i **„Ogłoszono"** (`promulgation` = publikacja w Dz.U./M.P. — od niej liczy się
+  vacatio legis); dalej **„WEJŚCIE W ŻYCIE"**, **„Stan prawny na"** (`legalStatusDate`, tylko t.j.) i
+  **„Uwagi"** (`comments` — np. „art. 5 ust. 4 … wchodzą w życie z dniem 25 grudnia 2024 r.", czyli RÓŻNE
+  daty wejścia w życie dla różnych jednostek; czytaj je zawsze).
+- **tj** — znajdź AKTUALNY TEKST JEDNOLITY dla aktu (posortowane, najnowszy oznaczony; na starym t.j. ostrzega o nowszym):
+  `python3 scripts/eli.py tj DU 2000 1037`
+- **tekst** — treść aktu (z `text.html` → czysty tekst; gdy API nie ma HTML dla aktu — `textHTML=false`,
+  np. Konstytucja, k.c. DU 2026 795 — z jego WŁASNEGO urzędowego PDF przez `pdftotext -layout`, z nagłówkiem
+  „tekst z urzędowego PDF przez pdftotext" i linią `ELI_TEXT_SOURCE_PDF=…`). **Do pojedynczego przepisu używaj `--fragment`**
+  (wycina tylko jednostki z frazą — pełny kodeks to setki tysięcy znaków):
+  `python3 scripts/eli.py tekst DU 2024 18 --fragment "art. 299"` (trafia w nagłówek artykułu, nie w odesłania)
+  `python3 scripts/eli.py tekst DU 2024 18 --fragment "przedawnienie"` (wyszukiwanie pełnotekstowe)
+  `--pdf ŚCIEŻKA` zapisuje urzędowy PDF (preferuje tekst jednolity). Indeks górny podawaj w nawiasie
+  albo unicodem: art. 299¹ → `--fragment "art. 299(1)"` lub `"art. 299¹"`; sufiks literowy normalnie:
+  `"art. 66c"`. Nagłówki przepisów niedawno dodanych lub zmienionych mają w tekście jednolitym
+  odsyłacz do przypisu („Art. 66c 6)Dodany przez…") — `--fragment` to obsługuje.
+  **„Nie znaleziono frazy" NIE znaczy, że przepisu nie ma w akcie** (zwłaszcza przy nietypowym
+  oznaczeniu jednostki): sprawdź jeszcze samym numerem (`--fragment "66c"`) albo słowem z treści,
+  zanim napiszesz, że przepis nie istnieje. Gdy nagłówka nie ma, narzędzie samo pokazuje trafienia
+  pełnotekstowe z ostrzeżeniem — mogą to być odesłania z innych przepisów, nie sam przepis.
+- **struktura** — spis jednostek redakcyjnych (tytuły/działy/rozdziały/artykuły):
+  `python3 scripts/eli.py struktura DU 2024 18 --filtr "Art. 299"` (opcje: `--filtr`, `--poziom N`)
+- **odniesienia** — powiązania: nowelizacje, podstawa prawna, tekst jednolity, akty wykonawcze:
+  `python3 scripts/eli.py odniesienia DU 2024 18`
+- każda komenda przyjmuje `--json` oraz `--strict`; obie flagi działają przed komendą i po niej.
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”); `szukaj` pokazuje
+  `totalCount` z API („Znaleziono: 58 (pokazuję 10, offset 0)") i jak stronicować (`--offset`/`--limit`) —
+  akt bazowy bywa na KOŃCU listy, za nowelizacjami.
+
+**Co sprawdza `--strict`** (wszystko PRZED wypisaniem czegokolwiek; niepowodzenie = komunikat, kod ≠ 0,
+pusty stdout): (1) istnieje nowszy t.j. niż podany → blokada; (2) odniesień lub aktu bazowego nie dało się
+pobrać (awaria sieci/zapory) → blokada; (3) `text.html` puste i tekst pochodziłby ze STARSZEGO t.j. albo
+`pdftotext` zawiódł → blokada (tekst z własnego urzędowego PDF aktu PRZECHODZI); (4) listy nowelizacji
+nie dało się uzupełnić z aktu bazowego → blokada. **Czego `--strict` NIE sprawdza:** czy przepis został
+zmieniony PO stanie prawnym t.j. — to wiesz tylko z sekcji „Nowelizacje po tekście jednolitym" (czytaj ją
+i sprawdzaj „wejście w życie zmiany" względem daty sprawy); nie sprawdza też obcięcia listy `szukaj`
+(to jest jawnie wypisane) ani opóźnień indeksacji API.
+
+Narzędzie samo ostrzega: `tekst` na akcie, który ma tekst jednolity, każe cytować z najnowszego t.j.;
+na tekście jednolitym wypisuje „Nowelizacje po tekście jednolitym" — własną listę t.j. UZUPEŁNIONĄ o
+„Akty zmieniające" aktu bazowego ogłoszone lub wchodzące w życie po `legalStatusDate` t.j. (Sejm nie
+synchronizuje obu list; każda pozycja ma osobno „data aktu", „ogłoszono", „wejście w życie zmiany") —
+a na STARSZYM t.j. (np. z pamięci) — „NIEAKTUALNY tekst jednolity, istnieje NOWSZY" (sprawdza to na akcie
+bazowym). Gdy `text.html` jest puste w API (`textHTML=false`), narzędzie czyta WŁASNY urzędowy PDF aktu
+(`pdftotext`); tylko bez `pdftotext` sięga po najnowszy STARSZY t.j. z HTML — wtedy nagłówek mówi
+„NIEAKTUALNE BRZMIENIE MOŻLIWE", wymienia pominięte t.j. i wypisuje INLINE zmiany aktu bazowego po stanie
+prawnym tego starszego t.j., które trzeba nałożyć samemu. Nie ignoruj tych ostrzeżeń.
+
+### Akty bazowe głównych kodeksów (pomiń `szukaj`)
+
+Sygnatury aktów bazowych są niezmienne — dla poniższych zaczynaj od razu od `tj <sygnatura>`,
+potem `tekst <t.j.> --fragment "art. N"` (dwie komendy zamiast trzech):
+
+| Akt | Sygnatura bazowa |
+|---|---|
+| Konstytucja RP (tekst wprost, bez `tj`; API nie ma HTML — `tekst … --fragment "Art. 45"` czyta urzędowy PDF przez `pdftotext`, bez niego tylko `--pdf`) | `DU 1997 483` |
+| Kodeks cywilny (k.c.) | `DU 1964 93` |
+| Kodeks postępowania cywilnego (k.p.c.) | `DU 1964 296` |
+| Kodeks rodzinny i opiekuńczy (k.r.o.) | `DU 1964 59` |
+| Kodeks karny (k.k.) | `DU 1997 553` |
+| Kodeks postępowania karnego (k.p.k.) | `DU 1997 555` |
+| Kodeks wykroczeń (k.w.) | `DU 1971 114` |
+| Kodeks postępowania administracyjnego (k.p.a.) | `DU 1960 168` |
+| Kodeks pracy (k.p.) | `DU 1974 141` |
+| Kodeks spółek handlowych (k.s.h.) | `DU 2000 1037` |
+| Ordynacja podatkowa | `DU 1997 926` |
+
+## Zasady (ważne — dlaczego)
+
+1. **Najpierw znajdź właściwy akt, potem cytuj.** Typowy przepływ: `szukaj` → ustal sygnaturę → `tj`
+   (aktualny tekst jednolity) → `tekst <t.j.> --fragment "art. N"`. Dla kodeksów z tabeli wyżej pomiń
+   `szukaj` i zacznij od `tj`. Cytowanie starej wersji to częsty błąd.
+2. **Sprawdź NOWELIZACJE i ich WEJŚCIE W ŻYCIE** (najczęstsze źródło błędu). `meta` pokazuje „Ogłoszono"
+   (publikacja w Dz.U. — od niej liczy się vacatio legis; NIE myl z „Data aktu"), „WEJŚCIE W ŻYCIE" i
+   „Uwagi" (różne daty dla różnych jednostek); `odniesienia` — zmiany; „Nowelizacje po tekście jednolitym"
+   oznacza, że nawet t.j. bywa już nieaktualny. Zanim powiesz „przepis brzmi…":
+   - **Akt OGŁOSZONY ≠ OBOWIĄZUJĄCY.** W nowelizacji sprawdź artykuł „wchodzi w życie" — możliwe vacatio
+     legis oraz RÓŻNE daty dla różnych jednostek redakcyjnych — i odnieś do **DATY zdarzenia/sprawy**
+     (przepis sprzed/po zmianie). Tekst jednolity oddaje stan na `legalStatusDate`; pozycje z listy
+     „Nowelizacje po tekście jednolitym" z „wejście w życie zmiany" po tej dacie trzeba nałożyć ręcznie
+     i sprawdzić, czy już obowiązują — `--strict` tego NIE robi za Ciebie.
+   - **Baza może NIE mieć najświeższej zmiany.** Brak nowelizacji w API ≠ pewność, że jej nie ma
+     (indeksacja bywa opóźniona). Przy sprawie na konkretną datę zweryfikuj dodatkowo (np. najnowsze
+     pozycje `dziennikustaw.gov.pl`, proces legislacyjny), a w odpowiedzi zaznacz:
+     „stan prawny na dzień X wg ELI — do potwierdzenia".
+3. **NIGDY nie twierdź, że przepisu nie ma, na podstawie pustego `--fragment`.** Pusty wynik to brak
+   dopasowania frazy, nie dowód nieistnienia przepisu — a najczęściej zawodzi przy przepisach ŚWIEŻO
+   dodanych lub zmienionych (nietypowe oznaczenie jednostki, odsyłacz do przypisu, indeks górny).
+   Zanim postawisz twierdzenie negatywne o prawie, przeszukaj pełny tekst aktu liniowo:
+   `python3 scripts/eli.py tekst <akt> | grep -n -i "<fraza>"` — i dopiero zero trafień tam jest
+   podstawą do „brak takiego przepisu w tym akcie". Sprawdź też, czy pytasz o WŁAŚCIWY akt: sankcja
+   za naruszenie obowiązku zwykle stoi w k.w./k.k., a nie w ustawie, która ten obowiązek nakłada.
+4. **Do DOSŁOWNEGO cytatu w umowie/piśmie/sądzie** używaj urzędowego PDF (`tekst … --pdf`), bo
+   `text.html` po konwersji bywa zlepiony, a tekst z PDF ma automatycznie sklejone wiersze i dzielone
+   wyrazy; `--fragment` jest świetny do szybkiego odczytu i analizy.
+   Linia zaczynająca się od `[przypis N)]` to **komentarz redakcyjny tekstu jednolitego** (kiedy przepis
+   dodano lub zmieniono, z jaką datą wejścia w życie), a NIE treść normy — nigdy jej nie cytuj jako
+   przepisu; sam numer odsyłacza nie wchodzi już w numer jednostki („§ 1.", „pkt 2)").
+5. **Zawsze podawaj sygnaturę Dz.U./M.P. i ELI** przy cytacie (np. „art. 299 § 1 k.s.h., Dz.U. 2024
+   poz. 18"). To pozwala odbiorcy zweryfikować źródło.
+6. Pełna lista endpointów i parametrów: `references/api.md` (czytaj przy zapytaniach spoza powyższych
+   komend — np. słowniki typów/haseł, listowanie roczników, akty zmieniające w okresie).
+
+## Czego ten skill NIE obejmuje
+
+- **prawa UE** (rozporządzenia, dyrektywy — użyj skilla **prawo-eu-eurlex**, EUR-Lex/CELLAR),
+  **prawa MIEJSCOWEGO** (uchwały gmin/powiatów, dzienniki wojewódzkie → skill
+  **prawo-pl-edzienniki**) i **dzienników resortowych**,
+- **orzecznictwa sądów** (SN/TK/sądy powszechne/KIO → skill **prawo-pl-saos**; sądy
+  administracyjne NSA/WSA → skill **prawo-pl-cbosa**; decyzje UODO → **prawo-pl-uodo**;
+  TSUE → **prawo-eu-eurlex**; w Dz.U. są tylko wyroki TK i to jako pozycje dziennika),
+- **projektów ustaw** w toku procesu legislacyjnego (to inne API Sejmu),
+- treści umów stron, KRS, ksiąg wieczystych.
+Jeśli zagadnienie wymaga tych źródeł — powiedz to wprost, nie udawaj, że ELI je pokryje.
+
+## Przykładowy przepływ
+
+Pytanie (np. przy analizie pozwu przeciwko członkowi zarządu sp. z o.o.): „co dokładnie mówi art. 299 § 1
+Kodeksu spółek handlowych i czy to aktualne?" (przykład — stan na czerwiec 2026):
+1. `szukaj "Kodeks spółek handlowych" --typ Ustawa` → akt bazowy ELI `DU/2000/1037`.
+2. `tj DU 2000 1037` → najnowszy tekst jednolity `DU/2024/18` (Dz.U. 2024 poz. 18), oznaczony „AKTUALNY".
+3. `tekst DU 2024 18 --fragment "art. 299"` → treść artykułu + automatyczne ostrzeżenie o nowelizacjach
+   po t.j. (tu 4: Dz.U. 2024 poz. 96 — wyrok TK K 29/23, oraz z aktu bazowego Dz.U. 2026 poz. 176, 187,
+   644 z „wejście w życie zmiany" 2027–2030). Odnieś każdą do daty sprawy; indeksacja API bywa opóźniona,
+   więc przy sprawie na konkretną datę dopytaj jeszcze `szukaj`iem.
+4. W odpowiedzi: zacytuj przepis, podaj sygnaturę i datę stanu prawnego.

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/references/api.md
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/references/api.md
@@ -1,0 +1,110 @@
+# API ELI Sejmu — referencja endpointów
+
+Baza: `https://api.sejm.gov.pl/eli`  ·  Spec (YAML): `https://api.sejm.gov.pl/eli/openapi/`  ·  Swagger UI: `https://api.sejm.gov.pl/eli/openapi/ui/`
+Wszystko **GET** (read-only). `{publisher}` = `DU` (Dziennik Ustaw) lub `MP` (Monitor Polski). `{year}` = rok, `{position}` = pozycja.
+
+## Endpointy
+
+| Ścieżka | Zwraca |
+|---|---|
+| `/` | informacje o API |
+| `/acts` | lista wydawców (DU, MP) |
+| `/acts/search` | wyszukiwarka aktów (parametry niżej) |
+| `/acts/{address}` | metadane po adresie ISAP, np. `/acts/WDU20240000018` |
+| `/acts/{publisher}` | lista roczników |
+| `/acts/{publisher}/{year}` | lista aktów w roku |
+| `/acts/{publisher}/{year}/{position}` | **metadane aktu** (JSON) |
+| `/acts/{publisher}/{year}/{position}/text.html` | tekst aktu (HTML) |
+| `/acts/{publisher}/{year}/{position}/text.html/{tree}` | tekst pojedynczej jednostki redakcyjnej — **UWAGA: zapora (WAF) Sejmu odrzuca id z myślnikami (czyli wszystkie artykuły) — stan na 2026-06; zamiast tego użyj `tekst --fragment`** |
+| `/acts/{publisher}/{year}/{position}/text.pdf` | tekst (PDF, jeśli jednoplikowy) |
+| `/acts/{publisher}/{year}/{position}/text/{type}/{fileName}` | konkretny plik tekstu (np. tekst jednolity PDF) |
+| `/acts/{publisher}/{year}/{position}/references` | powiązania (nowelizacje, podstawa prawna, tekst jednolity, akty wykonawcze) |
+| `/acts/{publisher}/{year}/{position}/struct` | struktura aktu (spis jednostek redakcyjnych → wartości `{tree}`) |
+| `/acts/{publisher}/{year}/volumes...` | warianty z numerem tomu (starsze roczniki) |
+| `/changes/acts` | akty zmieniające w okresie |
+| `/types` `/keywords` `/statuses` `/institutions` `/titles` `/references` | słowniki |
+
+## Parametry `/acts/search` (zweryfikowane / typowe)
+
+`title` (fraza w tytule), `type` (np. `Ustawa`, `Rozporządzenie`, `Obwieszczenie`), `year`, `publisher` (`DU`/`MP`),
+`inForce` (`1` = obowiązujące), `keyword`, `limit`, `offset`, oraz zakresy dat (np. `dateFrom`/`dateTo`,
+`announcementDateFrom`/`announcementDateTo`, `pubDateFrom`/`pubDateTo`). Pełny zestaw — w spec OpenAPI.
+Odpowiedź: `{ "count": N, "totalCount": M, "offset": O, "items": [ { "address": "WDU...", "ELI": "DU/RRRR/PPP", "title": ..., "status": ... }, ... ] }`.
+**`count` to rozmiar zwróconej strony, `totalCount` — prawdziwa liczba trafień** (zweryfikowane 2026-08:
+„Kodeks pracy"/Ustawa → count 10, totalCount 58; akt bazowy DU/1974/141 był na pozycji 58). Helper wypisuje
+`totalCount` i podpowiada `--offset`/`--limit`.
+
+## Pola metadanych aktu (`/acts/{pub}/{year}/{pos}`)
+
+`title`, `type`, `status`, `inForce` (`IN_FORCE`/…), `keywords`/`keywordsNames`, `references`, `ELI`,
+`address` (ISAP), `displayAddress` (np. „Dz.U. 2024 poz. 18"), `volume`, `texts` (lista plików),
+`textHTML`/`textPDF` (bool), `changeDate` (ostatnia zmiana rekordu w bazie — NIE data prawna).
+
+### Daty (zweryfikowane na żywym API i nagłówkach PDF Dz.U., 2026-08)
+| Pole | Znaczenie | Przykład DU/2024/928 |
+|---|---|---|
+| `announcementDate` | **data AKTU** = wydania/podpisania, czyli „z dnia …" w tytule (ISAP: „Data wydania") — NIE ogłoszenie | 2024-06-14 |
+| `promulgation` | **data OGŁOSZENIA** w Dz.U./M.P. (nagłówek PDF „Warszawa, dnia …"; ISAP: „Data ogłoszenia"); od niej liczy się vacatio legis; bywa `null` dla starych pozycji (Konstytucja DU/1997/483) | 2024-06-24 |
+| `entryIntoForce` | wejście w życie aktu (ogólna reguła); `null` dla obwieszczeń z t.j. | 2024-09-25 |
+| `comments` | uwagi ISAP — najczęściej **rozłożone wejście w życie** („art. 5 ust. 4 … wchodzą w życie z dniem 25 grudnia 2024 r.") | jw. |
+| `legalStatusDate` | **stan prawny t.j.** („z uwzględnieniem stanu prawnego na dzień …" w obwieszczeniu); zmiany ogłoszone lub wchodzące w życie po tej dacie NIE są w tekście | DU/2026/795 → 2026-05-19 |
+| `validFrom` | obowiązywanie (gdy różne od wejścia w życie) | — |
+Helper `meta` drukuje je jako „Data aktu" / „Ogłoszono" / „WEJŚCIE W ŻYCIE" / „Stan prawny na" / „Uwagi".
+Parametry wyszukiwarki: `announcementDateFrom/To` filtruje po dacie aktu, `pubDateFrom/To` po ogłoszeniu.
+
+### `textHTML=false` — kiedy `text.html` jest puste (HTTP 200, 0 bajtów)
+Nie jest to „opóźnienie" — dla części aktów API po prostu nie ma HTML, czasem trwale: Konstytucja DU/1997/483
+(akt z 1997 r.), k.c. t.j. DU/2026/795 **i** poprzedni t.j. DU/2025/1071 (HTML dopiero w DU/2024/1061), k.p.c.
+t.j. DU/2026/468, świeże pozycje (DU/2026/694). Helper `tekst` czyta wtedy WŁASNY urzędowy PDF aktu (`texts[]`
+typ U > T > O) przez `pdftotext -layout` i czyści go (nagłówki „Dziennik Ustaw – N – Poz. X"/„©Kancelaria
+Sejmu", stopki z datą, sklejanie zawiniętych wierszy i dzielonych wyrazów, indeks górny `68[1]` → „68 1" jak
+w HTML, odsyłacze do przypisów „§ 1.3)" → „§ 1." + linia `[przypis 3)] …` z dołu strony, obwieszczenie sprzed
+załącznika oznaczone „» "). Bez `pdftotext` helper sięga po najnowszy STARSZY t.j. z HTML — z nagłówkiem
+„NIEAKTUALNE BRZMIENIE MOŻLIWE" i listą zmian aktu bazowego po jego `legalStatusDate`; `--strict` to blokuje.
+
+### Kody `type` w `texts[]`
+- `H` — HTML (`text.html`)
+- `O` — tekst ogłoszony / oryginał (PDF)
+- `I` — tekst ogłoszony (skan/obraz, PDF)
+- `T` — tekst jednolity (PDF)
+- `U` — tekst ujednolicony / aktualny tekst jednolity (PDF) ← zwykle najlepszy do dosłownego cytatu
+
+Plik pobierasz: `/acts/{pub}/{year}/{pos}/text/{type}/{fileName}` (np. `/text/U/D20240018Lj.pdf`).
+
+## Kategorie w `/references` (zweryfikowane na żywym API, 2026-06)
+
+Każda pozycja to `{ "act": { ELI, displayAddress, title, status, ... }, "date"?, "art"? }`.
+Kategorie ZALEŻĄ od rodzaju aktu:
+
+Na **akcie bazowym** (np. ustawa `DU/2000/1037`):
+- **„Inf. o tekście jednolitym"** — obwieszczenia z tekstami jednolitymi tego aktu; najnowszy
+  (status „obowiązujący") = aktualny, starsze mają status „wygaśnięcie aktu".
+- **„Akty zmieniające"** — nowelizacje aktu; pole `date` = **wejście w życie ZMIANY** tego aktu (nie data
+  ani ogłoszenie nowelizacji; może różnić się od `entryIntoForce` nowelizacji — np. DU/2026/1003 ma
+  `entryIntoForce` 2026-08-11, a zmiana k.p.c. `date` 2026-10-28 zgodnie z jej `comments`); obiekt `act`
+  niesie `announcementDate` (data aktu) i `promulgation` (ogłoszono). **„Akty zmienione"** — co ten akt nowelizuje.
+- **„Akty wykonawcze"** — rozporządzenia wydane na podstawie aktu.
+- **„Orzeczenie TK"**, **„Akty uchylone"**, **„Odesłania"**.
+
+Na **tekście jednolitym** (obwieszczenie, np. `DU/2024/18`):
+- **„Tekst jednolity dla aktu"** — wskazuje akt BAZOWY, który ten t.j. konsoliduje (kierunek odwrotny niż sugeruje nazwa!).
+- **„Nowelizacje po tekście jednolitym"** — zmiany WPROWADZONE PO tym t.j. → sygnał, że t.j. bywa już nieaktualny.
+  Pole `date` = **data aktu** nowelizacji (nie wejście w życie!), bywa pominięte. **Kategoria istnieje TYLKO na
+  AKTUALNYM t.j.** (wygasły t.j., np. DU/2024/1061, ma już tylko „Podstawa prawna…" i „Tekst jednolity dla
+  aktu") i **nie jest synchronizowana** z „Akty zmieniające" aktu bazowego (2026-08: k.p.c. DU/2026/468 — 2 z 5,
+  k.s.h. DU/2024/18 — 1 z 4). Helper uzupełnia ją o „Akty zmieniające" aktu bazowego, których `promulgation`
+  lub `date` (wejście w życie zmiany) jest po `legalStatusDate` t.j., deduplikuje po ELI i opisuje każdą datę
+  etykietą („data aktu", „ogłoszono", „wejście w życie zmiany"); brakujące wejście w życie dopytuje z metadanych
+  nowelizacji (maks. 10 żądań).
+- **„Podstawa prawna" / „Podstawa prawna z art."** — delegacje/podstawy.
+
+## Wskazówki
+
+- Aby ustalić AKTUALNY stan przepisu: akt bazowy → `references` „Inf. o tekście jednolitym" (weź najnowszy) → na nim sprawdź „Nowelizacje po tekście jednolitym" ORAZ „Akty zmieniające" aktu bazowego po `legalStatusDate` t.j. Komendy `tj`/`tekst` robią to automatycznie.
+- `struct` pokazuje układ aktu i id jednostek, ale `text.html/{tree}` jest blokowany przez WAF dla artykułów — pojedynczy przepis pobieraj przez `tekst --fragment "art. N"` (lokalnie wycina z pełnego tekstu).
+- Tekst z `text.html` zawiera twarde spacje (NBSP) — helper normalizuje je do zwykłych spacji. Indeks górny siedzi w `<sup>`, więc po konwersji jest odspacjowany (art. 299¹ → „Art. 299 1."); w `--fragment` podawaj go jako `"art. 299(1)"` albo `"art. 299¹"`.
+- W nagłówku przepisu niedawno dodanego lub zmienionego stoi ODSYŁACZ DO PRZYPISU (też w `<sup>`), a treść przypisu API wstawia INLINE — w surowym HTML wygląda to tak: „Art. 66c 6)Dodany przez art. 3 pkt 2 ustawy… . Kto uporczywie…". Kropka artykułu stoi dopiero za przypisem, więc nagłówek ≠ „Art. N." — `--fragment` to obsługuje (`_KONIEC_ART` w `eli.py`).
+- Odsyłacz do przypisu siedzi w `<a class="gloss-link tooltip"><sup>N)</sup><span class="tooltip-text">…</span></a>` WEWNĄTRZ numeru jednostki (`<h3>2<a…><sup>1)</sup>…</a>)</h3>` = pkt 2 z przypisem 1; `§ 1<a…><sup>12)</sup>…</a>.`). Helper NIE przepisuje numeru odsyłacza do tekstu (wychodziło „2 1)", „a 2)", „§ 1 12)" — cyfra przypisu wchodziła w numer jednostki), a treść przypisu wynosi do osobnej linii `[przypis N)] …` za najbliższą granicą bloku, bo inaczej komentarz redakcyjny („Dodany przez…", „W tym brzmieniu obowiązuje do…") jest nieodróżnialny od normy; etykieta jest konieczna także dlatego, że część przypisów zaczyna się od „Art. 598…" / „Tytuł działu…" i na początku linii udawałaby nagłówek jednostki. Indeks górny artykułu (goły `<sup>` poza odsyłaczem) nadal dostaje spację („Art. 449 1." ≠ „Art. 4491."). **Linia `[przypis N)]` to jedyny fragment wyniku, którego NIE ma w urzędowym tekście** — nie cytuj jej jako przepisu.
+- Adres ISAP (`WDU{rok}{tom}{poz}` / `WMP...`) i ELI (`DU/{rok}/{poz}`) są równoważnymi identyfikatorami — helper przyjmuje obie formy.
+- `/struct` istnieje głównie dla tekstów jednolitych i starszych aktów; świeżo ogłoszone pozycje często go nie mają (HTTP 404 — helper `struktura` zgłasza „Brak struktury…" z kodem ≠ 0, nie surowy błąd HTTP).
+- Helper trzyma w pamięci udane GET-y bez parametrów w obrębie jednego uruchomienia (odniesienia aktu bazowego są potrzebne dwa razy), żeby nie drażnić zapory powtórzonymi żądaniami.

--- a/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
+++ b/plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py
@@ -1,0 +1,1234 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do OFICJALNEGO API ELI Sejmu (https://api.sejm.gov.pl/eli).
+Tylko biblioteka standardowa Pythona (urllib/json/re) — brak zależności pip.
+Operacje WYŁĄCZNIE read-only (GET). Źródło pierwotne prawa polskiego: Dziennik Ustaw (DU) i Monitor Polski (MP).
+
+Komendy:
+  szukaj ["<fraza>"] [--typ T] [--rok R] [--wyd DU|MP] [--haslo H] [--obowiazujace] [--limit N] [--offset N]
+  meta <sygnatura...>            np. meta DU 2024 18  |  meta "Dz.U. 2024 poz. 18"  |  meta WDU20240000018
+  tekst <sygnatura...> [--fragment "art. 299"] [--pdf ŚCIEŻKA]
+                                 tekst aktu (text.html → czysty tekst; gdy API nie ma HTML — własny urzędowy
+                                 PDF aktu przez `pdftotext -layout`, jeśli jest w PATH); --fragment wycina
+                                 tylko jednostki z frazą (np. jeden artykuł); --pdf zapisuje urzędowy PDF
+  struktura <sygnatura...> [--filtr F] [--poziom N]   spis jednostek redakcyjnych aktu (z /struct)
+  odniesienia <sygnatura...>     nowelizacje, tekst jednolity, podstawa prawna
+  tj <sygnatura...>              znajduje AKTUALNY TEKST JEDNOLITY dla aktu i podaje jego sygnaturę
+Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik PRZED emisją, gdy nie udało się zweryfikować aktualności lub
+                      kompletności: nowszy t.j., awaria kontroli, tekst ze STARSZEGO t.j. zamiast własnego
+                      PDF, niepełna lista nowelizacji; NIE wykrywa zmian przepisu po stanie prawnym t.j.)
+"""
+import sys, json, re, time, argparse, shutil, subprocess, tempfile, os
+import urllib.request, urllib.parse, urllib.error
+from html.parser import HTMLParser
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+BASE = "https://api.sejm.gov.pl/eli"
+CONTENT_HOSTS = ("api.sejm.gov.pl",)
+# Pamięć podręczna udanych GET-ów bez parametrów (metadane, odniesienia) w obrębie jednego
+# uruchomienia — te same odniesienia aktu bazowego potrzebuje kontrola nowszego t.j. i lista
+# nowelizacji; zapora api.sejm.gov.pl źle znosi powtórzone żądania.
+_CACHE = {}
+
+
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _nie_zweryfikowano(co, blad):
+    sys.exit(f"BŁĄD: nie udało się zweryfikować {co} ({blad}). "
+             "Spróbuj ponownie za chwilę.")
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści ELI, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
+
+
+def _get(path, params=None, soft=False):
+    """GET z jednym ponowieniem.
+
+    Zwraca dane, w tym pustą odpowiedź jako VERIFIED_ABSENT. Przy soft=True:
+    HTTP 404 to zweryfikowany brak zasobu (None) — API ELI odpowiada 404 wyłącznie dla
+    nieistniejącego adresu (zapora daje 200 + "Request Rejected", przeciążenie 5xx);
+    każdy inny błąd żądania to osobny stan UNKNOWN (VerificationUnknown).
+    """
+    url = BASE + path
+    if params:
+        q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "", False)})
+        if q:
+            url += "?" + q
+    elif url in _CACHE:
+        return _CACHE[url]
+    wynik = _pobierz(url, soft)
+    if not params:
+        _CACHE[url] = wynik
+    return wynik
+
+
+def _pobierz(url, soft):
+    req = urllib.request.Request(url, headers={"User-Agent": f"eli-skill/{__version__}", "Accept": "application/json, text/html"})
+    raw, ctype = None, ""
+    for attempt in (1, 2):
+        try:
+            with _opener.open(req, timeout=30) as r:
+                ctype = r.headers.get("Content-Type", "")
+                raw = r.read().decode("utf-8", "replace")
+            break
+        except urllib.error.HTTPError as e:
+            if e.code >= 500 and attempt == 1:
+                time.sleep(2); continue
+            if soft:
+                if e.code == 404:
+                    return None
+                raise VerificationUnknown(f"HTTP {e.code}: {url}") from e
+            sys.exit(f"BŁĄD HTTP {e.code}: {url}")
+        except Exception as e:
+            if attempt == 1:
+                time.sleep(2); continue
+            if soft:
+                raise VerificationUnknown(f"błąd sieci: {url} ({e})") from e
+            sys.exit(f"BŁĄD sieci: {url} ({e})")
+    if raw is not None and "Request Rejected" in raw and "rejected" in raw.lower():
+        # zapora (WAF) api.sejm.gov.pl potrafi odrzucać wybrane URL-e (m.in. /text.html/{tree})
+        if soft:
+            raise VerificationUnknown(f"zapora api.sejm.gov.pl odrzuciła żądanie: {url}")
+        sys.exit(f"BŁĄD: zapora api.sejm.gov.pl odrzuciła żądanie (Request Rejected): {url}\n"
+                 "Spróbuj ponownie; do pojedynczego artykułu użyj: tekst <syg> --fragment \"art. N\".")
+    if "json" in ctype:
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+    return raw
+
+
+def _get_bytes(url, soft=False):
+    """Pobiera plik (PDF). soft=True: awaria to VerificationUnknown zamiast zakończenia programu."""
+    req = urllib.request.Request(url, headers={"User-Agent": f"eli-skill/{__version__}"})
+    try:
+        with _opener.open(req, timeout=60) as r:
+            return r.read()
+    except Exception as e:
+        if soft:
+            raise VerificationUnknown(f"błąd pobierania {url} ({e})") from e
+        sys.exit(f"BŁĄD pobierania: {url} ({e})")
+
+
+def _expect_dict(d, what):
+    if not isinstance(d, dict):
+        sys.exit(f"BŁĄD: API zwróciło nieoczekiwaną odpowiedź ({what}) — spróbuj ponownie za chwilę.")
+    return d
+
+
+class _Stripper(HTMLParser):
+    """HTML z text.html → tekst.
+
+    Odsyłacz do przypisu API zapisuje jako <a class="gloss-link tooltip"><sup>N)</sup>
+    <span class="tooltip-text">treść przypisu</span></a> — WEWNĄTRZ numeru jednostki:
+    „<h3>2<a…><sup>1)</sup>…</a>)</h3>" (pkt 2 z przypisem 1), „Art. 66c<a…><sup>6)</sup>…</a>."
+    Przepisywanie tego liniowo dawało „2 1)", „a 2)", „§ 1 12)" — cyfra odsyłacza wchodziła
+    w numer jednostki (pkt 2 czytało się jak pkt 21). Dlatego numer odsyłacza NIE trafia do
+    tekstu, a treść przypisu czeka w kolejce i wychodzi na najbliższej granicy bloku jako
+    osobna linia „[przypis N)] …" (etykieta jest konieczna: 7 przypisów w k.p.c. zaczyna się
+    od „Art. 598…"/„Tytuł działu…" i na początku linii udawałoby nagłówek jednostki — _GRANICE).
+    """
+
+    BLOKI = ("p", "br", "div", "tr", "li", "h1", "h2", "h3", "h4")
+
+    def __init__(self):
+        super().__init__()
+        self.out, self.skip = [], 0
+        self.gloss = 0            # głębokość <a> wewnątrz odsyłacza do przypisu
+        self.w_sup = False        # w <sup> odsyłacza (numer przypisu)
+        self.tt = 0               # głębokość <span> wewnątrz treści przypisu (tooltip-text)
+        self.nr, self.tresc = [], []
+        self.oczekujace = []      # przypisy do wypisania na najbliższej granicy bloku
+
+    def _granica(self):
+        for nr, tresc in self.oczekujace:
+            if tresc:
+                self.out.append(f"\n[przypis {nr}] {tresc}" if nr else f"\n[przypis] {tresc}")
+        self.oczekujace = []
+        self.out.append("\n")
+
+    def zakoncz(self):
+        if self.oczekujace:
+            self._granica()
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style"):
+            self.skip += 1
+        klasa = dict(attrs).get("class", "") or ""
+        if tag in self.BLOKI:
+            self._granica()
+        if tag == "a" and self.gloss:
+            self.gloss += 1
+        elif tag == "a" and "gloss-link" in klasa:
+            self.gloss, self.nr, self.tresc = 1, [], []
+        if tag == "sup":
+            if self.gloss:
+                self.w_sup = True
+            else:
+                # Indeks górny artykułu (np. "Art. 21<sup>1</sup>.") rozdzielamy spacją, żeby
+                # "Art. 21 1." było odróżnialne od "Art. 211." — inaczej art. 21¹ i art. 211
+                # sklejają się do tego samego napisu i _fragmenty zwraca oba (znany bug).
+                self.out.append(" ")
+        if tag == "span":
+            if self.tt:
+                self.tt += 1
+            elif "tooltip-text" in klasa:
+                if self.gloss:
+                    self.tt = 1
+                else:   # dymek poza odsyłaczem (nieznany wariant znaczników) — jak dawniej, inline
+                    self.out.append("\n[przypis] ")
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style") and self.skip:
+            self.skip -= 1
+        if tag == "sup":
+            self.w_sup = False
+        if tag == "span" and self.tt:
+            self.tt -= 1
+        if tag == "a" and self.gloss:
+            self.gloss -= 1
+            if not self.gloss:
+                nr = "".join(self.nr).replace("\xa0", " ").strip()
+                tresc = " ".join("".join(self.tresc).replace("\xa0", " ").split())
+                self.oczekujace.append((nr, tresc))
+                self.nr, self.tresc = [], []
+
+    def handle_data(self, data):
+        if self.skip:
+            return
+        if self.gloss:
+            if self.w_sup:
+                self.nr.append(data)
+            elif self.tt:
+                self.tresc.append(data)
+            return
+        self.out.append(data)
+
+
+def html_to_text(html):
+    p = _Stripper()
+    p.feed(html)
+    p.zakoncz()
+    # API ELI używa twardych spacji (NBSP), np. "Art.\xa0299." — normalizuj, żeby frazy były wyszukiwalne
+    t = "".join(p.out).replace("\xa0", " ")
+    t = re.sub(r"[ \t]+", " ", t)
+    t = re.sub(r"\n[ \t]+", "\n", t)
+    t = re.sub(r"[ \t]+\n", "\n", t)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return t.strip()
+
+
+# ---------------------------------------------------------------------------------------------
+# Urzędowy PDF → tekst (gdy API ma textHTML=false: np. k.c. DU 2026 795, Konstytucja DU 1997 483)
+# ---------------------------------------------------------------------------------------------
+_PDF_NAGLOWEK = re.compile(r"^\s*(©\s*Kancelaria Sejmu|(Dziennik Ustaw|Monitor Polski)\s+–\s*\d+\s*–)")
+_PDF_STOPKA = re.compile(r"^\s*(\d{4}-\d{2}-\d{2}|–?\s*\d{1,4}\s*–?)\s*$")
+_PDF_PRZYPIS = re.compile(r"^(\d{1,3})\)(?:\s+(.*))?$")
+# glued odsyłacz do przypisu: „§ 1.3)", „(uchylony)5)", „chemicznych2)" — cyfry + „)" sklejone
+# z poprzedzającym znakiem, który nie jest spacją, cyfrą ani nawiasem otwierającym
+_PDF_ODSYLACZ = re.compile(r"(?<=[^\s\d\[(„\"'«])(\d{1,3})\)")
+_PDF_FRAZY_PRZYPISU = ("przez art.", "weszła w życie", "wszedł w życie", "wchodzi w życie", "Dodany ",
+                       "W brzmieniu", "Uchylony", "Ze zmianą", "Zmiany tekstu", "odnośniku", "Obecnie",
+                       "kieruje działem", "wdraża dyrektyw")
+# początek NOWEGO akapitu (jednostki redakcyjnej) — tylko to nie jest doklejane do poprzedniej linii
+_PDF_NOWY_AKAPIT = re.compile(
+    r"^[„\"]?(Art\.\s*\d|§\s*\d|Rozdział\s|ROZDZIAŁ\s|Dział\s|DZIAŁ\s|Tytuł\s|TYTUŁ\s|Księga\s|KSIĘGA\s|"
+    r"Oddział\s|ODDZIAŁ\s|Załącznik|Część\s|CZĘŚĆ\s|Preambuła|PREAMBUŁA|\d+[a-z]?\)\s|[a-z]\)\s|–\s|\d+[a-z]?\.\s)")
+# jednostka na LEWYM marginesie (pkt/lit./tiret mają wysunięty numer; „Art."/„§" bywają niewcięte)
+_PDF_JEDNOSTKA = re.compile(
+    r"^(Art\.\s*\d|§\s*\d|\d+[a-z]?\)\s|[a-z]\)\s|–\s|Rozdział\s|ROZDZIAŁ\s|Dział\s|DZIAŁ\s|Tytuł\s|TYTUŁ\s|"
+    r"Księga\s|KSIĘGA\s|Oddział\s|Załącznik)")
+_PDF_WCIECIE_NAGLOWKA = 16   # krótki wiersz wcięty co najmniej tyle = wyśrodkowany nagłówek (DZIAŁ IV)
+_PDF_MAKS_NAGLOWEK = 70
+
+
+def pdftotext_dostepny():
+    return shutil.which("pdftotext") is not None
+
+
+def pdf_do_tekstu_layout(pdf_bytes):
+    """`pdftotext -layout` na bajtach PDF → surowy tekst (pusty napis przy awarii)."""
+    tmp = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp = f.name
+        r = subprocess.run(["pdftotext", "-layout", "-enc", "UTF-8", tmp, "-"],
+                           capture_output=True, timeout=180)
+        if r.returncode != 0:
+            return ""
+        return r.stdout.decode("utf-8", "replace")
+    except Exception:
+        return ""
+    finally:
+        if tmp:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+
+def _pdf_strona(page, pierwsza):
+    """Jedna strona z `pdftotext -layout` → (linie treści [(wcięcie, tekst)], przypisy {nr: treść}).
+
+    Usuwa nagłówek („©Kancelaria Sejmu  s. 1/119", „Dziennik Ustaw – 22 – Poz. 795"), stopkę
+    (znacznik daty „2026-06-22", numer strony), normalizuje margines strony i wydziela blok
+    przypisów z dołu strony (po pustej linii; „3)   W brzmieniu ustalonym…" + wcięte kontynuacje).
+    """
+    lines = page.split("\n")
+    while lines and not lines[-1].strip():
+        lines.pop()
+    # nagłówek: pierwsze niepuste linie
+    i = 0
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    while i < len(lines) and _PDF_NAGLOWEK.match(lines[i]):
+        i += 1
+    lines = lines[i:]
+    # stopka: znacznik daty / numer strony na samym dole
+    while lines and (not lines[-1].strip() or _PDF_STOPKA.match(lines[-1])):
+        lines.pop()
+    if pierwsza and any("Opracowano na" in l for l in lines):
+        # Pierwsza strona „tekstu ujednoliconego" Kancelarii Sejmu (np. Konstytucja) ma na prawym
+        # marginesie notkę „Opracowano na podstawie: Dz. U. …", którą -layout dokleja do linii
+        # preambuły — odcinamy wszystko, co zaczyna się w prawej ćwiartce strony
+        szer = max(len(l.rstrip()) for l in lines) or 1
+        prog = int(szer * 0.75)
+
+        def bez_notki(l):
+            if len(l) - len(l.lstrip(" ")) >= prog:
+                return ""
+            for m in re.finditer(r"\S( {6,})(?=\S)", l):
+                if m.end() >= prog:
+                    return l[:m.start() + 1]
+            return l
+        lines = [bez_notki(l) for l in lines]
+    niepuste = [l for l in lines if l.strip()]
+    if not niepuste:
+        return [], {}
+    margines = min(len(l) - len(l.lstrip(" ")) for l in niepuste)
+    wiersze = [(0, "") if not l.strip() else (len(l) - len(l.lstrip(" ")) - margines, " ".join(l.split()))
+               for l in lines]
+    # blok przypisów: ostatni blok po pustej linii, zaczynający się od „N)" na marginesie
+    przypisy = {}
+    k = len(wiersze)
+    while k > 0 and wiersze[k - 1][1]:
+        k -= 1
+    blok = wiersze[k:]
+    if k > 0 and blok and blok[0][0] == 0 and _PDF_PRZYPIS.match(blok[0][1]):
+        numery = [m.group(1) for w, t in blok if w == 0 for m in [_PDF_PRZYPIS.match(t)] if m]
+        tresc_strony = "\n".join(t for w, t in wiersze[:k])
+        odsylacze = set(_PDF_ODSYLACZ.findall(tresc_strony))
+        tekst_bloku = " ".join(t for w, t in blok)
+        if (set(numery) & odsylacze) or any(f in tekst_bloku for f in _PDF_FRAZY_PRZYPISU):
+            biezacy = None
+            for w, t in blok:
+                m = _PDF_PRZYPIS.match(t) if w == 0 else None
+                if m:
+                    biezacy = m.group(1)
+                    przypisy[biezacy] = m.group(2) or ""
+                elif biezacy is not None:
+                    przypisy[biezacy] = _doklej(przypisy[biezacy], t)
+            wiersze = wiersze[:k]
+    return [(w, t) for w, t in wiersze if t], przypisy
+
+
+def _zlacz_rozstrzelone(t):
+    """Rozstrzelony tytuł z PDF („US T AW A", „O B W IE S Z CZ E N I E") → „USTAWA"; tylko wiersze
+    z samych wielkich liter, w których większość „wyrazów" to 1–2 znaki."""
+    tok = t.split()
+    if len(tok) >= 4 and all(x.isalpha() and x.isupper() for x in tok) \
+            and sum(len(x) <= 2 for x in tok) >= 0.6 * len(tok) and len("".join(tok)) <= 20:
+        return "".join(tok)
+    return t
+
+
+def _doklej(a, b):
+    """Łączy wiersz zawinięty w PDF: „zabez-" + „pieczenia" → „zabezpieczenia" (dzielenie wyrazów),
+    inaczej przez spację. Heurystyka: myślnik na końcu + mała litera na początku następnego wiersza."""
+    if not a:
+        return b
+    if a.endswith(("-", "­")) and b[:1].islower():
+        return a[:-1] + b
+    return a + " " + b
+
+
+def _pdf_normalizuj_indeksy(t):
+    # indeks górny w PDF: „Art. 68[1]." / „art. 385[1]–385[3]" / „68¹" → jak w ścieżce HTML: „Art. 68 1."
+    t = re.sub(r"(?<=\d)\[(\d+[a-z]?)\]", r" \1", t)
+    return re.sub(r"(?<=\d)([" + _SUPS + r"]+)", lambda m: " " + m.group(1).translate(_SUP), t)
+
+
+def pdf_layout_do_tekstu(raw):
+    """Tekst z `pdftotext -layout` → tekst w układzie jak z text.html.
+
+    Strony są czyszczone z nagłówków/stopek, zawinięte wiersze są sklejane w akapity (nowy akapit
+    zaczyna się od wciętego „Art."/„§"/„N)"/„lit."…, kontynuacja stoi na lewym marginesie),
+    a odsyłacze do przypisów („§ 1.3)") znikają z numeracji — treść przypisu wychodzi pod
+    akapit jako „[przypis 3)] …", dokładnie jak w ścieżce HTML.
+    """
+    strony = raw.split("\f")
+    akapity = []        # [wcięcie_nagłówka(bool), tekst, {strony}]
+    przypisy = {}       # nr strony → {nr przypisu: treść}
+    poprzedni_naglowek = False
+    for nr, strona in enumerate(strony):
+        wiersze, przyp = _pdf_strona(strona, pierwsza=(nr == 0))
+        if przyp:
+            przypisy[nr] = przyp
+        for wciecie, t in wiersze:
+            naglowek = wciecie >= _PDF_WCIECIE_NAGLOWKA and len(t) <= _PDF_MAKS_NAGLOWEK
+            if naglowek:
+                t = _zlacz_rozstrzelone(t)
+            nowy = (naglowek or poprzedni_naglowek or not akapity
+                    or (wciecie > 0 and _PDF_NOWY_AKAPIT.match(t)) or _PDF_JEDNOSTKA.match(t))
+            if nowy:
+                akapity.append([naglowek, t, {nr}])
+            else:
+                akapity[-1][1] = _doklej(akapity[-1][1], t)
+                akapity[-1][2].add(nr)
+            poprzedni_naglowek = naglowek
+    # Tekst jednolity zaczyna się od OBWIESZCZENIA Marszałka Sejmu (z cytowanymi przepisami
+    # przejściowymi: „Art. 3. Ustawa wchodzi w życie…"). To nie jest treść aktu, a na początku
+    # linii udawałoby nagłówek artykułu — wiersze obwieszczenia dostają znacznik „» ".
+    zal = next((i for i, a in enumerate(akapity[:400]) if a[1].lower().startswith("załącznik do obwieszczenia")), None)
+    if zal and any("jednolitego tekstu" in a[1] for a in akapity[:zal]):
+        for a in akapity[:zal]:
+            a[1] = "» " + a[1]
+        akapity.insert(0, [True, "[obwieszczenie Marszałka Sejmu sprzed załącznika — wiersze ze znakiem » NIE są treścią aktu]", set()])
+    out = []
+    for naglowek, t, na_stronach in akapity:
+        t = _pdf_normalizuj_indeksy(t)
+        odsylacze = []
+        t = _PDF_ODSYLACZ.sub(lambda m: odsylacze.append(m.group(1)) or "", t)
+        if naglowek or re.match(r"^Art\.\s*\d", t):
+            out.append("")
+        out.append(t)
+        for n in odsylacze:
+            tresc = None
+            for s in sorted(na_stronach) + [max(na_stronach) + 1, min(na_stronach) - 1]:
+                if n in przypisy.get(s, {}):
+                    tresc = przypisy[s][n]
+                    break
+            out.append(f"[przypis {n})] {tresc}" if tresc else f"[przypis {n})] (treści przypisu nie odnaleziono na tej stronie PDF)")
+    t = "\n".join(out)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return t.strip()
+
+
+def _wybierz_pdf(meta):
+    """Najlepszy urzędowy PDF z metadanych: tekst ujednolicony (U) > jednolity (T) > ogłoszony (O)."""
+    texts = meta.get("texts") or []
+    for code in ("U", "T", "O"):
+        pick = next((t for t in texts if t.get("type") == code
+                     and (t.get("fileName") or "").lower().endswith(".pdf")), None)
+        if pick:
+            return pick
+    return None
+
+
+# granice jednostek redakcyjnych w tekście po konwersji (nagłówki na początku linii)
+_GRANICE = r"(?m)^(Art\.\s*\d|Tytuł\s|TYTUŁ\s|Dział\s|DZIAŁ\s|Rozdział\s|Oddział\s|Księga\s|KSIĘGA\s|Załącznik)"
+
+# unicodowe indeksy górne (art. 21¹) — do rozpoznania w zapytaniu i przełożenia na cyfry ASCII
+_SUPS = "¹²³⁴⁵⁶⁷⁸⁹⁰"
+_SUP = str.maketrans(_SUPS, "1234567890")
+
+# Warianty myślnika (w tekstach ELI trafia się m.in. U+2012) — ujednolicane WYŁĄCZNIE na potrzeby
+# porównania, znak w znak, żeby nie przesunąć pozycji względem oryginału.
+_MYSLNIKI = str.maketrans("‐‑‒–—―−", "-------")
+
+
+def _norm(s):
+    """Postać do porównywania fraz: bez rozróżniania wielkości liter i wariantów myślnika."""
+    return s.translate(_MYSLNIKI).lower()
+
+
+# Koniec oznaczenia artykułu w nagłówku: albo kropka ("Art. 66."), albo ODSYŁACZ DO PRZYPISU
+# sklejony z numerem ("Art. 66c 6)Dodany przez art. 3 pkt 2 ustawy…" — kropka artykułu jest
+# dopiero za treścią przypisu). Przypis nowelizacyjny ma w tekście jednolitym KAŻDY niedawno
+# dodany lub zmieniony przepis, więc wymaganie samej kropki dawało fałszywy negatyw dokładnie
+# tam, gdzie prawo jest najświeższe. Rozróżnienie od indeksu górnego („Art. 60 1." = art. 60¹)
+# trzyma się nawiasu: przypis to CYFRY + „)", indeks górny — cyfry + kropka albo litera.
+# Spacja przed przypisem jest OBOWIĄZKOWA (odsyłacz siedzi w <sup>, a _Stripper zawsze go
+# odspacjowuje) — bez tego „art. 669¹" łapało też „Art. 669 101)", czyli art. 669 z przypisem 101.
+_KONIEC_ART = r"(?:\.|\s+\d+\))"
+
+
+def _hity_naglowka(txt, fraza):
+    """Pozycje NAGŁÓWKÓW artykułu wskazanego frazą ("art. 299", "art. 21¹", "art. 66c").
+
+    Pusta lista = fraza nie jest oznaczeniem artykułu ALBO tego artykułu nie ma w akcie.
+    """
+    # Baza + opcjonalny INDEKS GÓRNY (art. 21¹: unicode "21¹", nawiasowy "21(1)"/"21[1]"/"21^1")
+    # + opcjonalny SUFIKS LITEROWY (art. 1a, art. 168e). Rozróżnienie jest istotne, bo w tekście
+    # indeks górny ma spację ("Art. 21 1." — patrz _Stripper), a sufiks literowy jest sklejony
+    # ("Art. 1a."); dlatego indeks matchujemy z \s+, a literę z \s*.
+    m = re.match(
+        r"(?i)^art\.?\s*(\d+)"                                  # (1) baza
+        r"(?:[\(\[\^]\s*(\d+[a-z]?)\s*[\)\]]?|([" + _SUPS + r"]+))?"  # (2) nawiasowy | (3) unicode indeks
+        r"([a-z]*)\.?$",                                        # (4) sufiks literowy
+        fraza.strip())
+    if not m:
+        return []
+    base = m.group(1)
+    idx = m.group(2) or (m.group(3).translate(_SUP) if m.group(3) else "")
+    letter = m.group(4) or ""
+    # "art. 130(1a)" → indeks "1" + litera "a"; w tekście i one bywają rozdzielone
+    # („Art. 130 1 a."), więc literę doklejamy z \s*, nie na sztywno.
+    mi = re.match(r"(\d+)([a-z]*)$", idx)
+    if mi:
+        idx, letter = mi.group(1), letter or mi.group(2)
+    if idx:                       # indeks górny → w tekście rozdzielony spacją
+        pat = rf"(?m)^Art\.\s*{re.escape(base)}\s+{re.escape(idx)}\s*{re.escape(letter)}{_KONIEC_ART}"
+    elif letter:                  # sufiks literowy → sklejony z numerem
+        pat = rf"(?m)^Art\.\s*{re.escape(base)}\s*{re.escape(letter)}{_KONIEC_ART}"
+    else:
+        pat = rf"(?m)^Art\.\s*{re.escape(base)}{_KONIEC_ART}"
+    return [h.start() for h in re.finditer(pat, txt)]
+
+
+def _fragmenty(txt, fraza, maks=8):
+    """Spany (start, end) fragmentów z frazą, docięte do granic jednostek redakcyjnych.
+
+    Fraza w formie "art. 299" trafia w NAGŁÓWEK artykułu (nie w odesłania w treści);
+    inna fraza działa jak wyszukiwanie pełnotekstowe (bez rozróżniania wielkości liter).
+    Gdy nagłówka nie ma, fraza jest ponawiana pełnotekstowo — lepiej pokazać odesłanie
+    niż odpowiedzieć „nie znaleziono" na przepis, który w akcie jest.
+    """
+    bounds = [m.start() for m in re.finditer(_GRANICE, txt)]
+    hits = _hity_naglowka(txt, fraza)
+    if not hits:
+        # Szukamy po kopii znormalizowanej ZNAK W ZNAK (myślniki → "-"), żeby pozycje zgadzały się
+        # z oryginałem — dzięki temu wycinamy dosłowny tekst aktu, a nie jego przerobioną wersję.
+        low, f = _norm(txt), _norm(fraza).strip()
+        if len(low) != len(txt):        # awaryjnie (np. znaki zmieniające długość przy lower())
+            low, f = txt, fraza.strip()
+        if not f:
+            return []
+        hits, p = [], low.find(f)
+        while p != -1:
+            hits.append(p)
+            p = low.find(f, p + len(f))
+    spans = []
+    for pos in hits:
+        if len(spans) >= maks:
+            break
+        start = max((b for b in bounds if b <= pos), default=max(0, pos - 400))
+        end = min((b for b in bounds if b > pos), default=len(txt))
+        if spans and start < spans[-1][1]:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], end))
+        else:
+            spans.append((start, end))
+    return spans
+
+
+def _eli_rok_poz(act):
+    try:
+        _, rok, poz = (act.get("ELI") or "").split("/")
+        return (int(rok), int(poz))
+    except Exception:
+        return (0, 0)
+
+
+def _tj_acts(refs):
+    """Akty z kategorii 'Inf. o tekście jednolitym' (tylko na akcie bazowym), najnowszy pierwszy."""
+    key = next((k for k in refs if k.lower().startswith("inf. o tekście jednolit")), None)
+    if not key:
+        return []
+    items = refs[key] if isinstance(refs[key], list) else [refs[key]]
+    acts = [r.get("act") for r in items if isinstance(r, dict) and isinstance(r.get("act"), dict)]
+    return sorted(acts, key=_eli_rok_poz, reverse=True)
+
+
+def _akt_bazowy(refs):
+    """Akt BAZOWY z kategorii 'Tekst jednolity dla aktu' (tylko gdy akt sam jest t.j.), inaczej None."""
+    key = next((k for k in refs if k.lower().startswith("tekst jednolity dla aktu")), None)
+    if not key:
+        return None
+    items = refs[key] if isinstance(refs[key], list) else [refs[key]]
+    return next((r.get("act") for r in items if isinstance(r, dict) and isinstance(r.get("act"), dict)), None)
+
+
+def _nowszy_tj(path, refs):
+    """Tekst jednolity NOWSZY niż akt pod `path`, jeśli istnieje — inaczej None.
+
+    Akt bazowy ma listę swoich t.j. we własnych odniesieniach ('Inf. o tekście jednolitym').
+    Akt, który SAM jest t.j., ma w odniesieniach tylko wskazanie aktu bazowego — listę t.j.
+    trzeba pobrać z odniesień aktu bazowego (dodatkowe zapytanie; awaria → VerificationUnknown,
+    o reakcji decyduje wywołujący). Bez tego `tekst` na przestarzałym t.j. wyglądał jak aktualny.
+    """
+    m = re.match(r"^/acts/(?:DU|MP)/(\d+)/(\d+)$", path)
+    if not m:
+        return None
+    wlasne = (int(m.group(1)), int(m.group(2)))
+    tj = _tj_acts(refs)
+    if not tj:
+        base = _akt_bazowy(refs)
+        if not (base and base.get("ELI")):
+            return None
+        base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
+        tj = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
+    if tj and _eli_rok_poz(tj[0]) > wlasne:
+        return tj[0]
+    return None
+
+
+def _akt_opis(act):
+    return act.get("displayAddress") or act.get("ELI", "") or ""
+
+
+def _daty_aktu(act):
+    """Daty z obiektu aktu w odniesieniach: (data aktu = „z dnia" w tytule, ogłoszono w Dz.U./M.P.)."""
+    return act.get("announcementDate") or "", act.get("promulgation") or ""
+
+
+_ETYKIETY_DATY = (
+    # kategoria odniesień (początek nazwy, małe litery) → co oznacza pole `date` (zweryfikowane 2026-08)
+    ("akty zmieniające", "wejście w życie zmiany"),
+    ("akty zmienione", "wejście w życie zmiany"),
+    ("nowelizacje po tekście jednolit", "data aktu"),
+)
+
+
+def _etykieta_daty(kind):
+    k = (kind or "").lower()
+    return next((et for pref, et in _ETYKIETY_DATY if k.startswith(pref)), "data wg API")
+
+
+def _fmt_ref(ref, kind=None):
+    """Linia odniesienia z JEDNOZNACZNYMI etykietami dat: `date` z API znaczy co innego w każdej
+    kategorii („Akty zmieniające" = wejście w życie zmiany, „Nowelizacje po t.j." = data aktu)."""
+    if not isinstance(ref, dict):
+        return f"  - {ref}"
+    act = ref.get("act") if isinstance(ref.get("act"), dict) else None
+    extra = []
+    if act:
+        line = f"  - {_akt_opis(act)}  {act.get('title', '')}".rstrip()
+        data_aktu, ogloszono = _daty_aktu(act)
+        if data_aktu:
+            extra.append(f"data aktu {data_aktu}")
+        if ogloszono:
+            extra.append(f"ogłoszono {ogloszono}")
+    else:
+        line = f"  - {ref.get('displayAddress') or ref.get('ELI', '') or ref}"
+    if ref.get("date"):
+        et = _etykieta_daty(kind)
+        if not (et == "data aktu" and f"data aktu {ref['date']}" in extra):
+            extra.append(f"{et} {ref['date']}")
+    if ref.get("art"):
+        extra.append(f"art. {ref['art']}")
+    if extra:
+        line += "  (" + ", ".join(extra) + ")"
+    return line
+
+
+def _lista(refs, prefix):
+    key = next((k for k in refs if k.lower().startswith(prefix)), None)
+    if not key:
+        return []
+    items = refs[key] if isinstance(refs[key], list) else [refs[key]]
+    return [r for r in items if isinstance(r, dict) and isinstance(r.get("act"), dict)]
+
+
+def _zmiany_bazowe_po(base_eli, stan_prawny):
+    """„Akty zmieniające" aktu bazowego OGŁOSZONE lub WCHODZĄCE W ŻYCIE po dacie stanu prawnego t.j.
+
+    Tylko te nie są (w całości) oddane w tekście jednolitym. Może rzucić VerificationUnknown
+    (soft GET odniesień aktu bazowego).
+    """
+    base_refs = _get(f"/acts/{base_eli}/references", soft=True)
+    if not isinstance(base_refs, dict):
+        return []
+    out = []
+    for r in _lista(base_refs, "akty zmieniające"):
+        _, ogloszono = _daty_aktu(r["act"])
+        wejscie = r.get("date") or ""
+        if (ogloszono and ogloszono > stan_prawny) or (wejscie and wejscie > stan_prawny):
+            out.append(r)
+    return out
+
+
+_MAKS_DOPYTAN = 10
+
+
+def _nowelizacje_po_tj(refs, path, strict=False):
+    """Nowelizacje po tekście jednolitym: własna kategoria t.j. UZUPEŁNIONA o „Akty zmieniające"
+    aktu bazowego po `legalStatusDate` t.j. (Sejm nie synchronizuje obu list — audyt 2026-08:
+    k.p.c. t.j. 2026/468 wykazywał 2 z 5, k.s.h. 2024/18 — 1 z 4). Zwraca (linie, uwagi).
+
+    Każda pozycja ma daty opisane jednoznacznie: data aktu / ogłoszono / wejście w życie zmiany.
+    Awaria dopytań: w strict → VerificationUnknown, inaczej uwaga o możliwej niekompletności.
+    """
+    wlasne = _lista(refs, "nowelizacje po tekście jednolit")
+    base = _akt_bazowy(refs)
+    if not (wlasne or base):
+        return [], []
+    uwagi = []
+    stan_prawny = ""
+    zrodla = ["odniesienia t.j."] if wlasne else []
+    pozycje = {}   # ELI → {act, data_aktu, ogloszono, wejscie, etykieta}
+    for r in wlasne:
+        act = r["act"]
+        data_aktu, ogloszono = _daty_aktu(act)
+        pozycje[act.get("ELI")] = {"act": act, "data_aktu": data_aktu or r.get("date") or "",
+                                   "ogloszono": ogloszono, "wejscie": "", "etykieta": ""}
+    if base and base.get("ELI"):
+        try:
+            meta = _get(path, soft=True) if path else None
+            stan_prawny = (meta or {}).get("legalStatusDate") or "" if isinstance(meta, dict) else ""
+            if stan_prawny:
+                for r in _zmiany_bazowe_po(base["ELI"], stan_prawny):
+                    act = r["act"]
+                    data_aktu, ogloszono = _daty_aktu(act)
+                    poz = pozycje.setdefault(act.get("ELI"), {"act": act, "data_aktu": data_aktu,
+                                                              "ogloszono": ogloszono, "wejscie": "", "etykieta": ""})
+                    poz["wejscie"], poz["etykieta"] = r.get("date") or "", "wejście w życie zmiany"
+                zrodla.append(f"„Akty zmieniające\" aktu bazowego {_akt_opis(base)} ogłoszone lub "
+                              f"wchodzące w życie po {stan_prawny}")
+            else:
+                uwagi.append(f"UWAGA: brak legalStatusDate w metadanych {path} — listy nowelizacji nie "
+                             "uzupełniono z aktu bazowego (może być niepełna).")
+        except VerificationUnknown as e:
+            if strict:
+                raise VerificationUnknown(f"nie udało się uzupełnić listy nowelizacji z aktu bazowego ({e})") from e
+            uwagi.append(f"UWAGA: nie udało się uzupełnić listy nowelizacji z aktu bazowego ({e}) — "
+                         "lista poniżej może być NIEPEŁNA.")
+    # wejście w życie dla pozycji tylko z listy t.j. (bez `date` = wejście w życie): dopytaj metadane
+    dopytania = 0
+    for eli_id, poz in pozycje.items():
+        if poz["wejscie"] or not eli_id or dopytania >= _MAKS_DOPYTAN:
+            continue
+        dopytania += 1
+        try:
+            m = _get(f"/acts/{eli_id}", soft=True)
+        except VerificationUnknown as e:
+            if strict:
+                raise
+            uwagi.append(f"UWAGA: nie udało się pobrać wejścia w życie {eli_id} ({e}).")
+            continue
+        if isinstance(m, dict):
+            poz["wejscie"], poz["etykieta"] = m.get("entryIntoForce") or "", "wejście w życie aktu"
+            if m.get("comments"):
+                poz["uwagi"] = m["comments"]
+    linie = []
+    for poz in sorted(pozycje.values(), key=lambda x: (x["ogloszono"] or x["data_aktu"] or ""), reverse=True):
+        act = poz["act"]
+        daty = []
+        if poz["data_aktu"]:
+            daty.append(f"data aktu {poz['data_aktu']}")
+        if poz["ogloszono"]:
+            daty.append(f"ogłoszono {poz['ogloszono']}")
+        daty.append(f"{poz['etykieta'] or 'wejście w życie'} {poz['wejscie'] or '— sprawdź: meta ' + (act.get('ELI') or '').replace('/', ' ')}")
+        linie.append(f"  - {_akt_opis(act)}  {act.get('title', '')}".rstrip() + "  (" + ", ".join(daty) + ")")
+        if poz.get("uwagi"):
+            linie.append(f"      uwagi: {poz['uwagi']}")
+    if linie:
+        naglowek = (f"UWAGA: po tym tekście jednolitym" + (f" (stan prawny na {stan_prawny})" if stan_prawny else "")
+                    + f" odnotowano zmiany ({len(linie) - sum(1 for l in linie if l.startswith('      uwagi'))})"
+                    " — sprawdź ich wejście w życie" + (f" [źródła: {'; '.join(zrodla)}]" if zrodla else "") + ":")
+        linie.insert(0, naglowek)
+    return linie, uwagi
+
+
+def _ostrzezenia(refs, path=None, strict=False):
+    """Ostrzeżenia o aktualności (lista linii) na podstawie odniesień aktu."""
+    out = []
+    tj = _tj_acts(refs)
+    if tj:
+        a = tj[0]
+        out.append(f"UWAGA: ten akt ma TEKST JEDNOLITY — cytuj z najnowszego: "
+                   f"{a.get('displayAddress') or a.get('ELI', '')} (ELI {a.get('ELI', '')}).")
+    linie, uwagi = _nowelizacje_po_tj(refs, path, strict)
+    return out + uwagi + linie
+
+
+def _tj_z_tekstem(path, refs):
+    """Najnowszy tekst jednolity z NIEPUSTYM text.html, pomijając akt bieżący.
+
+    API potrafi zwrócić 200 i 0 bajtów dla text.html (textHTML=false) — także dla KILKU kolejnych
+    t.j. (k.c.: 2026/795 i 2025/1071 bez HTML, dopiero 2024/1061 z HTML). To jest ostatnia deska
+    ratunku, gdy nie da się przetworzyć urzędowego PDF. Zwraca (akt, tekst, pominięte_ELI) albo None.
+    """
+    biezacy_eli = path[len("/acts/"):]
+    tj = _tj_acts(refs)
+    if not tj:
+        # akt sam jest t.j. — pełną listę tekstów jednolitych mają odniesienia aktu BAZOWEGO
+        base = _akt_bazowy(refs)
+        if base and base.get("ELI"):
+            base_refs = _get(f"/acts/{base['ELI']}/references", soft=True)
+            tj = _tj_acts(base_refs) if isinstance(base_refs, dict) else []
+    niepewne = None
+    pominiete = []
+    for act in tj:
+        eli_id = act.get("ELI")
+        if not eli_id or eli_id == biezacy_eli:
+            continue
+        # awaria pobrania JEDNEGO kandydata nie może udawać, że zapasowego t.j. nie ma —
+        # próbujemy kolejnych, a UNKNOWN zgłaszamy dopiero gdy żaden nie dał tekstu
+        try:
+            html = _get(f"/acts/{eli_id}/text.html", soft=True)
+        except VerificationUnknown as e:
+            niepewne = e
+            continue
+        txt = html_to_text(html) if isinstance(html, str) else ""
+        if txt:
+            return act, txt, pominiete
+        pominiete.append(eli_id)
+    if niepewne is not None:
+        raise VerificationUnknown(f"nie wszystkie teksty jednolite dało się pobrać ({niepewne})")
+    return None
+
+
+def act_path(sig_parts):
+    """Zwraca ścieżkę bazową aktu, akceptując różne formy sygnatury."""
+    s = " ".join(sig_parts).strip()
+    compact = re.sub(r"\s+", "", s)
+    # ISAP address, np. WDU20240000018 (W + DU/MP + 9–12 cyfr)
+    m = re.match(r"^(W?)(DU|MP)(\d{9,12})$", compact, re.I)
+    if m:
+        addr = "W" + m.group(2).upper() + m.group(3)
+        return f"/acts/{addr}", s
+    pub = "DU"
+    mp = re.search(r"\b(DU|MP)\b", s, re.I)
+    if mp:
+        pub = mp.group(1).upper()
+    elif re.search(r"\bM\.?\s*P\.?\b", s):
+        pub = "MP"
+    nums = re.findall(r"\d+", s)
+    year = next((n for n in nums if len(n) == 4 and n[:2] in ("19", "20")), None)
+    poz = re.search(r"poz\.?\s*(\d+)", s, re.I)
+    if poz:
+        pos = poz.group(1)
+    else:
+        rest = [n for n in nums if n != year]
+        pos = rest[-1] if rest else None
+    if year and pos:
+        return f"/acts/{pub}/{year}/{int(pos)}", f"{pub} {year} poz. {int(pos)}"
+    sys.exit(f"Nie rozpoznano sygnatury: {s!r}. Przykłady: 'DU 2024 18', 'Dz.U. 2024 poz. 18', 'WDU20240000018'.")
+
+
+def cmd_szukaj(a):
+    if not (a.fraza or a.haslo):
+        sys.exit("Podaj frazę tytułu (np. szukaj \"Kodeks cywilny\") albo --haslo.")
+    params = {"title": a.fraza, "limit": a.limit, "offset": a.offset, "type": a.typ,
+              "year": a.rok, "publisher": a.wyd, "keyword": a.haslo}
+    if a.obowiazujace:
+        params["inForce"] = 1
+    d = _get("/acts/search", params)
+    d = _expect_dict(d, "wyniki wyszukiwania")
+    items = d.get("items") or []
+    total = d.get("totalCount")
+    if total is None:
+        total = d.get("count", len(items))
+    if not items:
+        # zero trafień = komunikat + kod wyjścia ≠ 0 (także z --json) — pusty JSON wyglądałby jak
+        # „sprawdzone, nic nie ma", a to tylko brak dopasowania TEJ frazy/filtrów
+        sys.exit(f"Brak wyników (totalCount={total}, offset {a.offset}) dla: fraza={a.fraza!r}, typ={a.typ!r}, "
+                 f"rok={a.rok!r}, haslo={a.haslo!r}. To NIE dowodzi, że aktu nie ma — spróbuj krótszej frazy "
+                 "z tytułu, bez --typ/--rok, albo --haslo.")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Znaleziono: {total} (pokazuję {len(items)}, offset {a.offset})")
+    try:
+        pozostalo = int(total) - (a.offset + len(items))
+    except (TypeError, ValueError):
+        pozostalo = 0
+    if pozostalo > 0:
+        print(f"UWAGA: to NIE wszystkie wyniki — pozostało {pozostalo}. Kolejna strona: "
+              f"--offset {a.offset + len(items)} --limit {a.limit}; albo zwiększ --limit (np. 100). "
+              "Akt bazowy bywa na końcu listy (API sortuje nowelizacje przed aktem bazowym).")
+    print()
+    for it in items:
+        print(f"  {it.get('address','')}  [{it.get('status','')}]")
+        print(f"    {it.get('title','').strip()[:160]}")
+        if it.get("ELI"):
+            print(f"    ELI: {it['ELI']}")
+        print()
+
+
+def cmd_meta(a):
+    path, label = act_path(a.sygnatura)
+    d = _get(path)
+    d = _expect_dict(d, "metadane aktu")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Akt: {label}")
+    print(f"  Tytuł:   {d.get('title','').strip()}")
+    print(f"  Adres:   {d.get('displayAddress','')}")
+    print(f"  Typ:     {d.get('type','')}")
+    print(f"  Status:  {d.get('status','')}  (inForce={d.get('inForce','')})")
+    # announcementDate = data AKTU (wydania/podpisania — „z dnia" w tytule), promulgation = data
+    # OGŁOSZENIA w Dz.U./M.P. — vacatio legis liczy się od ogłoszenia (audyt 2026-08: mylono je)
+    print(f"  Data aktu: {d.get('announcementDate') or '—'}   (data wydania — „z dnia” w tytule)")
+    print(f"  Ogłoszono: {d.get('promulgation') or '— (brak w API)'}   (publikacja w Dz.U./M.P.)")
+    print(f"  WEJŚCIE W ŻYCIE: {d.get('entryIntoForce') or '—'}")
+    if d.get("legalStatusDate"):
+        print(f"  Stan prawny na: {d['legalStatusDate']}   (tekst jednolity oddaje stan na ten dzień)")
+    if d.get("validFrom") and d.get("validFrom") != d.get("entryIntoForce"):
+        print(f"  Obowiązuje od: {d['validFrom']}")
+    if d.get("comments"):
+        # np. „art. 5 ust. 4 … wchodzą w życie z dniem 25 grudnia 2024 r." — RÓŻNE daty dla jednostek
+        print(f"  Uwagi:   {' '.join(str(d['comments']).split())}")
+    if d.get("keywordsNames"):
+        print(f"  Hasła:   {', '.join(d['keywordsNames'])}")
+    print(f"  ELI:     {d.get('ELI','')}")
+    texts = d.get("texts", [])
+    if texts:
+        print("  Dostępne teksty (type/fileName):")
+        for t in texts:
+            print(f"    - {t.get('type','?')}: {t.get('fileName','')}")
+    if d.get("textHTML") is False:
+        print(f"  Tekst HTML: BRAK w API (textHTML=false) — `tekst {label}` czyta urzędowy PDF przez pdftotext")
+    else:
+        print(f"  Tekst HTML: {BASE}{path}/text.html")
+    if "tekst jednolity" in (d.get("status") or "").lower():
+        print(f"  → Akt ma tekst jednolity — ustal aktualny: python3 {sys.argv[0]} tj {label}")
+
+
+def _tekst_z_pdf(path, label, meta):
+    """Tekst aktu z jego WŁASNEGO urzędowego PDF (pdftotext -layout). Zwraca (tekst, url, błąd)."""
+    pick = _wybierz_pdf(meta)
+    if not pick:
+        return "", "", "brak PDF w metadanych aktu"
+    if not pdftotext_dostepny():
+        return "", "", "brak programu pdftotext (poppler) w PATH"
+    url = f"{BASE}{path}/text/{pick['type']}/{pick['fileName']}"
+    try:
+        data = _get_bytes(url, soft=True)
+    except VerificationUnknown as e:
+        return "", url, str(e)
+    raw = pdf_do_tekstu_layout(data)
+    txt = pdf_layout_do_tekstu(raw) if raw else ""
+    if not txt:
+        return "", url, "pdftotext nie zwrócił tekstu (PDF bez warstwy tekstowej albo błąd konwersji)"
+    return txt, url, ""
+
+
+def cmd_tekst(a):
+    strict = getattr(a, "strict", False)
+    path, label = act_path(a.sygnatura)
+    # odniesienia służą tylko ostrzeżeniom o aktualności — ich awaria nie może odebrać
+    # użytkownikowi samego tekstu; zamiast tego tekst dostaje GŁOŚNE ostrzeżenie
+    try:
+        refs = _get(path + "/references", soft=True)
+    except VerificationUnknown as e:
+        if strict:
+            raise
+        refs = None
+        ostrz = [f"UWAGA: nie udało się zweryfikować aktualności aktu {label} ({e}) — "
+                 "sprawdź nowelizacje i teksty jednolite ręcznie, zanim zacytujesz."]
+    else:
+        ostrz = _ostrzezenia(refs, path, strict) if isinstance(refs, dict) else []
+        # nowszy t.j. — zarówno dla aktu bazowego, jak i dla aktu, który SAM jest (starszym) t.j.
+        try:
+            nowszy = _nowszy_tj(path, refs) if isinstance(refs, dict) else None
+        except VerificationUnknown as e:
+            if strict:
+                raise
+            nowszy = None
+            ostrz.append(f"UWAGA: nie udało się sprawdzić, czy istnieje nowszy tekst jednolity ({e}) — "
+                         f"zweryfikuj: tj {label}, zanim zacytujesz.")
+        if nowszy:
+            aktualny = nowszy.get("displayAddress") or nowszy.get("ELI", "")
+            if strict:
+                sys.exit(f"BŁĄD: istnieje nowszy tekst jednolity: {aktualny}. "
+                         "Tryb strict blokuje starszą treść.")
+            if not _tj_acts(refs):  # akt bazowy ma już ostrzeżenie „cytuj z najnowszego" z _ostrzezenia()
+                sig = (nowszy.get("ELI") or "").replace("/", " ")
+                ostrz.insert(0, f"UWAGA: {label} to NIEAKTUALNY tekst jednolity — istnieje NOWSZY: "
+                                f"{aktualny}. Cytuj z niego: tekst {sig}")
+    if a.pdf:
+        # pobierz urzędowy PDF (preferuj tekst jednolity, typ 'U'/'T', inaczej oryginał 'O')
+        meta = _expect_dict(_get(path), "metadane aktu")
+        pick = _wybierz_pdf(meta)
+        if not pick:
+            sys.exit("Brak PDF w metadanych aktu.")
+        url = f"{BASE}{path}/text/{pick['type']}/{pick['fileName']}"
+        data = _get_bytes(url)
+        with open(a.pdf, "wb") as f:
+            f.write(data)
+        print(f"Zapisano PDF ({len(data)} B): {a.pdf}\n(źródło: {url})")
+        for w in ostrz:
+            print(w)
+        return
+    html = _get(path + "/text.html")
+    if isinstance(html, (dict, list)):
+        html = json.dumps(html, ensure_ascii=False)
+    txt = html_to_text(html if isinstance(html, str) else "")
+    zrodlo = "z text.html; HTML→tekst"
+    if not txt:
+        # textHTML=false (np. k.c. DU 2026 795, Konstytucja DU 1997 483, świeże pozycje): najpierw
+        # WŁASNY urzędowy PDF tego aktu — to jest jego tekst, więc --strict go przepuszcza
+        meta = _expect_dict(_get(path), "metadane aktu")
+        txt, url, pdf_blad = _tekst_z_pdf(path, label, meta)
+        if txt:
+            zrodlo = "z urzędowego PDF przez pdftotext -layout"
+            ostrz = [f"ELI_TEXT_SOURCE_PDF={url}",
+                     f"UWAGA: text.html dla {label} jest PUSTE w API (textHTML=false) — poniżej tekst "
+                     f"WYEKSTRAHOWANY z urzędowego PDF tego aktu ({meta.get('legalStatusDate') and 'stan prawny na ' + meta['legalStatusDate'] or 'tekst ogłoszony'}). "
+                     "Sklejanie wierszy i dzielonych wyrazów jest automatyczne; linie „[przypis N)]\" to "
+                     "przypisy z dołu strony PDF. Do dosłownego cytatu: tekst " + label + " --pdf plik.pdf"] + ostrz
+        else:
+            if strict:
+                sys.exit(f"BŁĄD: text.html dla {label} jest PUSTE w API (textHTML=false), a urzędowego PDF "
+                         f"nie dało się przetworzyć ({pdf_blad}). Tryb strict blokuje zastępczy (STARSZY) tekst "
+                         f"jednolity, bo jego kompletności nie da się zweryfikować. Zainstaluj pdftotext "
+                         f"(poppler: brew install poppler / apt install poppler-utils) albo pobierz PDF: "
+                         f"tekst {label} --pdf plik.pdf")
+            try:
+                fb = _tj_z_tekstem(path, refs if isinstance(refs, dict) else {})
+            except VerificationUnknown as e:
+                _nie_zweryfikowano(f"zapasowego tekstu jednolitego dla {label}", e)
+            if not fb:
+                sys.exit(f"BŁĄD: text.html dla {label} jest PUSTE w API (textHTML=false — dla tego aktu API nie "
+                         f"udostępnia HTML), urzędowego PDF nie dało się przetworzyć ({pdf_blad}) i nie ma innego "
+                         f"tekstu jednolitego z tekstem. Zainstaluj pdftotext (poppler) albo pobierz PDF: "
+                         f"tekst {label} --pdf plik.pdf")
+            act, txt, pominiete = fb
+            addr = _akt_opis(act)
+            actual_eli = act.get("ELI") or ""
+            zrodlo = "z text.html STARSZEGO t.j.; HTML→tekst"
+            ostrz = _ostrzezenie_starszego_tj(path, label, refs, meta, act, pominiete, pdf_blad) + ostrz
+            label = f"{label} (NIEAKTUALNE BRZMIENIE MOŻLIWE — tekst z: {addr})"
+    print(f"# {label} — tekst ({zrodlo}; do dosłownego cytatu zweryfikuj z PDF urzędowym)\n")
+    for w in ostrz:
+        print(w)
+    if ostrz:
+        print()
+    if a.fragment:
+        spans = _fragmenty(txt, a.fragment)
+        if not spans:
+            goly = re.sub(r"(?i)^art\.?\s*", "", a.fragment.strip()) or "N"
+            sys.exit(f"Nie znaleziono frazy {a.fragment!r} w tekście aktu ({len(txt)} znaków).\n"
+                     "UWAGA: to NIE dowodzi, że przepisu nie ma — zanim tak napiszesz, sprawdź samym "
+                     f"numerem (--fragment \"{goly}\"), słowem kluczowym z treści "
+                     "albo pobierz pełny tekst bez --fragment.")
+        # tryb nagłówkowy zawiódł → poniżej trafienia pełnotekstowe, więc mogą to być ODESŁANIA
+        if re.match(r"(?i)^art\.?\s*\d", a.fragment.strip()) and not _hity_naglowka(txt, a.fragment):
+            print(f"UWAGA: nie znalazłem NAGŁÓWKA {a.fragment!r} w tym akcie — poniżej trafienia "
+                  "pełnotekstowe; sprawdź, czy to sam przepis, czy tylko odesłanie do niego.\n")
+        for i, (s, e) in enumerate(spans):
+            if i:
+                print("\n[...]\n")
+            print(txt[s:e].strip())
+        print(f"\n(fragmenty: {len(spans)} — pominięto resztę aktu; pełny tekst: bez --fragment)")
+        return
+    if len(txt) > 60000:
+        print(f"(UWAGA: pełny tekst ma {len(txt)} znaków — do pojedynczego przepisu użyj --fragment \"art. N\")\n")
+    print(txt)
+
+
+def _ostrzezenie_starszego_tj(path, label, refs, meta, act, pominiete, pdf_blad):
+    """Nagłówek ostrzegawczy dla tekstu ze STARSZEGO t.j. + INLINE lista zmian aktu bazowego po jego
+    stanie prawnym (dawna instrukcja „odniesienia <stary t.j.>" była martwa: wygasły t.j. nie ma
+    w API kategorii „Nowelizacje po tekście jednolitym")."""
+    addr = _akt_opis(act)
+    actual_eli = act.get("ELI") or ""
+    out = [f"ELI_TEXT_SOURCE_FALLBACK={actual_eli}"]
+    stan = ""
+    try:
+        m = _get(f"/acts/{actual_eli}", soft=True) if actual_eli else None
+        stan = m.get("legalStatusDate") or "" if isinstance(m, dict) else ""
+    except VerificationUnknown:
+        stan = ""
+    out.append(f"UWAGA — NIEAKTUALNE BRZMIENIE MOŻLIWE: text.html dla {label} jest PUSTE w API (textHTML=false), "
+               f"a urzędowego PDF nie dało się przetworzyć ({pdf_blad}). Poniżej tekst STARSZEGO tekstu "
+               f"jednolitego {addr}" + (f" (stan prawny na {stan})" if stan else "") + "."
+               + (f" Pominięto t.j. z pustym text.html: {', '.join(pominiete)}." if pominiete else ""))
+    base = _akt_bazowy(refs) if isinstance(refs, dict) else None
+    if not base and isinstance(refs, dict) and _tj_acts(refs):
+        base = {"ELI": path[len("/acts/"):], "displayAddress": meta.get("displayAddress", "")}
+    if base and base.get("ELI") and stan:
+        try:
+            zmiany = _zmiany_bazowe_po(base["ELI"], stan)
+        except VerificationUnknown as e:
+            out.append(f"UWAGA: nie udało się pobrać zmian aktu bazowego po {stan} ({e}) — sprawdź ręcznie: "
+                       f"odniesienia {base['ELI'].replace('/', ' ')} (sekcja „Akty zmieniające\").")
+        else:
+            if zmiany:
+                out.append(f"Zmiany aktu bazowego {_akt_opis(base)} ogłoszone lub wchodzące w życie po {stan} "
+                           f"({len(zmiany)}) — NIE ma ich w poniższym tekście, nałóż je sam:")
+                out += [_fmt_ref(r, "Akty zmieniające") for r in zmiany]
+            else:
+                out.append(f"W API brak zmian aktu bazowego {_akt_opis(base)} po {stan} (indeksacja bywa opóźniona).")
+    else:
+        out.append("UWAGA: nie ustaliłem stanu prawnego starszego t.j. — sprawdź „Akty zmieniające\" aktu bazowego ręcznie.")
+    out.append(f"Do dosłownego, aktualnego brzmienia: zainstaluj pdftotext (poppler) i powtórz, albo: tekst {label} --pdf plik.pdf")
+    return out
+
+
+def cmd_struktura(a):
+    path, label = act_path(a.sygnatura)
+    # /struct istnieje głównie dla t.j. i starszych aktów — 404 to zweryfikowany brak, nie awaria
+    d = _get(path + "/struct", soft=True)
+    nodes = d if isinstance(d, list) else [d] if isinstance(d, dict) else None
+    if not nodes:
+        sys.exit(f"Brak struktury dla tego aktu ({label}) — API udostępnia /struct głównie dla tekstów "
+                 f"jednolitych i starszych aktów; świeżo ogłoszone pozycje często go nie mają. "
+                 f"Spis jednostek odczytasz z tekstu: tekst {label} | grep -n \"^Art\\.\"")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    filtr = (a.filtr or "").lower()
+    poziom = a.poziom if a.poziom is not None else (None if filtr else 3)
+    print(f"Struktura: {label}  (frazę z 'title' podaj w: tekst {label} --fragment \"...\")\n")
+    wypisane = 0
+
+    def walk(n, depth=0):
+        nonlocal wypisane
+        line = f"{'  ' * depth}{n.get('id','?')}  [{n.get('type','')}]  {(n.get('title') or '').strip()}"
+        if (not filtr or filtr in line.lower()) and (poziom is None or depth < poziom):
+            print(line)
+            wypisane += 1
+        for c in n.get("children") or []:
+            walk(c, depth + 1)
+
+    for n in nodes:
+        walk(n)
+    if not wypisane:
+        print(f"(nic nie pasuje do filtra {a.filtr!r})")
+
+
+def cmd_odniesienia(a):
+    path, label = act_path(a.sygnatura)
+    d = _get(path + "/references")
+    d = _expect_dict(d, "odniesienia aktu")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Odniesienia dla: {label}")
+    print("(daty: „data aktu\" = data wydania z tytułu, „ogłoszono\" = publikacja w Dz.U./M.P., "
+          "„wejście w życie zmiany\" = pole date w „Akty zmieniające\")\n")
+    for kind, lst in d.items():
+        items = lst if isinstance(lst, list) else [lst]
+        print(f"## {kind}  ({len(items)})")
+        for ref in items:
+            print(_fmt_ref(ref, kind))
+        print()
+    if _akt_bazowy(d):
+        linie, uwagi = _nowelizacje_po_tj(d, path, getattr(a, "strict", False))
+        for w in uwagi + linie:
+            print(w)
+
+
+def cmd_tj(a):
+    path, label = act_path(a.sygnatura)
+    d = _get(path + "/references")
+    d = _expect_dict(d, "odniesienia aktu")
+    # akt bazowy: kategoria 'Inf. o tekście jednolitym' listuje obwieszczenia z t.j.
+    tj = _tj_acts(d)
+    if tj:
+        if a.json:
+            print(json.dumps(d, ensure_ascii=False, indent=2)); return
+        print(f"TEKSTY JEDNOLITE dla {label} (najnowszy pierwszy):")
+        for i, act in enumerate(tj):
+            marker = "  ← AKTUALNY" if i == 0 else ""
+            print(f"  - {act.get('displayAddress') or act.get('ELI','')}  [{act.get('status','')}]{marker}")
+        eli = tj[0].get("ELI", "")
+        if eli:
+            sig = eli.replace("/", " ")
+            print(f"\nDalej: python3 {sys.argv[0]} tekst {sig} --fragment \"art. N\"")
+            print(f"(tekst na t.j. sam wypisuje „Nowelizacje po tekście jednolitym\" — uzupełnione o „Akty "
+                  f"zmieniające\" aktu bazowego po stanie prawnym t.j.; pełna lista: odniesienia {label})")
+        return
+    # akt sam jest tekstem jednolitym: kategoria 'Tekst jednolity dla aktu' wskazuje akt BAZOWY
+    base_key = next((k for k in d if k.lower().startswith("tekst jednolity dla aktu")), None)
+    if base_key:
+        base = _akt_bazowy(d)
+        # sprawdź na akcie bazowym, czy nie ma już NOWSZEGO tekstu jednolitego
+        kontrola = None
+        try:
+            newer = _nowszy_tj(path, d)
+        except VerificationUnknown as e:
+            if getattr(a, "strict", False):
+                raise
+            kontrola = (f"UWAGA: nie udało się sprawdzić, czy istnieje nowszy tekst jednolity ({e}) — "
+                        "zweryfikuj ręcznie, zanim zacytujesz.")
+        else:
+            if newer:
+                aktualny = newer.get("displayAddress") or newer.get("ELI", "")
+                if getattr(a, "strict", False):
+                    sys.exit(f"BŁĄD: istnieje nowszy tekst jednolity: {aktualny}. "
+                             "Tryb strict blokuje starszy wynik.")
+                kontrola = f"UWAGA: istnieje NOWSZY tekst jednolity: {aktualny} — cytuj z niego."
+        ostrz = _ostrzezenia(d, path, getattr(a, "strict", False))
+        if a.json:
+            print(json.dumps(d, ensure_ascii=False, indent=2)); return
+        print(f"{label} SAM JEST tekstem jednolitym" + (f" (dla: {base.get('displayAddress','')} — {base.get('title','')[:90]})" if base else "") + ".")
+        for w in ostrz:
+            print(w)
+        if kontrola:
+            print(kontrola)
+        return
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Dla {label} brak tekstu jednolitego w odniesieniach — akt może nie mieć t.j. (cytuj z aktu, "
+          f"ale sprawdź „Akty zmieniające\" w: odniesienia {label}).")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="API ELI Sejmu (read-only). Źródło pierwotne prawa polskiego.")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("szukaj"); s.add_argument("fraza", nargs="?", default=None); s.add_argument("--typ"); s.add_argument("--rok")
+    s.add_argument("--wyd", type=str.upper, choices=["DU", "MP"]); s.add_argument("--obowiazujace", action="store_true")
+    s.add_argument("--haslo", help="hasło przedmiotowe (keyword)"); s.add_argument("--offset", type=int, default=0)
+    s.add_argument("--limit", type=int, default=10); s.set_defaults(func=cmd_szukaj)
+
+    for name, fn in (("meta", cmd_meta), ("odniesienia", cmd_odniesienia), ("tj", cmd_tj)):
+        p = sub.add_parser(name); p.add_argument("sygnatura", nargs="+"); p.set_defaults(func=fn)
+
+    t = sub.add_parser("tekst"); t.add_argument("sygnatura", nargs="+"); t.add_argument("--pdf")
+    t.add_argument("--fragment", help='wytnij tylko jednostki z frazą, np. "art. 299" albo "przedawnienie"')
+    t.set_defaults(func=cmd_tekst)
+
+    st = sub.add_parser("struktura"); st.add_argument("sygnatura", nargs="+")
+    st.add_argument("--filtr", help="pokaż tylko linie z frazą (np. 'Art. 299')")
+    st.add_argument("--poziom", type=int, help="maks. głębokość drzewa (domyślnie 3; z --filtr bez limitu)")
+    st.set_defaults(func=cmd_struktura)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
+
+    a = ap.parse_args()
+    try:
+        a.func(a)
+    except VerificationUnknown as e:
+        _nie_zweryfikowano("danych w API ELI", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/prawo-pl-saos/.claude-plugin/plugin.json
+++ b/plugins/prawo-pl-saos/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-pl-saos",
+  "description": "Polskie orzecznictwo z publicznego API SAOS (saos.org.pl): wyroki, postanowienia i uchwały Sądu Najwyższego, Trybunału Konstytucyjnego, sądów powszechnych i KIO. Wyszukiwanie po frazie, sygnaturze, sądzie, sędzim, powołanym przepisie i dacie; pełna treść uzasadnień, powołane przepisy i orzeczenia. Read-only — JAK sądy stosują przepisy (treść przepisów: prawo-pl-eli).",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-pl-saos/.codex-plugin/plugin.json
+++ b/plugins/prawo-pl-saos/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prawo-pl-saos",
+  "version": "2.0.0",
+  "description": "Polskie orzecznictwo z publicznego API SAOS (saos.org.pl): SN, TK, sądy powszechne, KIO. Wyszukiwanie po frazie, sygnaturze, sądzie, sędzim, powołanym przepisie i dacie; pełna treść uzasadnień, powołane przepisy i orzeczenia. Read-only.",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": ["prawo", "polish-law", "orzecznictwo", "case-law", "saos", "sad-najwyzszy", "legal"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo PL — orzecznictwo (SAOS)",
+    "shortDescription": "Polskie orzecznictwo z API SAOS (SN, TK, sądy powszechne, KIO).",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/SKILL.md
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: prawo-pl-saos
+version: 2.0.0
+description: >-
+  Odpytuje PUBLICZNE API SAOS (saos.org.pl) — bazę polskiego ORZECZNICTWA: wyroki, postanowienia
+  i uchwały Sądu Najwyższego (SN), Trybunału Konstytucyjnego (TK), sądów powszechnych (SA/SO/SR)
+  i Krajowej Izby Odwoławczej (KIO). Używaj, gdy potrzebujesz ORZECZEŃ, a nie treści przepisu:
+  „orzecznictwo SN/TK do art. X", „jak sądy interpretują/stosują…", „linia orzecznicza", „znajdź
+  wyrok o sygnaturze…", „uchwała SN sygn. …", przy ANALIZIE i PISANIU pism procesowych (poszukiwanie
+  podstawy w judykaturze). Treść przepisu bierz z ELI (skill prawo-pl-eli), tu szukasz JAK go stosują.
+  Filtruj po sądzie, sygnaturze, sędzim, powołanym przepisie i dacie; zwraca pełne uzasadnienia,
+  powołane przepisy i powołane orzeczenia. UWAGA: SAOS to baza WTÓRNA (agregat) — sądy administracyjne
+  (NSA/WSA) są w niej praktycznie nieobecne (dla nich: skill prawo-pl-cbosa), a zbiory SN (do 22.06.2016),
+  TK (do 9.12.2015) i KIO (do 6.09.2018) są zamknięte; sądy powszechne idą na bieżąco. Polish case-law
+  from the public SAOS API.
+---
+
+# Polskie orzecznictwo z publicznego API SAOS
+
+Skill do **orzecznictwa** (judykatury) polskiego: wyroków, postanowień i uchwał. Sięga do publicznego API
+**SAOS** (System Analizy Orzeczeń Sądowych, `https://www.saos.org.pl/api`) — agregatu orzeczeń jawnych:
+**SN, TK, sądy powszechne (SA/SO/SR), KIO**. Używaj go zawsze, gdy pytanie dotyczy tego, **jak sądy
+stosują/interpretują przepis**, gdy trzeba znaleźć **konkretny wyrok po sygnaturze**, ustalić **linię
+orzeczniczą** albo poprzeć argument w piśmie procesowym judykaturą.
+
+## Podział ról (przepis ≠ orzeczenie)
+
+1. **Treść przepisu — z ELI**, nie z SAOS. Brzmienie polskiej ustawy/kodeksu cytuj przez skill
+   **prawo-pl-eli** (`scripts/eli.py`). SAOS daje orzeczenia, nie autorytatywny tekst przepisu.
+2. **JAK sądy stosują przepis — z SAOS.** „Co mówi orzecznictwo o art. 299 k.s.h.", „czy SN dopuszcza…",
+   „linia orzecznicza w sprawie…", „znajdź wyrok sygn. III CSK 203/09" — to zadania dla tego skilla.
+3. **Most ELI → SAOS:** najpierw ustal przepis w ELI, potem `szukaj --przepis "..."` w SAOS, by znaleźć
+   orzeczenia powołujące ten przepis.
+4. **Delegując research subagentowi**, wpisz: „orzecznictwo polskie pobieraj przez `scripts/saos.py`
+   (skill prawo-pl-saos); treść przepisów przez `scripts/eli.py` (prawo-pl-eli)".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/saos.py` (tylko biblioteka standardowa Pythona — bez instalacji).
+Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/saos.py`) — NIE zakładaj, że to
+`~/.claude/skills/prawo-pl-saos` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+SAOS="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-saos/scripts/saos.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$SAOS" ] || SAOS="<katalog skilla>/scripts/saos.py"
+[ -f "$SAOS" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $SAOS" >&2; exit 1; }
+python3 "$SAOS" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/saos.py` oznacza `python3 "$SAOS"`, jeśli nie jesteś w katalogu skilla.)
+
+### Komendy
+
+- **szukaj** — znajdź orzeczenia po kryteriach:
+  `python3 scripts/saos.py szukaj "rękojmia wiary publicznej" --sad SN --limit 5`
+  Opcje: `--sad SN|TK|powszechne|admin|KIO`, `--sygnatura "III CSK 203/09"`, `--przepis "Kodeks cywilny"`
+  (powołany przepis/akt — **luźne dopasowanie pełnotekstowe**: `--przepis "art. 415"` trafia art. 415 k.c.,
+  k.p.c. i k.p.k. jednakowo; dopisz nazwę aktu, np. `"Kodeks cywilny art. 415"`, i sprawdź akt w
+  `orzeczenie <id>`), `--sedzia "Górski"`, `--haslo "nienależne świadczenie"`,
+  `--typ wyrok|postanowienie|uchwala|zarzadzenie|uzasadnienie`, `--od 2020-01-01`, `--do 2024-12-31`
+  (także `RRRR` / `RRRR-MM`), `--limit N` (1–100), `--strona N` (od 0).
+- **orzeczenie** — pełne orzeczenie po ID (z listy `szukaj`):
+  `python3 scripts/saos.py orzeczenie 76341`
+  Pokazuje metadane, **powołane przepisy** i **powołane orzeczenia** (z ID do dalszego skoku) oraz treść
+  uzasadnienia. Do długich uzasadnień: `--fragment "rękojmia"` (okna wokół frazy, dosunięte do granic
+  zdań/słów, z „…" na ucięciu). Typ orzeczenia zawsze po polsku (wyrok / postanowienie / uchwała /
+  zarządzenie / uzasadnienie). „Powołane przepisy" to **automatyczna ekstrakcja SAOS — bywa niepełna**
+  (KIO 1564/18 nie ma w niej ŻADNEGO przepisu Pzp, o które chodzi w sentencji) i bywa uszkodzona
+  (`art. 4793647945`, `Nr 0`, `art. 2oraz` — silnik oznacza takie wpisy „wpis SAOS prawdopodobnie
+  uszkodzony"); przepisy rozstrzygnięcia czytaj z sentencji.
+- **sygnatura** — szybkie odszukanie po numerze sprawy:
+  `python3 scripts/saos.py sygnatura III CSK 203/09`
+- każda komenda przyjmuje `--json` oraz `--strict`; obie flagi działają przed komendą i po niej.
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”); przy `--sad SN|TK|KIO`
+  komunikat zawiera granicę zbioru do dnia i to, czy Twój zakres leży poza nią. Z `--json` i wynikami
+  ostrzeżenie o granicy idzie na stderr (stdout to czysty JSON).
+  **Co sprawdza `--strict`:** (1) zakres dat dla SN/TK/KIO nie może wychodzić poza koniec zbioru
+  (porównanie do dnia; brak `--do` = blokada; przed blokadą silnik potwierdza granicę na żywo jednym
+  zapytaniem o najnowsze orzeczenie — gdyby SAOS wznowił zasilanie, granica się przesunie), (2) odpowiedź
+  API musi być kompletnym wynikiem (`items` + `totalResults`) albo pełnym orzeczeniem — inaczej błąd,
+  (3) żadna z tych kontroli nie przepuszcza „pustego" wyniku jako sukcesu. `--strict` NIE sprawdza
+  prawdziwości treści ani kompletności listy powołanych przepisów.
+- Czas: `/search/judgments` bywa bardzo wolne (40–60 s); limit na żądanie to 90 s, 2 próby. Przekroczenie
+  czasu lub „Przerwa techniczna" (nocne okno serwisowe SAOS) to `BŁĄD sieci` / `przerwa techniczna`
+  z kodem ≠ 0 — nigdy fałszywe zero trafień. Wtedy ponów później, nie wnioskuj „brak orzecznictwa".
+
+Typowy przepływ: `szukaj` (zawęź `--sad`/`--przepis`/`--haslo`) → wybierz ID → `orzeczenie <id>`
+→ w razie potrzeby skacz po `referencedCourtCases` do powołanych orzeczeń.
+
+## Zasady (ważne — dlaczego)
+
+1. **SAOS to baza WTÓRNA (agregat), nie źródło urzędowe.** Orzeczenia są jawne, ale do **dosłownego cytatu**
+   i pewności zweryfikuj w portalu właściwego sądu. Link `source.judgmentUrl` z SAOS dla **SN/TK/KIO jest
+   martwy albo ogólny** (sprawdzone 2026-08-23: `sn.pl/…/Baza_orzeczen` → 404, `otk.trybunal.gov.pl`
+   i `ftp.uzp.gov.pl` nieosiągalne) — silnik pokazuje go tylko jako „link z metadanych SAOS" i NIE jest to
+   ścieżka weryfikacji. Zamiast tego `orzeczenie` drukuje **źródło urzędowe**: dla SN wzorzec adresu PDF
+   `https://www.sn.pl/sites/orzecznictwo/Orzeczenia3/<SYGN z „/"→„-", spacje %20>.pdf` (np.
+   `II%20KK%2056-16.pdf`; zweryfikowany `curl -I` na II KK 56/16, I CSK 364/15, III CZP 17/15 — traktuj jako
+   wzorzec „sprawdź", nie gwarancję; uzasadnienie bywa pod `…-1.pdf`), dla TK wyszukiwarkę OTK
+   (`ipo.trybunal.gov.pl/ipo/`), dla KIO wyszukiwarkę UZP (`orzeczenia.uzp.gov.pl/Home/Search`). Linki
+   sądów powszechnych (`apiorzeczenia.*.sa.gov.pl`) działają. Zawsze podawaj **sygnaturę + sąd + datę**
+   (np. „wyrok SN z 9.04.2010, III CSK 203/09").
+2. **Brak sądów administracyjnych.** NSA/WSA są w SAOS praktycznie nieobecne (`--sad admin` zwykle zwraca 0).
+   Orzecznictwo administracyjne pobieraj skillem **prawo-pl-cbosa** (baza CBOSA, `scripts/cbosa.py`).
+3. **Zbiory SN, TK i KIO są ZAMKNIĘTE — granice DO DNIA, sprawdzone na żywo 2026-08-23** (najnowsze
+   orzeczenie w SAOS, sortowanie po dacie malejąco): **SN kończy się 22.06.2016** (III KK 195/16),
+   **TK 9.12.2015** (K 35/15, Ts 266/14), **KIO 6.09.2018** (KIO 1711/18); sądy powszechne idą na bieżąco.
+   Rocznik granicy NIE jest pokryty w całości: uchwała SN III CZP 81/16 z 8.12.2016 i wyrok KIO 2577/18
+   z 27.12.2018 istnieją, a w SAOS ich nie ma — dlatego silnik porównuje `--od/--do` z granicą do dnia,
+   `--strict` blokuje zakres sięgający poza nią (podpowiada `--do 2016-06-22` itd.), a `sygnatura` dla
+   numeru z rocznika granicy mówi „może być późniejsze niż koniec zbioru", nie „nie ma". Zero trafień
+   z nowszą datą NIE znaczy, że orzecznictwa nie ma. Nowsze bierz z portalu SN (`sn.pl/orzecznictwo`),
+   OTK (`ipo.trybunal.gov.pl`) albo UZP (`orzeczenia.uzp.gov.pl`) i oznacz jako źródło spoza SAOS.
+4. **Świeżość bywa opóźniona.** Najnowsze orzeczenia sądów powszechnych mogą jeszcze nie być w bazie — przy
+   sprawie na konkretną datę zaznacz „wg SAOS na dzień X — do potwierdzenia" i sprawdź portal sądu.
+5. **Nie myl orzeczenia z przepisem.** Po znalezieniu orzeczenia, brzmienie powołanego przepisu i jego
+   aktualność potwierdź w ELI (`prawo-pl-eli`) — orzeczenie mogło zapaść na starszym stanie prawnym.
+6. **Indeksy górne w numerach przepisów.** W tekstach **SN/TK/KIO SAOS spłaszcza indeksy górne**:
+   art. 417¹ k.c. → „art. 4171 k.c.", art. 398¹⁴ → „39814", art. 479⁴⁵ → „47945" (w surowym API nie ma
+   `<sup>`, więc silnik nie może tego odtworzyć — drukuje stałą notę „UWAGA: SAOS spłaszcza indeksy górne…").
+   **Nigdy nie cytuj „art. 4171 k.c."** — numerację sprawdź w źródle urzędowym albo w ELI. W tekstach
+   sądów powszechnych `<sup>` jest zachowane i silnik renderuje je w linii: `art. 556¹ § 1 k.c.`.
+7. **`--przepis` jest luźne, a lista „Powołane przepisy" niepełna.** Filtr `referencedRegulation` to
+   dopasowanie pełnotekstowe w polu powołanych przepisów (bez rozróżnienia aktu), a samo pole to automatyczna
+   ekstrakcja SAOS z lukami — trafienia przez `--przepis` traktuj jako kandydatów, nie jako „wszystkie
+   orzeczenia do art. X". Uzupełnij wyszukiwanie frazą (`szukaj "art. 415 k.c."`) i `--haslo`.
+8. Pełna lista endpointów i parametrów: `references/api.md`.
+
+## Czego ten skill NIE obejmuje
+
+- **treści przepisów** (ustawy/kodeksy → skill **prawo-pl-eli**, ELI Sejmu),
+- **prawa UE i orzecznictwa TSUE** (→ skill **prawo-eu-eurlex**, EUR-Lex/CELLAR),
+- **sądów administracyjnych** (NSA/WSA — w SAOS ich nie ma; → skill **prawo-pl-cbosa**),
+- **decyzji Prezesa UODO** (→ skill **prawo-pl-uodo**),
+- pism stron, akt sprawy, KRS, ksiąg wieczystych.
+Jeśli zagadnienie wymaga tych źródeł — powiedz to wprost, nie udawaj, że SAOS je pokryje.
+
+## Przykładowy przepływ
+
+Pytanie (przy analizie pozwu z art. 299 k.s.h.): „jak SN podchodzi do odpowiedzialności członka zarządu
+za zobowiązania spółki — znajdź orzecznictwo".
+1. (opcjonalnie) ELI: `tj DU 2000 1037` → brzmienie art. 299 k.s.h. (skill prawo-pl-eli).
+2. `szukaj "odpowiedzialność członka zarządu" --przepis "Kodeks spółek handlowych" --sad SN --limit 5`
+   → lista orzeczeń SN z sygnaturami i ID.
+3. `orzeczenie <id>` → teza/uzasadnienie + powołane przepisy + powołane orzeczenia (skok po linii orzeczniczej).
+4. W odpowiedzi: zacytuj tezę, podaj sygnaturę + sąd + datę, zaznacz „baza SAOS (wtórna) — do dosłownego
+   cytatu zweryfikuj w portalu sądu" (dla SN: wzorzec PDF z `orzeczenie`), a dla SN/TK/KIO nie przepisuj
+   spłaszczonych numerów przepisów (art. 4171 → art. 417¹) i pamiętaj, że zbiór SN kończy się 22.06.2016.

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/references/api.md
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/references/api.md
@@ -1,0 +1,111 @@
+# API SAOS — referencja endpointów
+
+Baza: `https://www.saos.org.pl/api`  ·  Dokumentacja: `https://www.saos.org.pl/help/index.php/dokumentacja-api`
+Wszystko **GET** (read-only), bez klucza i bez autoryzacji. SAOS to baza **wtórna** (agregat orzeczeń jawnych:
+SN, TK, sądy powszechne, KIO; sądy administracyjne — praktycznie brak). Dane: ICM UW / Fundacja ePaństwo.
+
+## Granice zbiorów (sprawdzone na żywo 2026-08-23)
+
+`/search/judgments?courtType=X&pageSize=1&sortingField=JUDGMENT_DATE&sortingDirection=DESC` → najnowsze orzeczenie:
+
+| courtType | najnowsze orzeczenie w SAOS | totalResults | nowsze orzeczenia |
+|---|---|---|---|
+| `SUPREME` (SN) | **2016-06-22** (III KK 195/16, id 245360) | 38 081 | sn.pl/orzecznictwo |
+| `CONSTITUTIONAL_TRIBUNAL` (TK) | **2015-12-09** (Ts 266/14, K 35/15) | 9 503 | ipo.trybunal.gov.pl |
+| `NATIONAL_APPEAL_CHAMBER` (KIO) | **2018-09-06** (KIO 1711/18, id 354890) | 22 168 | orzeczenia.uzp.gov.pl |
+| `COMMON` | na bieżąco (z opóźnieniem) | — | orzeczenia.ms.gov.pl |
+
+Zbiory SN/TK/KIO nie są zasilane od tych dat; rocznik granicy jest pokryty tylko **do dnia** (np. SN: brak
+uchwał III CZP 56/16 z 26.10.2016 i III CZP 81/16 z 8.12.2016, które istnieją na sn.pl). `saos.py` trzyma te
+daty w `ZASIEG`, porównuje `--od/--do` do dnia i przed blokadą `--strict` / przy zerze trafień potwierdza
+granicę tym samym zapytaniem (`_granica_zbioru`, cache w procesie).
+
+## Wydajność i okna serwisowe
+
+`/search/judgments` bywa bardzo wolne (40–60 s na zapytanie, stan z 2026-08-22/23); `/judgments/{id}` jest
+szybkie. W nocy SAOS zwraca HTTP 200 ze stroną HTML „Przerwa techniczna" zamiast JSON — helper traktuje to
+jako stan UNKNOWN (błąd, kod ≠ 0), nigdy jako zero trafień. Limit na żądanie w helperze: 90 s, 2 próby.
+
+## Endpointy
+
+| Ścieżka | Zwraca |
+|---|---|
+| `/search/judgments` | wyszukiwarka orzeczeń (parametry niżej) — zwraca `items[]` + `info.totalResults` |
+| `/judgments/{id}` | **pełne orzeczenie** (JSON pod kluczem `data`) |
+| `/dump/judgments` | zrzut masowy (zakres dat, paginacja) — do bulk, nie do pojedynczych zapytań |
+| `/dump/courts`, `/dump/commonCourts`, `/dump/scChambers` | słowniki sądów / izb SN |
+| `/dump/enrichments` | dane wzbogacające |
+
+## Parametry `/search/judgments` (z `queryTemplate` żywego API, 2026-06)
+
+Tekst/identyfikacja: `all` (pełnotekstowo), `legalBase`, `referencedRegulation` (powołany przepis/akt —
+**luźne dopasowanie pełnotekstowe** w polu `referencedRegulations`: `art. 415` zwraca orzeczenia do art. 415
+k.c., k.p.c. i k.p.k.; nawet `Kodeks cywilny art. 415` nie eliminuje innych aktów — sprawdź akt w
+`/judgments/{id}`), `lawJournalEntryCode` (`rok/pozycja`), `judgeName`, `caseNumber`, `keywords`.
+Sąd: `courtType` ∈ `COMMON | SUPREME | CONSTITUTIONAL_TRIBUNAL | NATIONAL_APPEAL_CHAMBER | ADMINISTRATIVE`;
+powszechne: `ccCourtType` (`APPEAL|REGIONAL|DISTRICT`), `ccCourtId/Code/Name`, `ccDivisionId/Code/Name`,
+`ccIncludeDependentCourtJudgments`; SN: `scPersonnelType`, `scJudgmentForm`, `scChamberId/Name`, `scDivisionId/Name`.
+Rodzaj: `judgmentTypes` ∈ `DECISION | RESOLUTION | SENTENCE | REGULATION | REASONS`.
+Daty: `judgmentDateFrom`, `judgmentDateTo` (`yyyy-MM-dd`).
+Paginacja/sort: `pageSize` (1–100), `pageNumber` (od 0), `sortingField`
+(`DATABASE_ID | JUDGMENT_DATE | REFERENCING_JUDGMENTS_COUNT | …`), `sortingDirection` (`ASC|DESC`).
+
+Mapowanie komend `saos.py` → parametry: `--sad`→`courtType`, `--sygnatura`→`caseNumber`,
+`--przepis`→`referencedRegulation`, `--sedzia`→`judgeName`, `--haslo`→`keywords`, `--typ`→`judgmentTypes`,
+`--od/--do`→`judgmentDateFrom/To`, `--limit`→`pageSize`, `--strona`→`pageNumber`.
+
+## Pole `items[]` (wynik wyszukiwania)
+
+`id`, `href`, `courtType`, `courtCases[].caseNumber`, `judgmentType`, `judgmentDate`,
+`judges[].name` (+`specialRoles`), `keywords[]`, `judgmentForm` (np. „wyrok SN"), `textContent`
+(snippet z podświetleniem `<em>`), `division` (zależne od sądu — niżej).
+
+## Pole `data` (pełne orzeczenie `/judgments/{id}`)
+
+`id`, `courtType`, `courtCases[]`, `judgmentType` (enum `SENTENCE|DECISION|RESOLUTION|REGULATION|REASONS`
+— helper tłumaczy na wyrok / postanowienie / uchwała / zarządzenie / uzasadnienie), `judgmentDate`, `judges[]`,
+`summary`, `textContent` (pełna treść), `legalBases[]`, **`referencedRegulations[]`** (`text` = gotowy opis
+aktu + powołane artykuły, oraz `journalTitle/journalYear/journalNo/journalEntry`), **`referencedCourtCases[]`**
+(`caseNumber`, `judgmentIds[]` = ID w SAOS do skoku, `generated`), `keywords[]`, `source` (`code`,
+`judgmentUrl`, `publicationDate`), `judgmentForm` (tylko SN, np. „wyrok SN"), `division`, `chambers[]`,
+`receiptDate`, `meansOfAppeal`, `judgmentResult`, `lowerCourtJudgments[]`.
+
+### Jakość danych (zweryfikowane 2026-08-22/23 wobec sn.pl / UZP / feedu sądów powszechnych)
+
+- **Indeksy górne.** W `textContent` SN/TK/KIO nie ma `<sup>` — numery są spłaszczone: art. 417¹ → „4171",
+  art. 398¹⁴ → „39814", art. 479⁴⁵ → „47945" (I CSK 364/15, III CZP 17/15 vs PDF na sn.pl). Nie da się tego
+  odtworzyć z API; helper drukuje stałą notę. Sądy powszechne mają `<sup>\n<!-- -->1</sup>` — helper renderuje
+  `art. 556¹ § 1 k.c.` (feed sądu: `art. 556<xSUPx>1</xSUPx>`).
+- **`referencedRegulations` jest niepełne i bywa uszkodzone.** KIO 1564/18 (id 354889): lista ma tylko k.p.k.
+  i Konstytucję, a ŻADNEGO przepisu Pzp z sentencji (art. 93 ust. 1 pkt 4, art. 7 ust. 1, art. 24 ust. 1 pkt 22).
+  Śmieci: `art. 4793647945` (= art. 479³⁶–479⁴⁵), `Dz. U. z 2015 r. Nr 0 poz. 184`, `art. 180 ust. 2oraz`,
+  `art. 194 ust. atakże`, `art. n`, przepisy Konstytucji przypisane Konwencji (K 35/15). Helper oznacza takie
+  wpisy „(wpis SAOS prawdopodobnie uszkodzony: …)".
+- **`source.judgmentUrl` dla SN/TK/KIO jest martwy lub ogólny:** SN → `http://www.sn.pl/orzecznictwo/SitePages/Baza_orzeczen`
+  (404, bez sygnatury), TK → `otk.trybunal.gov.pl/…/K_35_15.doc` (host nieosiągalny), KIO →
+  `ftp://ftp.uzp.gov.pl/KIO/Wyroki/2018_1564.pdf` (nieosiągalny). Działa: SN
+  `https://www.sn.pl/sites/orzecznictwo/Orzeczenia3/<SYGN, „/"→„-", spacje %20>.pdf` (HTTP 200 + application/pdf
+  dla II KK 56/16, I CSK 364/15, III CZP 17/15, III CZP 81/16; nieistniejąca sygnatura → 404), TK
+  `https://ipo.trybunal.gov.pl/ipo/`, KIO `https://orzeczenia.uzp.gov.pl/Home/Search`; sądy powszechne
+  `apiorzeczenia.*.sa.gov.pl/ncourt-api/judgement/details?id=…` (działa).
+- Anonimizacja i treść sądów powszechnych są zgodne z feedem sądu (I C 374/25: różnice tylko w numeracji list).
+
+### Pole `division` (opis sądu — różne kształty)
+
+- **Sądy powszechne (COMMON):** `division.court.name` (np. „Sąd Apelacyjny w Krakowie") + `division.name`
+  (wydział, np. „I Wydział Cywilny").
+- **SN (SUPREME):** w wyszukiwaniu `division.chambers[].name` (lista izb), w szczególe `division.chamber.name`
+  (jedna izba, np. „Izba Cywilna") + `division.name` (wydział).
+Helper `_court_label()` w `saos.py` obsługuje oba kształty.
+
+## Wskazówki
+
+- **Most z ELI:** najpierw ustal akt/artykuł w ELI (skill prawo-pl-eli), potem `--przepis "<nazwa aktu>"`
+  lub `lawJournalEntryCode` zawęża do orzeczeń powołujących ten przepis.
+- `textContent` w wynikach to fragment z `<em>…</em>` wokół trafienia; helper czyści HTML do tekstu.
+- **Sądy administracyjne**: `courtType=ADMINISTRATIVE` zwykle zwraca `totalResults: 0` — użyj skilla
+  **prawo-pl-cbosa** (baza CBOSA, `https://orzeczenia.nsa.gov.pl`).
+- Do dosłownego cytatu w piśmie/sądzie korzystaj ze źródła urzędowego, bo SAOS to agregat: dla sądów
+  powszechnych `source.judgmentUrl`, dla SN wzorzec PDF na sn.pl, dla TK/KIO wyszukiwarki OTK/UZP (wyżej) —
+  `source.judgmentUrl` dla SN/TK/KIO nie działa.
+- Licencja danych: orzeczenia jawne, udostępniane publicznie; przy reużyciu podawaj źródło (SAOS) i sygnaturę.

--- a/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
+++ b/plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py
@@ -1,0 +1,840 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do PUBLICZNEGO API SAOS (System Analizy Orzeczeń Sądowych, https://www.saos.org.pl/api).
+Tylko biblioteka standardowa Pythona (urllib/json/re) — brak zależności pip.
+Operacje WYŁĄCZNIE read-only (GET).
+
+SAOS to baza WTÓRNA orzecznictwa polskiego (agregat orzeczeń jawnych): Sąd Najwyższy (SN),
+Trybunał Konstytucyjny (TK), sądy powszechne (SA/SO/SR) i Krajowa Izba Odwoławcza (KIO).
+Sądy administracyjne (NSA/WSA) są w SAOS praktycznie nieobecne — dla nich użyj skilla
+prawo-pl-cbosa (baza CBOSA, https://orzeczenia.nsa.gov.pl). Treść przepisów bierz z ELI
+(skill prawo-pl-eli), nie z SAOS — tu szukasz, JAK sądy stosują przepisy.
+
+Komendy:
+  szukaj ["<fraza>"] [--sad SN|TK|powszechne|admin|KIO] [--sygnatura S] [--przepis P]
+         [--sedzia N] [--haslo H] [--typ wyrok|postanowienie|uchwala|zarzadzenie|uzasadnienie]
+         [--od RRRR-MM-DD] [--do RRRR-MM-DD] [--limit N] [--strona N]
+  orzeczenie <id> [--fragment "<fraza>"]   pełne orzeczenie: metadane, powołane przepisy/orzeczenia, treść
+  sygnatura <sygnatura...>                  znajdź orzeczenie po numerze sprawy (caseNumber)
+Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
+"""
+import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
+from html.parser import HTMLParser
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+BASE = "https://www.saos.org.pl/api"
+CONTENT_HOSTS = ("saos.org.pl",)
+
+
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści SAOS, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
+
+# Aliasy typów sądów (courtType w API SAOS)
+SADY = {
+    "SN": "SUPREME", "SUPREME": "SUPREME",
+    "TK": "CONSTITUTIONAL_TRIBUNAL", "TRYBUNAŁ": "CONSTITUTIONAL_TRIBUNAL",
+    "TRYBUNAL": "CONSTITUTIONAL_TRIBUNAL", "CONSTITUTIONAL_TRIBUNAL": "CONSTITUTIONAL_TRIBUNAL",
+    "POWSZECHNE": "COMMON", "POWSZECHNY": "COMMON", "COMMON": "COMMON",
+    "SA": "COMMON", "SO": "COMMON", "SR": "COMMON",
+    "ADMIN": "ADMINISTRATIVE", "ADMINISTRACYJNE": "ADMINISTRATIVE",
+    "NSA": "ADMINISTRATIVE", "WSA": "ADMINISTRATIVE", "ADMINISTRATIVE": "ADMINISTRATIVE",
+    "KIO": "NATIONAL_APPEAL_CHAMBER", "NATIONAL_APPEAL_CHAMBER": "NATIONAL_APPEAL_CHAMBER",
+}
+# Aliasy typów orzeczeń (judgmentTypes w API SAOS)
+TYPY = {
+    "WYROK": "SENTENCE", "SENTENCE": "SENTENCE",
+    "POSTANOWIENIE": "DECISION", "DECISION": "DECISION",
+    "UCHWAŁA": "RESOLUTION", "UCHWALA": "RESOLUTION", "RESOLUTION": "RESOLUTION",
+    "ZARZĄDZENIE": "REGULATION", "ZARZADZENIE": "REGULATION", "REGULATION": "REGULATION",
+    "UZASADNIENIE": "REASONS", "REASONS": "REASONS",
+}
+# Czytelne nazwy typów sądów
+CT_PL = {
+    "SUPREME": "Sąd Najwyższy", "CONSTITUTIONAL_TRIBUNAL": "Trybunał Konstytucyjny",
+    "COMMON": "sąd powszechny", "ADMINISTRATIVE": "sąd administracyjny",
+    "NATIONAL_APPEAL_CHAMBER": "Krajowa Izba Odwoławcza",
+}
+# Czytelne nazwy typów orzeczeń (judgmentType w API SAOS) — API zwraca surowy enum
+TYPY_PL = {
+    "SENTENCE": "wyrok", "DECISION": "postanowienie", "RESOLUTION": "uchwała",
+    "REGULATION": "zarządzenie", "REASONS": "uzasadnienie",
+}
+# SAOS jest bazą WTÓRNĄ i część zbiorów przestała być zasilana. Bez tej informacji zero trafień
+# z nowszą datą wygląda jak „nie ma takiego orzecznictwa" — a to najgroźniejszy fałszywy negatyw
+# w pracy prawnika. Granica = data NAJNOWSZEGO orzeczenia danego sądu w SAOS (sortowanie po dacie
+# malejąco), sprawdzona na żywo 2026-08-23; porównujemy z DOKŁADNOŚCIĄ DO DNIA, bo np. uchwały SN
+# z II półrocza 2016 r. (III CZP 81/16 z 8.12.2016) istnieją, a w SAOS ich nie ma. Sądy powszechne
+# są zasilane na bieżąco, więc ich tu nie ma. Silnik dodatkowo potwierdza granicę na żywo
+# (_granica_zbioru), gdy ma zablokować albo wyjaśnić zero wyników — gdyby SAOS wznowił zasilanie.
+ZASIEG = {
+    "SUPREME": ("2016-06-22", "nowsze orzeczenia SN: portal SN (www.sn.pl/orzecznictwo) "
+                              "albo Baza Orzeczeń SN"),
+    "CONSTITUTIONAL_TRIBUNAL": ("2015-12-09", "nowsze orzeczenia TK: OTK (ipo.trybunal.gov.pl)"),
+    "NATIONAL_APPEAL_CHAMBER": ("2018-09-06", "nowsze orzeczenia KIO: UZP "
+                                              "(orzeczenia.uzp.gov.pl)"),
+}
+_granice_na_zywo = {}  # courtType -> data najnowszego orzeczenia wg API (cache tylko w procesie)
+
+
+def _data_pl(iso):
+    """'2016-06-22' → '22.06.2016' (format dat w polskich pismach)."""
+    if iso and re.match(r"^\d{4}-\d{2}-\d{2}$", iso):
+        return f"{iso[8:10]}.{iso[5:7]}.{iso[:4]}"
+    return iso or "?"
+
+
+def _norma_data(d, koniec=False):
+    """Normalizuje datę z CLI do RRRR-MM-DD (RRRR → 1 stycznia / 31 grudnia; RRRR-MM → 1./ostatni dzień).
+
+    Dzięki temu granice zbiorów porównujemy po prostu leksykograficznie (ISO 8601).
+    """
+    if d is None:
+        return None
+    d = d.strip()
+    if re.match(r"^\d{4}$", d):
+        return f"{d}-12-31" if koniec else f"{d}-01-01"
+    if re.match(r"^\d{4}-\d{2}$", d):
+        if not koniec:
+            return f"{d}-01"
+        rok, mies = int(d[:4]), int(d[5:7])
+        dni = 29 if mies == 2 and (rok % 4 == 0 and (rok % 100 != 0 or rok % 400 == 0)) else \
+            [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][mies - 1]
+        return f"{d}-{dni:02d}"
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", d):
+        sys.exit(f"BŁĄD: data {d!r} ma zły format — użyj RRRR-MM-DD (albo RRRR / RRRR-MM).")
+    return d
+
+
+def _granica_zbioru(ct):
+    """Koniec zamkniętego zbioru: znana data z ZASIEG, potwierdzona na żywo (najnowsze orzeczenie).
+
+    Zwraca (data_ISO, potwierdzona_na_zywo: bool). Jedno tanie zapytanie (pageSize=1, sort po dacie
+    malejąco) na proces; przy awarii transportu lub przerwie technicznej zostaje znana granica.
+    Gdyby SAOS wznowił zasilanie, granica na żywo będzie późniejsza od znanej i to ona obowiązuje.
+    """
+    znana = ZASIEG[ct][0]
+    if ct in _granice_na_zywo:
+        zywa = _granice_na_zywo[ct]
+        return (max(znana, zywa), True) if zywa else (znana, False)
+    zywa = None
+    try:
+        d = _get("/search/judgments", {"courtType": ct, "pageSize": 1, "pageNumber": 0,
+                                       "sortingField": "JUDGMENT_DATE",
+                                       "sortingDirection": "DESC"}, soft=True)
+        items = d.get("items") if isinstance(d, dict) else None
+        if isinstance(items, list) and items and re.match(r"^\d{4}-\d{2}-\d{2}$",
+                                                           str(items[0].get("judgmentDate", ""))):
+            zywa = items[0]["judgmentDate"]
+    except VerificationUnknown:
+        zywa = None
+    _granice_na_zywo[ct] = zywa
+    return (max(znana, zywa), True) if zywa else (znana, False)
+
+
+def _granica_znana(ct, items=()):
+    """Granica zbioru bez zapytania: cache z potwierdzenia na żywo albo stała; a jeśli wśród wyników
+    (posortowanych po dacie malejąco) jest orzeczenie PÓŹNIEJSZE niż granica, to ona się przesuwa —
+    wynik wyszukiwania sam dowodzi, że SAOS wznowił zasilanie."""
+    granica, potwierdzona = ZASIEG[ct][0], False
+    zywa = _granice_na_zywo.get(ct)
+    if zywa:
+        granica, potwierdzona = max(granica, zywa), True
+    daty = [str(it.get("judgmentDate") or "") for it in items if isinstance(it, dict)]
+    daty = [d for d in daty if re.match(r"^\d{4}-\d{2}-\d{2}$", d) and d > granica]
+    if daty:
+        granica, potwierdzona = max(daty), True
+        _granice_na_zywo[ct] = granica
+    return granica, potwierdzona
+
+
+def _ostrzezenie_zasiegu(ct, od=None, do=None, granica=None, potwierdzona=False):
+    """Komunikat o granicy zbioru dla typu sądu (None = zbiór zasilany na bieżąco).
+
+    Porównania z dokładnością do DNIA: zakres zaczynający się po granicy jest cały poza zbiorem;
+    zakres sięgający poza granicę (albo bez --do) ma w SAOS tylko część sprzed granicy.
+    """
+    wpis = ZASIEG.get(ct or "")
+    if not wpis:
+        return None
+    gdzie = wpis[1]
+    granica = granica or wpis[0]
+    jak = "potwierdzone na żywo: najnowsze orzeczenie w SAOS" if potwierdzona \
+        else "data najnowszego orzeczenia w SAOS, sprawdzona 2026-08-23"
+    tekst = (f"UWAGA: w SAOS {CT_PL.get(ct, ct)} kończy się DOKŁADNIE na {_data_pl(granica)} ({jak}) — "
+             f"ten zbiór nie jest już zasilany. Brak nowszych trafień to NIE brak orzecznictwa; {gdzie}.")
+    od, do = _norma_data(od), _norma_data(do, koniec=True)
+    if od and od > granica:
+        tekst += (f"\n     Twój zakres zaczyna się {_data_pl(od)}, czyli POZA zbiorem — stąd zero wyników; "
+                  f"orzeczenia z tego okresu istnieją, ale nie w SAOS.")
+    elif do is None or do > granica:
+        koniec = "nie ma górnej granicy" if do is None else f"sięga {_data_pl(do)}"
+        tekst += (f"\n     Twój zakres {koniec} — po {_data_pl(granica)} SAOS nie ma NIC; "
+                  f"orzeczenia z okresu po tej dacie sprawdź w źródle urzędowym.")
+    return tekst
+
+
+def _sprawdz_zasieg_strict(a, ct):
+    """Blokuje zakres sięgający poza znany koniec zamkniętego zbioru SAOS (porównanie do DNIA)."""
+    if not getattr(a, "strict", False) or ct not in ZASIEG:
+        return
+    od, do = _norma_data(getattr(a, "od", None)), _norma_data(a.do, koniec=True)
+    if do is not None and do <= ZASIEG[ct][0]:
+        return
+    # zakres wychodzi poza znaną granicę — zanim zablokujemy, potwierdź granicę na żywo
+    # (gdyby SAOS wznowił zasilanie, granica przesunie się i zakres może być w zbiorze)
+    granica, potwierdzona = _granica_zbioru(ct)
+    if do is not None and do <= granica:
+        return
+    gdzie = ZASIEG[ct][1]
+    # blokada jest DETERMINISTYCZNA (znana granica zbioru), nie awarią transportu —
+    # komunikat nie może sugerować ponowienia, tylko jak zawęzić zakres albo gdzie szukać
+    if od and od > granica:
+        zakres, rada = f"zaczyna się {_data_pl(od)}", gdzie
+    else:
+        zakres = "nie ma górnej granicy" if do is None else f"sięga {_data_pl(do)}"
+        rada = f"zawęź zakres: --do {granica}; {gdzie}"
+    jak = "granica potwierdzona na żywo" if potwierdzona \
+        else "nie udało się potwierdzić granicy na żywo — przyjęto znaną z 2026-08-23"
+    sys.exit(f"BŁĄD: zbiór {CT_PL.get(ct, ct)} w SAOS kończy się na orzeczeniu z {_data_pl(granica)} "
+             f"({jak}), a żądany zakres {zakres} — tryb strict nie zwróci wyniku, którego "
+             f"kompletności nie da się zweryfikować. {rada[0].upper() + rada[1:]}.")
+
+
+def _get(path, params=None, soft=False):
+    """GET z jednym ponowieniem (limit 90 s na żądanie — /search/judgments bywa bardzo wolny).
+
+    Zwraca dane, w tym pusty wynik jako VERIFIED_ABSENT. Przy soft=True błąd
+    żądania ma osobny stan UNKNOWN (VerificationUnknown), nigdy None/pusty wynik.
+    Przekroczenie czasu to „BŁĄD sieci" (kod ≠ 0) — nigdy fałszywe zero trafień.
+    """
+    url = BASE + path
+    if params:
+        q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "", False)})
+        if q:
+            url += "?" + q
+    req = urllib.request.Request(url, headers={"User-Agent": f"saos-skill/{__version__}", "Accept": "application/json"})
+    raw = None
+    for attempt in (1, 2):
+        try:
+            with _opener.open(req, timeout=90) as r:
+                raw = r.read().decode("utf-8", "replace")
+            if "Przerwa techniczna" in raw:
+                # SAOS bywa w oknie serwisowym — zwraca stronę HTML zamiast JSON (HTTP 200)
+                if attempt == 1:
+                    time.sleep(2); continue
+                if soft:
+                    raise VerificationUnknown("SAOS ma przerwę techniczną")
+                sys.exit("BŁĄD: SAOS ma przerwę techniczną (serwis chwilowo niedostępny) — spróbuj ponownie później.")
+            break
+        except urllib.error.HTTPError as e:
+            if e.code >= 500 and attempt == 1:
+                time.sleep(2); continue
+            if soft:
+                raise VerificationUnknown(f"HTTP {e.code}: {url}") from e
+            if e.code == 404:
+                sys.exit(f"BŁĄD HTTP 404 (nie znaleziono): {url}")
+            sys.exit(f"BŁĄD HTTP {e.code}: {url}")
+        except Exception as e:
+            if attempt == 1:
+                time.sleep(2); continue
+            if soft:
+                raise VerificationUnknown(f"błąd sieci: {url} ({e})") from e
+            sys.exit(f"BŁĄD sieci: {url} ({e})")
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+
+def _expect_dict(d, what):
+    if not isinstance(d, dict):
+        sys.exit(f"BŁĄD: nie udało się zweryfikować {what}, ponieważ API SAOS zwróciło "
+                 "nieoczekiwaną odpowiedź. Spróbuj ponownie za chwilę.")
+    return d
+
+
+def _expect_search(d, what):
+    d = _expect_dict(d, what)
+    info = d.get("info")
+    if not isinstance(d.get("items"), list) or not isinstance(info, dict) \
+            or "totalResults" not in info:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować {what}, ponieważ odpowiedź API SAOS "
+                 "nie zawiera kompletnego wyniku wyszukiwania. Spróbuj ponownie za chwilę.")
+    return d
+
+
+def _expect_judgment(d, judgment_id):
+    d = _expect_dict(d, f"orzeczenia {judgment_id}")
+    data = d.get("data", d)
+    if not isinstance(data, dict) or data.get("id") is None:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować orzeczenia {judgment_id}, ponieważ odpowiedź "
+                 "API SAOS nie zawiera danych orzeczenia. Spróbuj ponownie za chwilę.")
+    return d
+
+
+_INDEKS_GORNY = str.maketrans("0123456789+-=()", "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾")
+_INLINE = ("sup", "sub", "em", "strong", "b", "i", "u", "a", "span", "font")
+
+
+def _indeks_gorny(tekst):
+    """Treść <sup> → indeks górny w Unicode, w jednej linii: 'art. 556<sup>1</sup>' → 'art. 556¹'.
+
+    W tekstach sądów powszechnych SAOS wstawia do <sup> łamanie linii i komentarz
+    (`<sup>\n<!-- -->1</sup>`), co bez tej obsługi rozbija numer przepisu na dwie linie.
+    """
+    rdzen = tekst.strip()
+    koncowka = " " if tekst and tekst[-1].isspace() and rdzen else ""
+    return rdzen.translate(_INDEKS_GORNY) + koncowka
+
+
+class _Stripper(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.out, self.skip, self.sup, self.po_inline = [], 0, None, False
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style"):
+            self.skip += 1
+        if tag in ("p", "br", "div", "tr", "li", "h1", "h2", "h3", "h4"):
+            self.out.append("\n")
+        if tag == "sup" and not self.skip:
+            self.sup = []
+        self.po_inline = tag in _INLINE
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style") and self.skip:
+            self.skip -= 1
+        if tag == "sup" and self.sup is not None:
+            self.out.append(_indeks_gorny("".join(self.sup)))
+            self.sup = None
+        self.po_inline = False
+
+    def handle_data(self, data):
+        if self.skip:
+            return
+        if self.po_inline:
+            # SAOS wstawia „\n<!-- -->” tuż za znacznikiem inline (<em>, <sup>, <a>) — to artefakt,
+            # nie koniec akapitu
+            data = data.lstrip("\n")
+            self.po_inline = False
+        if self.sup is not None:
+            self.sup.append(data)
+        else:
+            self.out.append(data)
+
+
+def html_to_text(html):
+    """HTML/snippet → czysty tekst. SAOS używa m.in. <em> w podświetleniach i twardych spacji (NBSP);
+    <sup> (indeksy górne numerów przepisów) trafia do tekstu jako cyfry w indeksie górnym (art. 556¹)."""
+    p = _Stripper()
+    p.feed(html)
+    t = "".join(p.out).replace("\xa0", " ")
+    t = re.sub(r"[ \t]+", " ", t)
+    t = re.sub(r"\n[ \t]+", "\n", t)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return t.strip()
+
+
+def _fragmenty(txt, fraza, maks=6, okno=600):
+    """Okna tekstu wokół wystąpień frazy (bez rozróżniania wielkości liter).
+
+    Uzasadnienia bywają wielostronicowe i nie mają jednostek redakcyjnych jak ustawy —
+    dlatego pokazujemy kontekst wokół trafień, a nie całe „artykuły".
+    """
+    low, f = txt.lower(), fraza.lower().strip()
+    if not f:
+        return []
+    spans, p = [], low.find(f)
+    while p != -1 and len(spans) < maks:
+        start = _do_granicy(txt, max(0, p - okno // 3), p, poczatek=True)
+        end = _do_granicy(txt, min(len(txt), p + len(f) + okno), p + len(f), poczatek=False)
+        if spans and start <= spans[-1][1]:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], end))
+        else:
+            spans.append((start, end))
+        p = low.find(f, p + len(f))
+    return spans
+
+
+# koniec zdania: kropka/!/? + biały znak + wielka litera; NIE po skrótach prawniczych („art. 535",
+# „ust. 2", „poz. 93", „2016 r. Sąd", inicjałach „M. B." ani po „k.c."/„k.p.c.")
+_KONIEC_ZDANIA = re.compile(
+    r"(?<![A-ZĄĆĘŁŃÓŚŹŻ])(?<!\.[a-z])(?<!\bart)(?<!\bust)(?<!\bpoz)(?<!\bzob)(?<!\bnp)(?<!\bpor)"
+    r"(?<!\bsygn)(?<!\btj)(?<!\bpkt)(?<!\blit)(?<!\bNr)(?<!\bnr)(?<!\br)(?<!\bs)(?<!\bt)(?<!\bz)"
+    r"(?<!\bm\.in)(?<!\bitp)(?<!\bitd)(?<!\bwyd)(?<!\bred)(?<!\bop)(?<!\bcyt)"
+    r"[.!?…]\s+(?=[A-ZĄĆĘŁŃÓŚŹŻ„(])")
+
+
+def _do_granicy(txt, poz, granica_trafienia, poczatek, margines=120):
+    """Dosuwa brzeg okna do granicy zdania (w zasięgu `margines`), a w braku — do granicy słowa.
+
+    Okno nigdy nie wchodzi w trafienie (`granica_trafienia`); gdy w tekście nie ma żadnej
+    spacji w zasięgu (np. sztuczny ciąg znaków), zostaje surowy offset.
+    """
+    if poczatek:
+        if poz == 0:
+            return 0
+        lo = max(0, poz - margines)
+        zdania = [m.end() for m in _KONIEC_ZDANIA.finditer(txt, lo, min(len(txt), poz + margines))
+                  if m.end() <= granica_trafienia]
+        if zdania:
+            return min(zdania, key=lambda e: abs(e - poz))
+        nl = txt.rfind("\n", lo, poz)
+        if nl != -1:
+            return nl + 1
+        if txt[poz - 1].isspace():
+            return poz
+        sp = txt.find(" ", poz, granica_trafienia)
+        return sp + 1 if sp != -1 else poz
+    if poz >= len(txt):
+        return len(txt)
+    hi = min(len(txt), poz + margines)
+    zdania = [m.start() + 1 for m in _KONIEC_ZDANIA.finditer(txt, max(0, poz - margines), hi)
+              if m.start() + 1 >= granica_trafienia]
+    if zdania:
+        return min(zdania, key=lambda e: abs(e - poz))
+    nl = txt.find("\n", poz, hi)
+    if nl != -1:
+        return nl
+    if txt[poz].isspace() or txt[poz - 1].isspace():
+        return poz
+    sp = txt.rfind(" ", granica_trafienia, poz)
+    return sp if sp != -1 else poz
+
+
+def _court_type(s):
+    if not s:
+        return None
+    ct = SADY.get(s.strip().upper())
+    if not ct:
+        sys.exit(f"Nieznany sąd: {s!r}. Użyj: SN, TK, powszechne, admin, KIO.")
+    return ct
+
+
+def _jtype(s):
+    if not s:
+        return None
+    t = TYPY.get(s.strip().upper())
+    if not t:
+        sys.exit(f"Nieznany typ orzeczenia: {s!r}. Użyj: wyrok, postanowienie, uchwala, zarzadzenie, uzasadnienie.")
+    return t
+
+
+def _court_label(it):
+    """Czytelny opis sądu/izby z pola division (zależny od rodzaju sądu)."""
+    div = it.get("division") or {}
+    court = div.get("court") or {}
+    if court.get("name"):  # sądy powszechne: nazwa sądu + wydział
+        parts = [court["name"]]
+        if div.get("name"):
+            parts.append(div["name"])
+        return ", ".join(parts)
+    # SN: izby — w wyszukiwaniu pole 'chambers' (lista), w szczególe 'chamber' (jeden)
+    ch = div.get("chamber") or {}
+    chambers = div.get("chambers") or ([ch] if ch.get("name") else [])
+    names = [c.get("name") for c in chambers if c.get("name")]
+    if names:
+        return ", ".join(names)
+    return div.get("name") or ""
+
+
+def _case_numbers(it):
+    return ", ".join(c.get("caseNumber", "") for c in (it.get("courtCases") or []) if c.get("caseNumber"))
+
+
+def _judges(it, maks=3):
+    js = [j.get("name") for j in (it.get("judges") or []) if j.get("name")]
+    extra = f" (+{len(js) - maks})" if len(js) > maks else ""
+    return ", ".join(js[:maks]) + extra
+
+
+def _forma(it):
+    """Typ orzeczenia po polsku (wyrok / postanowienie / uchwała / zarządzenie / uzasadnienie).
+
+    API zwraca surowy enum `judgmentType` (SENTENCE…) dla każdego sądu; `judgmentForm` (w /search
+    string 'wyrok SN', w /judgments/{id} obiekt {'name': …}) ma tylko SN i bywa dokładniejszy
+    ('uchwała składu 7 sędziów SN') — wtedy dopisujemy go w nawiasie.
+    """
+    typ = it.get("judgmentType") or ""
+    typ_pl = TYPY_PL.get(typ, typ)
+    f = it.get("judgmentForm")
+    if isinstance(f, dict):
+        f = f.get("name")
+    if f and f.strip().lower() not in ("", typ_pl.lower()):
+        return f"{typ_pl} ({f.strip()})" if typ_pl else f.strip()
+    return typ_pl
+
+
+# Wpisy „Powołane przepisy" to automatyczna ekstrakcja SAOS — bywa uszkodzona: 'Nr 0' (brak numeru
+# Dz.U.), spłaszczone indeksy górne sklejone w jeden numer (art. 479³⁶–479⁴⁵ → 'art. 4793647945'),
+# sklejone słowa ('art. 2oraz', 'ust. atakże'), 'art. n'.
+_USZKODZONY_WPIS = (
+    (re.compile(r"\bart\. ?\d{5,}"), "sklejony numer artykułu (spłaszczone indeksy górne)"),
+    (re.compile(r"\b(?:art|ust|pkt|lit)\. ?\d+[a-ząćęłńóśźż]{2,}|\b(?:ust|pkt)\. ?[a-ząćęłńóśźż]{2,}\b"),
+     "sklejone słowa"),
+    (re.compile(r"\bart\. n\b"), "„art. n” zamiast numeru"),
+    (re.compile(r"\bNr 0\b"), "„Nr 0” zamiast publikatora"),
+)
+
+
+def _wpis_przepisu(r):
+    """Tekst wpisu z referencedRegulations + ostrzeżenie (z powodem), gdy wpis wygląda na uszkodzony."""
+    tekst = r.get("text") or r.get("journalTitle", "") or ""
+    powody = [opis for wzor, opis in _USZKODZONY_WPIS if wzor.search(tekst)]
+    if powody:
+        tekst += f"   (wpis SAOS prawdopodobnie uszkodzony: {', '.join(powody)} — zweryfikuj w treści orzeczenia)"
+    return tekst
+
+
+UWAGA_INDEKSY = ("UWAGA: SAOS spłaszcza indeksy górne w tekstach SN/TK/KIO (art. 417¹ → 4171) — "
+                 "numerację przepisów weryfikuj w źródle")
+
+
+def _zrodla_urzedowe(data):
+    """Linki do weryfikacji w źródle urzędowym.
+
+    `source.judgmentUrl` z SAOS dla SN/TK/KIO jest martwy albo ogólny (sprawdzone 2026-08-23:
+    sn.pl/…/Baza_orzeczen → 404, otk.trybunal.gov.pl i ftp.uzp.gov.pl nieosiągalne), więc NIE
+    jest ścieżką weryfikacji. Dla SN działa wzorzec adresu PDF (zweryfikowany curl -I na
+    II KK 56/16, I CSK 364/15, III CZP 17/15): sygnatura z '/'→'-' i spacjami %20; dla TK i KIO
+    wyszukiwarki OTK / UZP. Linki sądów powszechnych (apiorzeczenia.*.sa.gov.pl) działają.
+    """
+    ct = data.get("courtType", "")
+    cn = next((c.get("caseNumber") for c in (data.get("courtCases") or []) if c.get("caseNumber")), "")
+    src = (data.get("source") or {}).get("judgmentUrl")
+    linie = []
+    if ct == "SUPREME" and cn:
+        pdf = urllib.parse.quote(cn.replace("/", "-"), safe="")
+        linie.append(f"  Źródło urzędowe: https://www.sn.pl/sites/orzecznictwo/Orzeczenia3/{pdf}.pdf"
+                     "  (sprawdź — wzorzec adresu; bywa też z przyrostkiem -1.pdf dla uzasadnienia)")
+    elif ct == "CONSTITUTIONAL_TRIBUNAL":
+        linie.append(f"  Źródło urzędowe: https://ipo.trybunal.gov.pl/ipo/  (wyszukaj sygnaturę {cn or '?'})")
+    elif ct == "NATIONAL_APPEAL_CHAMBER":
+        linie.append(f"  Źródło urzędowe: https://orzeczenia.uzp.gov.pl/Home/Search  (wyszukaj sygnaturę {cn or '?'})")
+    if src:
+        if ct in ZASIEG:
+            linie.append(f"  Link z metadanych SAOS (dla SN/TK/KIO zwykle martwy lub ogólny — nie służy "
+                         f"do weryfikacji): {src}")
+        else:
+            linie.append(f"  Źródło oryginalne: {src}")
+    return linie
+
+
+_SYGN_TK = re.compile(r"^(?:K|Kp|Kpt|P|Pp|SK|U|Tw|Ts|Tp|S|W|M)\s*\d+/\d{2}$", re.I)
+_SYGN_KIO = re.compile(r"^KIO(?:/(?:KU|KD|UZP|W))?\s*\d+/\d{2}$", re.I)
+# symbole SN (repertoria): CSK/CZP/CZ/CO/CNP/CSKP, KK/KZP/KZ/KO/KSK, PK/PZP/PO, UK/UZP/UO, BU/BP, SNO/SDI…
+_SYGN_SN = re.compile(r"^(?:I|II|III|IV|V|VI|VII)\s+(?:C[A-Z]{1,3}|K[A-Z]{1,3}|P[A-Z]{1,3}|U[A-Z]{1,3}|"
+                      r"B[A-Z]{1,2}|S[DN][A-Z]?)\s*\d+/\d{2,4}$")
+
+
+def _sady_dla_sygnatury(sig):
+    """Zgaduje zamknięty zbiór po kształcie sygnatury (KIO…, K 35/15 → TK, III CZP 81/16 → SN)."""
+    sig = sig.strip()
+    if _SYGN_KIO.match(sig):
+        return ["NATIONAL_APPEAL_CHAMBER"]
+    if _SYGN_TK.match(sig):
+        return ["CONSTITUTIONAL_TRIBUNAL"]
+    if _SYGN_SN.match(sig):
+        return ["SUPREME"]
+    return list(ZASIEG)
+
+
+def _rok_sygnatury(sig):
+    m = re.search(r"/(\d{2,4})\s*$", sig.strip())
+    if not m:
+        return None
+    r = int(m.group(1))
+    return r if r >= 1000 else (1900 + r if r >= 50 else 2000 + r)
+
+
+def _wyjasnienie_zera_sygnatury(sig):
+    """Dlaczego SAOS może nie mieć tej sygnatury — z granicą zbioru podaną do DNIA.
+
+    Sygnatura z rocznika granicy (III CZP 81/16 z 8.12.2016 przy końcu zbioru SN 22.06.2016)
+    NIE może dostać „nie ma" — tylko „może być późniejsze niż koniec zbioru".
+    """
+    rok = _rok_sygnatury(sig)
+    sady = _sady_dla_sygnatury(sig)
+    rozpoznany = len(sady) == 1
+    linie = []
+    if not rozpoznany:
+        linie.append("sąd powszechny (sygnatura nierozpoznana jako SN/TK/KIO): zbiór zasilany na bieżąco, "
+                     "ale z opóźnieniem i lukami — sprawdź portal orzeczeń sądów powszechnych "
+                     "(orzeczenia.ms.gov.pl)")
+    for ct in sady:
+        granica = ZASIEG[ct][0]
+        nazwa, gdzie = CT_PL[ct], ZASIEG[ct][1]
+        if not rozpoznany:
+            nazwa = "jeśli to " + nazwa
+        if rok is None:
+            linie.append(f"{nazwa}: zbiór kończy się na {_data_pl(granica)} — {gdzie}")
+        elif rok > int(granica[:4]):
+            linie.append(f"{nazwa}: zbiór kończy się na {_data_pl(granica)}, a sygnatura jest z {rok} r. — "
+                         f"SAOS tego orzeczenia NIE MA z założenia; {gdzie}")
+        elif rok == int(granica[:4]):
+            linie.append(f"{nazwa}: zbiór kończy się na {_data_pl(granica)}, a sygnatura jest z {rok} r. — "
+                         f"orzeczenie może być późniejsze niż koniec zbioru {_data_pl(granica)}; {gdzie}")
+        else:
+            linie.append(f"{nazwa}: rocznik {rok} mieści się w zbiorze (do {_data_pl(granica)}), "
+                         f"ale SAOS to agregat z lukami — {gdzie}")
+    return linie
+
+
+def _wiersz(it):
+    """Jedna pozycja listy wyników (id, sygnatura, sąd, data, forma, hasła, snippet)."""
+    cn = _case_numbers(it) or "—"
+    ctype = CT_PL.get(it.get("courtType", ""), it.get("courtType", ""))
+    court = _court_label(it)
+    forma = _forma(it)
+    print(f"  [{it.get('id')}]  {cn}   ({it.get('judgmentDate', '?')})")
+    drugi = f"    {ctype}" + (f" — {court}" if court else "")
+    if forma:
+        drugi += f"  · {forma}"
+    print(drugi)
+    kw = it.get("keywords") or []
+    if kw:
+        print(f"    hasła: {', '.join(kw)}")
+    snip = html_to_text(it.get("textContent") or "")
+    if snip:
+        snip = snip.replace("\n", " ")
+        print(f"    …{snip[:200].strip()}…")
+    print(f"    → orzeczenie {it.get('id')}")
+    print()
+
+
+def cmd_szukaj(a):
+    ct = _court_type(a.sad)
+    _sprawdz_zasieg_strict(a, ct)
+    params = {
+        "all": a.fraza,
+        "caseNumber": a.sygnatura,
+        "referencedRegulation": a.przepis,
+        "judgeName": a.sedzia,
+        "keywords": a.haslo,
+        "courtType": ct,
+        "judgmentTypes": _jtype(a.typ),
+        "judgmentDateFrom": _norma_data(a.od),
+        "judgmentDateTo": _norma_data(a.do, koniec=True),
+        "pageSize": max(1, min(a.limit, 100)),
+        "pageNumber": max(0, a.strona),
+        "sortingField": "JUDGMENT_DATE",
+        "sortingDirection": "DESC",
+    }
+    kryteria = any(params.get(k) for k in
+                   ("all", "caseNumber", "referencedRegulation", "judgeName", "keywords",
+                    "courtType", "judgmentTypes", "judgmentDateFrom", "judgmentDateTo"))
+    if not kryteria:
+        sys.exit("Podaj kryterium: frazę albo --sad / --sygnatura / --przepis / --sedzia / --haslo / --typ / zakres dat.")
+    d = _get("/search/judgments", params)
+    d = _expect_search(d, "wyników wyszukiwania")
+    items = d.get("items", [])
+    total = (d.get("info") or {}).get("totalResults", "?")
+    if not items:
+        # zero trafień = komunikat + kod ≠ 0, TAKŻE z --json (pusty JSON wyglądałby jak
+        # „sprawdzone, nic nie ma") — z wyjaśnieniem granicy zamkniętego zbioru, gdy dotyczy
+        linie = [f"Brak trafień w SAOS dla podanych kryteriów (totalResults: {total})."]
+        if ct == "ADMINISTRATIVE":
+            linie.append("Sądy administracyjne (NSA/WSA) są w SAOS praktycznie nieobecne — orzecznictwo "
+                         "administracyjne pobieraj skillem prawo-pl-cbosa (scripts/cbosa.py, baza CBOSA).")
+        if ct in ZASIEG:
+            granica, potwierdzona = _granica_zbioru(ct)
+            linie.append(_ostrzezenie_zasiegu(ct, a.od, a.do, granica, potwierdzona))
+        if a.przepis:
+            linie.append("--przepis to luźne dopasowanie pełnotekstowe w polu powołanych przepisów "
+                         "(lista SAOS bywa niepełna) — spróbuj też samą frazą albo --haslo.")
+        linie.append("SAOS to baza wtórna (agregat z lukami) — brak trafień tu nie dowodzi braku orzecznictwa.")
+        sys.exit("\n".join(linie))
+    granica = _ostrzezenie_zasiegu(ct, a.od, a.do, *(_granica_znana(ct, items) if ct in ZASIEG else ()))
+    if a.json:
+        if granica:
+            print(granica, file=sys.stderr)
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Znaleziono: {total}  (pokazuję {len(items)}, strona {params['pageNumber']}, po {params['pageSize']})\n")
+    if ct == "ADMINISTRATIVE":
+        print("UWAGA: sądy administracyjne (NSA/WSA) są w SAOS praktycznie nieobecne — orzecznictwo "
+              "administracyjne pobieraj skillem prawo-pl-cbosa (scripts/cbosa.py, baza CBOSA).\n")
+    if granica:
+        print(granica + "\n")
+    if a.przepis:
+        print(f"UWAGA: --przepis {a.przepis!r} to LUŹNE dopasowanie pełnotekstowe w polu powołanych "
+              "przepisów — „art. 415” trafia art. 415 k.c., k.p.c. i k.p.k. jednakowo, a lista powołanych "
+              "przepisów w SAOS bywa niepełna. Dopisz nazwę aktu (np. \"Kodeks cywilny art. 415\") "
+              "i sprawdź w 'orzeczenie <id>', którego aktu dotyczy trafienie.\n")
+    for it in items:
+        _wiersz(it)
+    if items:
+        print(f"Pełna treść: orzeczenie <id>  (np. orzeczenie {items[0].get('id')})")
+        if isinstance(total, int) and total > len(items):
+            print(f"Kolejna strona: --strona {params['pageNumber'] + 1}")
+
+
+def cmd_orzeczenie(a):
+    d = _get(f"/judgments/{a.id}")
+    d = _expect_judgment(d, a.id)
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    data = d.get("data", d)
+    cn = _case_numbers(data) or "—"
+    ctype = CT_PL.get(data.get("courtType", ""), data.get("courtType", ""))
+    court = _court_label(data)
+    print(f"# Orzeczenie [{data.get('id')}]  {cn}")
+    print(f"  Sąd:    {ctype}" + (f" — {court}" if court else ""))
+    print(f"  Data:   {data.get('judgmentDate', '?')}    typ: {_forma(data)}")
+    js = _judges(data, maks=12)
+    if js:
+        print(f"  Skład:  {js}")
+    kw = data.get("keywords") or []
+    if kw:
+        print(f"  Hasła:  {', '.join(kw)}")
+    for linia in _zrodla_urzedowe(data):
+        print(linia)
+    print(f"  SAOS:   https://www.saos.org.pl/judgments/{data.get('id')}")
+    ct = data.get("courtType", "")
+    if ct in ZASIEG:
+        print(f"  {UWAGA_INDEKSY}")
+
+    reg = data.get("referencedRegulations") or []
+    if reg:
+        print(f"\n## Powołane przepisy ({len(reg)}) — lista z SAOS (automatyczna ekstrakcja) — bywa niepełna; "
+              "przepisy rozstrzygnięcia zobacz w sentencji")
+        for r in reg[:40]:
+            print(f"  - {_wpis_przepisu(r)}")
+        if len(reg) > 40:
+            print(f"  … (+{len(reg) - 40}; pełna lista: --json)")
+
+    rcc = data.get("referencedCourtCases") or []
+    if rcc:
+        print(f"\n## Powołane orzeczenia ({len(rcc)})")
+        for r in rcc[:40]:
+            ids = r.get("judgmentIds") or []
+            hint = f"   → orzeczenie {ids[0]}" if ids else ""
+            print(f"  - {r.get('caseNumber', '?')}{hint}")
+        if len(rcc) > 40:
+            print(f"  … (+{len(rcc) - 40}; pełna lista: --json)")
+
+    summary = html_to_text(data.get("summary") or "")
+    if summary:
+        print(f"\n## Teza / streszczenie\n{summary}")
+
+    txt = html_to_text(data.get("textContent") or "")
+    print(f"\n## Treść uzasadnienia ({len(txt)} znaków)")
+    if ct in ZASIEG:
+        print(f"({UWAGA_INDEKSY})")
+    if not txt:
+        print("(brak treści w API — otwórz źródło urzędowe wyżej)")
+        return
+    if a.fragment:
+        spans = _fragmenty(txt, a.fragment)
+        if not spans:
+            sys.exit(f"Nie znaleziono frazy {a.fragment!r} w treści ({len(txt)} znaków). Spróbuj inną frazą.")
+        for i, (s, e) in enumerate(spans):
+            if i:
+                print("\n[...]\n")
+            # okna są dosunięte do granic zdań/słów; „…" oznacza, że tekst ciągnie się dalej
+            print(("…" if s > 0 else "") + txt[s:e].strip() + ("…" if e < len(txt) else ""))
+        print(f"\n(okna: {len(spans)} — pominięto resztę; pełna treść: bez --fragment)")
+        return
+    if len(txt) > 40000:
+        print(f"(UWAGA: długie uzasadnienie {len(txt)} znaków — do wycinka użyj --fragment \"<fraza>\")\n")
+    print(txt)
+
+
+def cmd_sygnatura(a):
+    sig = " ".join(a.sygnatura).strip()
+    d = _get("/search/judgments", {"caseNumber": sig, "pageSize": 20, "pageNumber": 0,
+                                   "sortingField": "JUDGMENT_DATE", "sortingDirection": "DESC"})
+    d = _expect_search(d, f"orzeczenia o sygnaturze {sig!r}")
+    items = d.get("items", [])
+    total = (d.get("info") or {}).get("totalResults", 0)
+    if not items:
+        wyjasnienie = "\n".join("  - " + w for w in _wyjasnienie_zera_sygnatury(sig))
+        sys.exit(f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w SAOS.\n"
+                 "SAOS to baza wtórna (nie ma wszystkiego) — sprawdź też portal właściwego sądu; "
+                 "sygnatury sądów administracyjnych (NSA/WSA) szukaj skillem prawo-pl-cbosa.\n"
+                 "Granice zamkniętych zbiorów (do DNIA; sądy powszechne są na bieżąco):\n" + wyjasnienie)
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Sygnatura {sig!r}: dopasowań {total}\n")
+    for it in items:
+        cn = _case_numbers(it)
+        ctype = CT_PL.get(it.get("courtType", ""), it.get("courtType", ""))
+        forma = _forma(it)
+        print(f"  [{it.get('id')}]  {cn}  · {ctype}  ({it.get('judgmentDate', '?')})  {forma}".rstrip())
+    print(f"\nPełna treść: orzeczenie {items[0].get('id')}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="API SAOS (read-only). Baza orzecznictwa polskiego: SN/TK/sądy powszechne/KIO.")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("szukaj")
+    s.add_argument("fraza", nargs="?", default=None)
+    s.add_argument("--sad", help="SN | TK | powszechne | admin | KIO")
+    s.add_argument("--sygnatura", help="numer sprawy (caseNumber)")
+    s.add_argument("--przepis", help="powołany przepis/akt (referencedRegulation), np. \"Kodeks cywilny\" albo \"art. 299\"")
+    s.add_argument("--sedzia", help="nazwisko sędziego (judgeName)")
+    s.add_argument("--haslo", help="hasło tematyczne (keywords)")
+    s.add_argument("--typ", help="wyrok | postanowienie | uchwala | zarzadzenie | uzasadnienie")
+    s.add_argument("--od", help="data orzeczenia od (RRRR-MM-DD)")
+    s.add_argument("--do", help="data orzeczenia do (RRRR-MM-DD)")
+    s.add_argument("--limit", type=int, default=10, help="ile wyników (1–100)")
+    s.add_argument("--strona", type=int, default=0, help="numer strony (od 0)")
+    s.set_defaults(func=cmd_szukaj)
+
+    o = sub.add_parser("orzeczenie")
+    o.add_argument("id")
+    o.add_argument("--fragment", help='wytnij okna wokół frazy w uzasadnieniu (np. "rękojmia")')
+    o.set_defaults(func=cmd_orzeczenie)
+
+    sy = sub.add_parser("sygnatura")
+    sy.add_argument("sygnatura", nargs="+")
+    sy.set_defaults(func=cmd_sygnatura)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
+
+    a = ap.parse_args()
+    try:
+        a.func(a)
+    except VerificationUnknown as e:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować danych w SAOS ({e}). "
+                 "Spróbuj ponownie za chwilę.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_edzienniki.py
+++ b/tools/test_edzienniki.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for edzienniki.py pure functions (no network). Run: python3 tools/test_edzienniki.py"""
+import contextlib
+import io
+import ssl
+import sys
+import importlib.util
+import pathlib
+import unittest
+import urllib.error
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "edzienniki", ROOT / "plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki/scripts/edzienniki.py")
+edz = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(edz)
+
+
+class TestWoj(unittest.TestCase):
+    def test_kod(self):
+        kod, nazwa, host, pub = edz._woj("DS")
+        self.assertEqual((kod, host, pub), ("DS", "edzienniki.duw.pl", "POL_WOJ_DS"))
+
+    def test_kod_male_litery(self):
+        self.assertEqual(edz._woj("ds")[0], "DS")
+
+    def test_nazwa_z_diakrytykami(self):
+        self.assertEqual(edz._woj("dolnośląskie")[0], "DS")
+        self.assertEqual(edz._woj("łódzkie")[0], "LD")
+
+    def test_nazwa_bez_diakrytykow(self):
+        self.assertEqual(edz._woj("dolnoslaskie")[0], "DS")
+        self.assertEqual(edz._woj("lodzkie")[0], "LD")
+        self.assertEqual(edz._woj("swietokrzyskie")[0], "SK")
+
+    def test_prefiks_nazwy(self):
+        self.assertEqual(edz._woj("mazow")[0], "MZ")
+
+    def test_prefiks_niejednoznaczny_wymienia_kandydatow(self):
+        # D9: 'MA' pasuje do małopolskie i mazowieckie — błąd z listą, nie cichy wybór pierwszego
+        with self.assertRaises(SystemExit) as cm:
+            edz._woj("MA")
+        self.assertIn("MP=małopolskie", str(cm.exception))
+        self.assertIn("MZ=mazowieckie", str(cm.exception))
+
+    def test_wszystkie_16(self):
+        self.assertEqual(len(edz.WOJEWODZTWA), 16)
+        for kod, (nazwa, host, pub) in edz.WOJEWODZTWA.items():
+            self.assertEqual(pub, f"POL_WOJ_{kod}")
+            self.assertTrue(host)
+
+    def test_nieznane_exits(self):
+        with self.assertRaises(SystemExit):
+            edz._woj("pomorze-gdanskie-x")
+
+    def test_brak_exits(self):
+        with self.assertRaises(SystemExit):
+            edz._woj(None)
+
+
+class TestNorm(unittest.TestCase):
+    def test_pascal_case(self):
+        # 4 hosty (starsze wdrożenia ABC PRO) zwracają PascalCase — normalizacja do lowercase
+        d = edz._norm({"Items": [{"Title": "Uchwała", "Pos": 5092, "Year": 2026}],
+                       "TotalCount": 5092})
+        self.assertEqual(d["totalcount"], 5092)
+        self.assertEqual(d["items"][0]["title"], "Uchwała")
+
+    def test_camel_case(self):
+        d = edz._norm({"items": [], "totalCount": 3301})
+        self.assertEqual(d["totalcount"], 3301)
+
+    def test_zagniezdzenie_i_listy(self):
+        d = edz._norm([{"A": {"B": [1, 2]}}])
+        self.assertEqual(d, [{"a": {"b": [1, 2]}}])
+
+
+class TestData(unittest.TestCase):
+    def test_sentinel(self):
+        self.assertIsNone(edz._data("0001-01-01T00:00:00"))
+
+    def test_none(self):
+        self.assertIsNone(edz._data(None))
+
+    def test_iso_z_godzina(self):
+        self.assertEqual(edz._data("2026-07-10T00:00:00"), "2026-07-10")
+
+
+class TestDaty(unittest.TestCase):
+    """D1: semantyka pól RÓŻNI SIĘ między endpointami — akt: announcementDate=data aktu,
+    promulgation=ogłoszenie; lista rocznika: odwrotnie."""
+    AKT = {"announcementdate": "2026-08-11T00:00:00", "promulgation": "2026-08-13T10:46:01.443"}
+    LISTA = {"promulgation": "2026-08-11T00:00:00", "announcementdate": "2026-08-13T10:46:01.443"}
+
+    def test_rekord_aktu(self):
+        self.assertEqual(edz._daty(self.AKT), ("2026-08-11", "2026-08-13"))
+
+    def test_lista_rocznika_odwrotnie(self):
+        self.assertEqual(edz._daty(self.LISTA, lista=True), ("2026-08-11", "2026-08-13"))
+
+    def test_ogloszenie_nie_poprzedza_aktu(self):
+        # host o odwrotnej konwencji: ogłoszenie < data aktu → zamiana z powrotem
+        self.assertEqual(edz._daty(self.LISTA), ("2026-08-11", "2026-08-13"))
+
+    def test_sentinel(self):
+        self.assertEqual(edz._daty({"announcementdate": "2026-08-11T00:00:00",
+                                    "promulgation": "0001-01-01T00:00:00"}), ("2026-08-11", None))
+
+
+class TestAscii(unittest.TestCase):
+    def test_diakrytyki(self):
+        self.assertEqual(edz._ascii("Zagospodarowania Przestrzennego ŚĄŻ"),
+                         "zagospodarowania przestrzennego saz")
+
+
+class TestHtmlToText(unittest.TestCase):
+    def test_akapity(self):
+        t = edz.html_to_text("<p>§ 1. Uchwala się.</p><p>§ 2. Wykonanie.</p>")
+        self.assertIn("§ 1. Uchwala się.", t)
+        self.assertIn("\n", t)
+
+    def test_nbsp(self):
+        self.assertEqual(edz.html_to_text("<p>art.\xa05</p>"), "art. 5")
+
+    def test_sup_inline(self):
+        # D10: <sup> w linii, cyfra jako indeks górny — bez łamania wiersza
+        self.assertEqual(edz.html_to_text("<p>1,00 zł od 1 m<sup>2</sup> powierzchni</p>"),
+                         "1,00 zł od 1 m² powierzchni")
+
+    def test_osobny_akapit_z_cyfra_indeksu(self):
+        # D10: serwer emituje indeks jako osobny <p>2 </p> PRZED linią z „m"
+        t = edz.html_to_text("<p>a w tym czasie nie </p><p>2 </p><p>zakończono budowy - 3,40 zł od 1 m powierzchni, </p>")
+        self.assertIn("od 1 m² powierzchni,", t)
+        self.assertNotIn("\n2\n", t)
+
+
+class TestCzyscPdf(unittest.TestCase):
+    """D3: tekst z pdftotext -layout — nagłówek dziennika, nagłówki stron i stopki usunięte,
+    zawinięte linie scalone, jednostki na początku linii."""
+    SUROWY = (
+        "                     DZIENNIK URZĘDOWY\n"
+        "                            WOJEWÓDZTWA MAŁOPOLSKIEGO\n\n"
+        "                                   Kraków, dnia 16 grudnia 2025 r.                   Podpisany przez:\n"
+        "                                                                                     Jan Kowalski\n"
+        "                                                                                     Data: 16.12.2025 15:32:19\n"
+        "                                                Poz. 7877\n\n"
+        "                                     UCHWAŁA NR XII/112/2025\n\n"
+        "   Na podstawie art. 18 ust. 2 pkt 8 ustawy z dnia 8 marca 1990 r. o samorządzie gminnym (t.j.\n"
+        "Dz.U. z 2025r. poz. 1153 ze zm.) uchwala się co następuje:\n"
+        "   § 1. Określa się wysokość stawek podatku od nieruchomości:\n"
+        " 1) od gruntów:\n"
+        "   a) związanych z prowadzeniem działalności gospodarczej bez względu na sposób zakwalifikowania\n"
+        "      w ewidencji gruntów i budynków – 1,00 zł od 1 m² powierzchni,\n"
+        "Id: 9E7C6D3A-1234-5678-ABCD-0123456789AB. Podpisany                                   Strona 1\n"
+        "\x0cDziennik Urzędowy Województwa Małopolskiego       –2–                                             Poz. 7877\n\n"
+        " 3) od budowli – 2% ich wartości określonej na podstawie art.4 ust. 1 pkt 3 ustawy o podatkach\n"
+        "    i opłatach lokalnych.\n"
+        "   § 2. Wykonanie uchwały powierza się Burmistrzowi.\n"
+        "Strona 2\n"
+        "\x0c")
+
+    def test_czyszczenie_i_scalanie(self):
+        txt, strony, naglowek = edz._czysc_pdf(self.SUROWY)
+        self.assertEqual(strony, 2)
+        self.assertEqual(naglowek, "Kraków, dnia 16 grudnia 2025 r., poz. 7877")
+        for smiec in ("DZIENNIK URZĘDOWY", "Podpisany przez", "Data: 16.12", "Poz. 7877", "–2–", "Id: 9E7C", "Strona 1", "Strona 2"):
+            self.assertNotIn(smiec, txt, smiec)
+        self.assertIn("o samorządzie gminnym (t.j. Dz.U. z 2025r. poz. 1153 ze zm.) uchwala się", txt)
+        self.assertIn("bez względu na sposób zakwalifikowania w ewidencji gruntów i budynków – 1,00 zł od 1 m² powierzchni,", txt)
+        self.assertIn("ustawy o podatkach i opłatach lokalnych.", txt)
+        linie = txt.split("\n")
+        self.assertIn("§ 1. Określa się wysokość stawek podatku od nieruchomości:", linie)
+        self.assertIn("§ 2. Wykonanie uchwały powierza się Burmistrzowi.", linie)
+        self.assertTrue(any(l.startswith("1) od gruntów") for l in linie))
+
+    def test_bez_naglowka_dziennika(self):
+        txt, strony, naglowek = edz._czysc_pdf("   § 1. Tekst.\n   § 2. Koniec.\n\x0c")
+        self.assertEqual((strony, naglowek), (1, None))
+        self.assertEqual(txt, "§ 1. Tekst.\n§ 2. Koniec.")
+
+
+class TestOcenaTekstu(unittest.TestCase):
+    """D4/D5: wykrywanie tekstu niezweryfikowanego (U+FFFD, brak §/Art., text.html = 1. strona)."""
+
+    def test_pdf_poprawny_bez_uwag(self):
+        self.assertEqual(edz._ocena_tekstu("§ 1. Tekst.\n§ 2. Koniec.", "pdf"), ([], []))
+
+    def test_fffd_blokuje(self):
+        ostrz, blok = edz._ocena_tekstu("§ 1. Tekst \ufffd\ufffd.", "pdf")
+        self.assertTrue(any("U+FFFD" in b for b in blok))
+
+    def test_html_zawsze_niezweryfikowany(self):
+        ostrz, blok = edz._ocena_tekstu("§ 1. Tekst.\n§ 2. Koniec.", "html")
+        self.assertTrue(any("PIERWSZĄ STRONĘ" in b for b in blok))
+
+    def test_pdf_narracyjny_tylko_ostrzega(self):
+        # rozstrzygnięcie nadzorcze bez § — poprawny tekst z PDF, strict NIE blokuje
+        txt = "ROZSTRZYGNIĘCIE NADZORCZE\n" + "Stwierdza się nieważność uchwały. " * 20
+        ostrz, blok = edz._ocena_tekstu(txt, "pdf")
+        self.assertEqual(blok, [])
+        self.assertTrue(ostrz)
+
+    def test_pdf_krotki_bez_jednostek_blokuje(self):
+        ostrz, blok = edz._ocena_tekstu("skan", "pdf")
+        self.assertTrue(blok)
+
+
+class TestStronicuj(unittest.TestCase):
+    # regresja BUG 2026-07-23 (PM/Rumia): paginacja MUSI działać na liście przefiltrowanych
+    # trafień i strony 1..N muszą pokrywać cały policzony zbiór (bez fałszywych negatywów)
+    def test_strony_pokrywaja_caly_zbior(self):
+        trafienia = list(range(43))  # 43 trafienia jak w zgłoszeniu
+        _, _, strony = edz._stronicuj(trafienia, 10, 1)
+        self.assertEqual(strony, 5)
+        zebrane = []
+        for s in range(1, strony + 1):
+            okno, start, _ = edz._stronicuj(trafienia, 10, s)
+            self.assertEqual(start, (s - 1) * 10)
+            zebrane.extend(okno)
+        self.assertEqual(zebrane, trafienia)
+
+    def test_okno_rowne_limitowi(self):
+        okno, start, strony = edz._stronicuj(list(range(43)), 50, 1)
+        self.assertEqual((len(okno), start, strony), (43, 0, 1))
+
+    def test_ostatnia_strona_czesciowa(self):
+        okno, _, _ = edz._stronicuj(list(range(43)), 10, 5)
+        self.assertEqual(okno, [40, 41, 42])
+
+    def test_strona_poza_zakresem_pusta(self):
+        okno, _, strony = edz._stronicuj(list(range(43)), 10, 6)
+        self.assertEqual((okno, strony), ([], 5))
+
+    def test_pusty_zbior(self):
+        self.assertEqual(edz._stronicuj([], 10, 1), ([], 0, 1))
+
+
+class TestFragmenty(unittest.TestCase):
+    TEKST = ("Preambuła.\n"
+             "§ 1. Określa się stawki:\n1) od gruntów – 1,00 zł;\n2) od budowli – 2% wartości.\n"
+             "§ 2. Traci moc uchwała.\n"
+             "§ 10. Inny paragraf.\n"
+             "Załącznik do uchwały\n"
+             "§ 1. 1. Żłobek nosi nazwę.\n2. Siedziba.\n"
+             "§ 2. Koniec statutu.\n")
+
+    def test_okno_wokol_frazy(self):
+        txt = ("X" * 50) + "PLAN" + ("Y" * 50)
+        spans = edz._fragmenty(txt, "plan")
+        self.assertEqual(len(spans), 1)
+        self.assertIn("PLAN", txt[spans[0][0]:spans[0][1]])
+
+    def test_brak_trafien(self):
+        self.assertEqual(edz._fragmenty("dowolny tekst", "nie ma"), [])
+
+    def test_cala_jednostka_do_nastepnego_paragrafu(self):
+        # D7: „§ 1" = CAŁY § 1 (do następnego §), nie okno 600 znaków; oba wystąpienia (uchwała + załącznik)
+        spans = edz._fragmenty(self.TEKST, "§ 1")
+        self.assertEqual(len(spans), 2)
+        pierwszy = self.TEKST[spans[0][0]:spans[0][1]]
+        self.assertTrue(pierwszy.startswith("§ 1. Określa się"))
+        self.assertIn("2) od budowli – 2% wartości.", pierwszy)
+        self.assertNotIn("§ 2.", pierwszy)
+        drugi = self.TEKST[spans[1][0]:spans[1][1]]
+        self.assertTrue(drugi.startswith("§ 1. 1. Żłobek"))
+        self.assertIn("2. Siedziba.", drugi)
+        self.assertNotIn("Koniec statutu", drugi)
+
+    def test_paragraf_1_nie_lapie_10(self):
+        spans = edz._fragmenty(self.TEKST, "§ 10")
+        self.assertEqual(len(spans), 1)
+        self.assertTrue(self.TEKST[spans[0][0]:spans[0][1]].startswith("§ 10. Inny"))
+        self.assertNotIn("Załącznik", self.TEKST[spans[0][0]:spans[0][1]])
+
+    def test_ostatni_paragraf_konczy_sie_na_zalaczniku(self):
+        spans = edz._fragmenty(self.TEKST, "§ 10.")
+        self.assertEqual(self.TEKST[spans[0][0]:spans[0][1]].strip(), "§ 10. Inny paragraf.")
+
+    def test_artykul(self):
+        t = "Art. 1. Pierwszy.\nArt. 2. Drugi.\n"
+        spans = edz._fragmenty(t, "art. 2")
+        self.assertEqual(t[spans[0][0]:spans[0][1]].strip(), "Art. 2. Drugi.")
+
+    def test_okno_rozszerzone_do_granic_linii(self):
+        # D7: okno nigdy nie tnie w pół słowa — rozszerzane do granic linii
+        t = "linia pierwsza\n" + ("słowo " * 200) + "FRAZA " + ("dalej " * 200) + "\nlinia ostatnia"
+        spans = edz._fragmenty(t, "fraza")
+        s, e = spans[0]
+        self.assertEqual(s, len("linia pierwsza\n"))
+        self.assertEqual(t[e - 6:e], "dalej ")
+        self.assertNotIn("linia", t[s:e])
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj", "--woj", "mazowieckie"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, edz.cmd_szukaj
+        edz.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            edz.main()
+        finally:
+            sys.argv, edz.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+
+class TestStrict(unittest.TestCase):
+    """--strict: rocznik bez listy aktów = wynik NIEKOMPLETNY → blokada; domyślnie głośne ostrzeżenie.
+    Zero trafień kończy się komunikatem także z --json."""
+    ROCZNIK = {"items": [{"pos": 10, "title": "Uchwała w sprawie statutu gminy X", "year": 2026}],
+               "totalcount": 1}
+
+    def _fake_get(self, host, path, params=None, raw=False):
+        if path.endswith("/2026"):
+            return self.ROCZNIK
+        return None  # rocznik 2025 → nieoczekiwana odpowiedź
+
+    def _uruchom(self, argv):
+        out = io.StringIO()
+        with mock.patch.object(edz, "_get", side_effect=self._fake_get), \
+                mock.patch.object(edz, "_roczniki", return_value={"years": [2026, 2025]}), \
+                mock.patch.object(sys, "argv", ["edzienniki.py", *argv]), \
+                contextlib.redirect_stdout(out):
+            try:
+                edz.main()
+            except SystemExit as e:
+                return out.getvalue(), e
+        return out.getvalue(), None
+
+    def test_strict_blokuje_gdy_rocznik_pominiety_i_stdout_jest_pusty(self):
+        out, e = self._uruchom(["szukaj", "statut", "--woj", "DS", "--strict"])
+        self.assertIsNotNone(e)
+        self.assertIn("rocznika 2025", str(e))
+        self.assertEqual(out, "")
+
+    def test_domyslnie_ostrzega_o_pominietym_roczniku(self):
+        out, e = self._uruchom(["szukaj", "statut", "--woj", "DS"])
+        self.assertIsNone(e)
+        self.assertIn("2025 POMINIĘTE", out)
+        self.assertIn("statutu gminy X", out)
+
+    def test_json_zero_trafien_konczy_sie_komunikatem(self):
+        out, e = self._uruchom(["szukaj", "zzqq", "--woj", "DS", "--rok", "2026", "--json"])
+        self.assertIsNotNone(e)
+        self.assertIn("Brak wyników", str(e))
+        self.assertEqual(out, "")
+
+    def test_strict_po_komendzie_i_przed(self):
+        for argv in (["szukaj", "statut", "--woj", "DS", "--rok", "2026", "--strict"],
+                     ["--strict", "szukaj", "statut", "--woj", "DS", "--rok", "2026"]):
+            out, e = self._uruchom(argv)
+            self.assertIsNone(e, argv)
+            self.assertIn("statutu gminy X", out)
+
+
+def _uruchom(argv, **patches):
+    """main() z podmienionymi funkcjami sieciowymi → (stdout, SystemExit|None)."""
+    out = io.StringIO()
+    with contextlib.ExitStack() as st:
+        for nazwa, wartosc in patches.items():
+            st.enter_context(mock.patch.object(edz, nazwa, **wartosc))
+        st.enter_context(mock.patch.object(sys, "argv", ["edzienniki.py", *argv]))
+        st.enter_context(contextlib.redirect_stdout(out))
+        try:
+            edz.main()
+        except SystemExit as e:
+            return out.getvalue(), e
+    return out.getvalue(), None
+
+
+class TestListaRocznika(unittest.TestCase):
+    """D2/D5/D11: lista rocznika bez magicznego limit=100000; niepełna lista = głośne ostrzeżenie,
+    w strict blokada; nagłówek mówi prawdę o faktycznie przeszukanych rocznikach; status etykietowany."""
+
+    def _item(self, pos, status="obowiązujący"):
+        return {"pos": pos, "year": 2026, "title": f"Uchwała nr {pos} Rady Gminy Ryjewo w sprawie planu",
+                "type": "Uchwała", "status": status,
+                "promulgation": "2026-08-12T00:00:00", "announcementdate": "2026-08-20T13:59:37.743"}
+
+    def test_bez_parametru_limit_i_pelna_lista(self):
+        wywolania = []
+
+        def fake_get(host, path, params=None, raw=False):
+            wywolania.append((path, params))
+            return {"items": [self._item(1), self._item(2)], "totalcount": 2}
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026", "--strict"],
+                          _get={"side_effect": fake_get})
+        self.assertIsNone(e)
+        self.assertEqual(wywolania[0], ("/acts/POL_WOJ_PM/2026", None))
+        self.assertFalse(any(p and p.get("limit") == 100000 for _, p in wywolania))
+        self.assertIn("2026: 2/2", out)
+        self.assertIn("data aktu: 2026-08-12  · ogłoszono: 2026-08-20", out)
+
+    def test_niepelna_lista_ponawia_z_innym_limitem(self):
+        wywolania = []
+
+        def fake_get(host, path, params=None, raw=False):
+            wywolania.append((path, params))
+            if params:  # ponowienie z limitem → pełna lista
+                return {"items": [self._item(1), self._item(2), self._item(3)], "totalcount": 3}
+            return {"items": [self._item(1), self._item(2)], "totalcount": 3}
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026", "--strict"],
+                          _get={"side_effect": fake_get})
+        self.assertIsNone(e)
+        self.assertEqual(wywolania[1][1], {"limit": 503})
+        self.assertIn("[2026/3]", out)
+        self.assertNotIn("NIEPEŁNA", out)
+
+    def test_nadal_niepelna_ostrzega_a_strict_blokuje(self):
+        def fake_get(host, path, params=None, raw=False):
+            if path.count("/") == 4:
+                return None  # rekord aktu (weryfikacja statusu w strict) — nieistotne tutaj
+            return {"items": [self._item(1), self._item(2)], "totalcount": 3330}
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026"], _get={"side_effect": fake_get})
+        self.assertIsNone(e)
+        self.assertIn("NIEPEŁNA", out)
+        self.assertIn("brakuje 3328 NAJNOWSZYCH", out)
+        self.assertIn("2026: 2/3330 (pobrano 2 — NIEPEŁNA)", out)
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026", "--strict"],
+                          _get={"side_effect": fake_get})
+        self.assertIsNotNone(e)
+        self.assertIn("NIEPEŁNA", str(e))
+        self.assertEqual(out, "")
+
+    def test_json_niepelna_lista_ma_flage(self):
+        import json
+
+        def fake_get(host, path, params=None, raw=False):
+            return {"items": [self._item(1)], "totalcount": 5}
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026", "--json"], _get={"side_effect": fake_get})
+        self.assertIsNone(e)
+        d = json.loads(out)
+        self.assertEqual(d["roczniki_niepelne"], {"2026": {"pobrano": 1, "aktow": 5}})
+        self.assertFalse(d["roczniki"]["2026"]["pelna"])
+
+    def test_naglowek_mowi_ktore_roczniki_przeszukano(self):
+        # D11: bez frazy okno strony wypełnia 2026 → nagłówek NIE twierdzi „2024–2026"
+        def fake_get(host, path, params=None, raw=False):
+            return {"items": [self._item(i) for i in range(1, 6)], "totalcount": 5}
+        out, e = _uruchom(["szukaj", "--woj", "DS", "--limit", "2"], _get={"side_effect": fake_get},
+                          _roczniki={"return_value": {"years": [2024, 2025, 2026]}})
+        self.assertIsNone(e)
+        self.assertIn("przeszukane roczniki: 2026 ", out)
+        self.assertNotIn("2024–2026", out)
+        self.assertIn("roczniki 2025, 2024 NIE przeszukane", out)
+        self.assertIn("z 5 trafień (roczniki 2026)", out)
+
+    def test_strict_weryfikuje_status_w_rekordzie_aktu(self):
+        # C09: lista podaje „obowiązujący", rekord aktu „Stwierdzono nieważność aktu" → pokazujemy prawdę
+        def fake_get(host, path, params=None, raw=False):
+            if path.endswith("/2026/3104"):
+                return {"title": "Uchwała", "status": "Stwierdzono nieważność aktu"}
+            return {"items": [self._item(3104)], "totalcount": 1}
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026", "--strict"],
+                          _get={"side_effect": fake_get})
+        self.assertIsNone(e)
+        self.assertIn("status (zweryfikowany w rekordzie aktu): Stwierdzono nieważność aktu  "
+                      "[lista rocznika podawała: obowiązujący]", out)
+        out, e = _uruchom(["szukaj", "Ryjewo", "--woj", "PM", "--rok", "2026"], _get={"side_effect": fake_get})
+        self.assertIn("status (wg listy rocznika): obowiązujący", out)
+
+
+class TestTekst(unittest.TestCase):
+    """D3/D4/D5/D7: tekst z PDF przez pdftotext (gdy dostępny), inaczej text.html z głośnym ostrzeżeniem;
+    strict blokuje text.html i tekst uszkodzony, NIE blokuje poprawnego tekstu z PDF."""
+    HTML = b"<html><p>\xc2\xa7 1. Pierwsza strona.</p><p>\xc2\xa7 2. Koniec strony 1.</p></html>"
+    PDF_SUROWY = ("                     DZIENNIK URZĘDOWY\n   WOJEWÓDZTWA X\n"
+                  "   Wrocław, dnia 13 sierpnia 2026 r.\n   Poz. 3654\n\n"
+                  "   § 1. Pierwsza strona.\n   § 2. Koniec strony 1.\n"
+                  "\x0cDziennik Urzędowy Województwa X  –2–  Poz. 3654\n"
+                  "   § 3. Druga strona: od budowli – 2% ich\nwartości.\n\x0c")
+
+    def _get(self, host, path, params=None, raw=False):
+        if path.endswith("text.pdf"):
+            return b"%PDF-1.4 ..."
+        if path.endswith("text.html"):
+            return self.HTML
+        raise AssertionError(path)
+
+    def test_pdf_przez_pdftotext(self):
+        out, e = _uruchom(["tekst", "DS", "2026", "3654", "--strict"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": "/usr/bin/pdftotext"},
+                          _pdftotext={"return_value": self.PDF_SUROWY})
+        self.assertIsNone(e)
+        self.assertIn("(tekst z urzędowego PDF przez pdftotext, 2 str.", out)
+        self.assertIn("nagłówek dziennika: Wrocław, dnia 13 sierpnia 2026 r., poz. 3654", out)
+        self.assertIn("§ 3. Druga strona: od budowli – 2% ich wartości.", out)
+        self.assertNotIn("UWAGA", out)
+
+    def test_fragment_cala_jednostka_z_pdf(self):
+        out, e = _uruchom(["tekst", "DS", "2026", "3654", "--fragment", "§ 3"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": "/usr/bin/pdftotext"},
+                          _pdftotext={"return_value": self.PDF_SUROWY})
+        self.assertIsNone(e)
+        self.assertIn("§ 3. Druga strona: od budowli – 2% ich wartości.", out)
+        self.assertIn("jednostka § 3: 1 wystąpień", out)
+
+    def test_bez_pdftotext_html_z_glosnym_ostrzezeniem(self):
+        out, e = _uruchom(["tekst", "DS", "2026", "3654"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": None})
+        self.assertIsNone(e)
+        self.assertIn("(tekst z text.html", out)
+        self.assertIn("UWAGA: text.html zawiera zwykle tylko PIERWSZĄ STRONĘ aktu — to NIE jest pełny tekst; "
+                      "pobierz PDF: tekst DS 2026 3654 --pdf", out)
+        self.assertIn("zalecane: zainstaluj poppler", out)
+
+    def test_bez_pdftotext_strict_blokuje(self):
+        out, e = _uruchom(["--strict", "tekst", "DS", "2026", "3654"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": None})
+        self.assertIsNotNone(e)
+        self.assertIn("PIERWSZĄ STRONĘ", str(e))
+        self.assertEqual(out, "")
+
+    def test_html_nie_znaleziono_frazy_nie_jest_definitywne(self):
+        out, e = _uruchom(["tekst", "DS", "2026", "3654", "--fragment", "budowli"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": None})
+        self.assertIsNotNone(e)
+        self.assertIn("TYLKO 1. strona aktu", str(e))
+
+    def test_uszkodzony_html_fffd(self):
+        html = "<p>\ufffd\ufffd\ufffd</p><p>Tworzy się jednostkę onazwie Klub</p>".encode()
+        out, e = _uruchom(["tekst", "PL", "2026", "3155"], _get={"return_value": html},
+                          _pdftotext_dostepny={"return_value": None})
+        self.assertIsNone(e)
+        self.assertIn("3 znaków zastępczych U+FFFD", out)
+        self.assertIn("brak oznaczeń jednostek", out)
+        out, e = _uruchom(["tekst", "PL", "2026", "3155", "--strict"], _get={"return_value": html},
+                          _pdftotext_dostepny={"return_value": None})
+        self.assertIsNotNone(e)
+        self.assertIn("U+FFFD", str(e))
+
+    def test_json_ma_zrodlo_i_uwagi(self):
+        import json
+        out, e = _uruchom(["tekst", "DS", "2026", "3654", "--json"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": None})
+        d = json.loads(out)
+        self.assertEqual(d["zrodlo"], "html")
+        self.assertTrue(any("PIERWSZĄ STRONĘ" in x for x in d["niezweryfikowany"]))
+
+    def test_pdftotext_pada_to_html(self):
+        out, e = _uruchom(["tekst", "DS", "2026", "3654"], _get={"side_effect": self._get},
+                          _pdftotext_dostepny={"return_value": "/usr/bin/pdftotext"},
+                          _pdftotext={"return_value": None})
+        self.assertIsNone(e)
+        self.assertIn("pdftotext nie przetworzył PDF", out)
+        self.assertIn("(tekst z text.html", out)
+
+
+class TestAkt(unittest.TestCase):
+    """D1/D8: „Data aktu" vs „Ogłoszony" z właściwych pól; powiązania z rejestru dziennika (best-effort)."""
+    ELI = {"title": "Uchwała Nr XII/112/2025 Rady Miejskiej w Koszycach z dnia 15 grudnia 2025 r.",
+           "type": "Uchwała", "releasedby": ["Rada Gminy Koszyce"], "status": "obowiązujący",
+           "announcementdate": "2025-12-15T00:00:00", "promulgation": "2025-12-16T14:57:54.347",
+           "displayaddress": "DZ. URZ. WOJ. 2025.7877", "texthtml": True, "textpdf": True}
+    REJESTR = {"actdate": "2025-12-15T00:00:00", "publicationdate": "2025-12-16T14:57:54.347",
+               "actstatus": {"isinvalid": False, "ispartialinvalid": False, "description": ""},
+               "actrelations": [{"relationtype": "JestSprostowaniemDla", "description": "Ma sprostowanie",
+                                 "legalactsrelated": [{"year": 2026, "position": 446, "legalacttype": "Obwieszczenie",
+                                                       "actdate": "2026-01-26T00:00:00", "casenumber": None,
+                                                       "description": "DZ. URZ. WOJ. 2026.446"}]}]}
+
+    def test_daty_i_powiazania(self):
+        out, e = _uruchom(["akt", "MP", "2025", "7877"], _get={"return_value": dict(self.ELI)},
+                          _get_rejestr={"return_value": self.REJESTR})
+        self.assertIsNone(e)
+        self.assertIn("Data aktu: 2025-12-15   Ogłoszony (publikacja w dzienniku): 2025-12-16", out)
+        self.assertIn("Ma sprostowanie: Obwieszczenie z 2026-01-26 → DZ. URZ. WOJ. 2026.446  [rok 2026 poz. 446]", out)
+
+    def test_rejestr_niedostepny_tylko_ostrzega_takze_w_strict(self):
+        out, e = _uruchom(["--strict", "akt", "MP", "2025", "7877"], _get={"return_value": dict(self.ELI)},
+                          _get_rejestr={"return_value": None})
+        self.assertIsNone(e)
+        self.assertIn("Powiązania: nie udało się pobrać rejestru dziennika", out)
+
+    def test_status_z_rejestru_gdy_inny(self):
+        rej = dict(self.REJESTR, actstatus={"isinvalid": True, "ispartialinvalid": True,
+                                             "description": "Stwierdzono częściową nieważność"}, actrelations=[])
+        out, e = _uruchom(["akt", "MP", "2025", "7877"], _get={"return_value": dict(self.ELI)},
+                          _get_rejestr={"return_value": rej})
+        self.assertIn("Status (rejestr dziennika): Stwierdzono częściową nieważność", out)
+        self.assertIn("częściowa nieważność", out)
+        self.assertIn("Powiązania: brak w rejestrze dziennika", out)
+
+    def test_json_zawiera_rejestr(self):
+        import json
+        out, e = _uruchom(["akt", "MP", "2025", "7877", "--json"], _get={"return_value": dict(self.ELI)},
+                          _get_rejestr={"return_value": self.REJESTR})
+        d = json.loads(out)
+        self.assertEqual(d["_rejestr_dziennika"]["actrelations"][0]["description"], "Ma sprostowanie")
+
+
+class TestTls(unittest.TestCase):
+    """D6: niepełny łańcuch certyfikatów → dociągnięcie pośredniego przez AIA i ponowienie z PEŁNĄ
+    weryfikacją; gdy się nie uda — komunikat o łańcuchu (nie o geoblokadzie), nigdy CERT_NONE dla treści."""
+
+    def _blad_cert(self):
+        return urllib.error.URLError(ssl.SSLCertVerificationError(
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate"))
+
+    def test_aia_urls_z_der(self):
+        url = b"http://certumdvtlsg2r39ca.repository.certum.pl/certumdvtlsg2r39ca.cer"
+        der = b"\x30\x82" + edz._OID_CA_ISSUERS + b"\x86" + bytes([len(url)]) + url + b"\x30\x1f\x06\x03"
+        self.assertEqual(edz._aia_urls(der), [url.decode()])
+
+    def test_aia_urls_dluga_forma_dlugosci(self):
+        url = b"http://x.example/" + b"a" * 130 + b".crt"
+        der = edz._OID_CA_ISSUERS + b"\x86\x81" + bytes([len(url)]) + url
+        self.assertEqual(edz._aia_urls(der), [url.decode()])
+
+    def test_aia_urls_pomija_ocsp_i_crl(self):
+        der = (b"\x06\x08\x2b\x06\x01\x05\x05\x07\x30\x01\x86\x10http://ocsp.x.pl/"
+               + edz._OID_CA_ISSUERS + b"\x86\x12http://x.pl/ca.crl")
+        self.assertEqual(edz._aia_urls(der), [])
+
+    def test_pobrany_posredni_nie_jest_kotwica_zaufania(self):
+        # adres pośredniego pochodzi z NIEZWERYFIKOWANEGO liścia — gdyby pobrany certyfikat był
+        # kotwicą (PARTIAL_CHAIN), atakujący w tranzycie podstawiłby własny „pośredni"; łańcuch
+        # musi kończyć się na samopodpisanym korzeniu z domyślnego magazynu
+        url = "http://ca.example/posredni.cer"
+        der = edz._OID_CA_ISSUERS + b"\x86" + bytes([len(url)]) + url.encode()
+        pem = edz._der_do_pem(b"\x30\x03\x02\x01\x01")
+        zaladowane = []
+        ctx = ssl.create_default_context()
+        with mock.patch.object(edz, "_lisc_der", return_value=der), \
+                mock.patch.object(edz, "_SSL_CTX", None), \
+                mock.patch.object(edz.ssl, "create_default_context", return_value=ctx), \
+                mock.patch.object(ctx, "load_verify_locations", side_effect=lambda cadata: zaladowane.append(cadata)), \
+                mock.patch.object(edz.urllib.request, "urlopen") as uo:
+            uo.return_value.__enter__.return_value.read.return_value = pem.encode()
+            wynik = edz._ctx_z_aia("edziennik.example")
+        self.assertIs(wynik, ctx)
+        self.assertEqual(zaladowane, [pem])
+        self.assertFalse(ctx.verify_flags & ssl.VERIFY_X509_PARTIAL_CHAIN)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_der_do_pem(self):
+        pem = edz._der_do_pem(b"\x30\x03\x02\x01\x01")
+        self.assertTrue(pem.startswith("-----BEGIN CERTIFICATE-----\nMAMCAQE=\n-----END CERTIFICATE-----"))
+        self.assertEqual(edz._der_do_pem(b"-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----\n").count("BEGIN"), 1)
+
+    def test_ponowienie_z_pelna_weryfikacja(self):
+        ctx = ssl.create_default_context()
+        odp = mock.MagicMock()
+        odp.__enter__.return_value.read.return_value = b"[]"
+        urlopen = mock.Mock(side_effect=[self._blad_cert(), odp])
+        with mock.patch.object(edz.urllib.request, "urlopen", urlopen), \
+                mock.patch.object(edz, "_ctx_z_aia", return_value=ctx), \
+                mock.patch.object(edz, "_SSL_CTX", None):
+            dane = edz._fetch("https://edziennik.malopolska.uw.gov.pl/api/eli/acts", "edziennik.malopolska.uw.gov.pl")
+        self.assertEqual(dane, b"[]")
+        self.assertEqual(urlopen.call_count, 2)
+        self.assertIs(urlopen.call_args_list[1].kwargs["context"], ctx)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_brak_posredniego_komunikat_o_lancuchu(self):
+        urlopen = mock.Mock(side_effect=self._blad_cert())
+        with mock.patch.object(edz.urllib.request, "urlopen", urlopen), \
+                mock.patch.object(edz, "_ctx_z_aia", return_value=None), \
+                mock.patch.object(edz, "_SSL_CTX", None), mock.patch.object(edz.time, "sleep"):
+            with self.assertRaises(SystemExit) as cm:
+                edz._fetch("https://dzienniki.luw.pl/api/eli/acts", "dzienniki.luw.pl")
+        self.assertIn("niepełny łańcuch certyfikatów po stronie serwera", str(cm.exception))
+        self.assertNotIn("spoza PL", str(cm.exception))
+        self.assertEqual(urlopen.call_count, 1)
+
+    def test_soft_zwraca_none(self):
+        urlopen = mock.Mock(side_effect=self._blad_cert())
+        with mock.patch.object(edz.urllib.request, "urlopen", urlopen), \
+                mock.patch.object(edz, "_ctx_z_aia", return_value=None), mock.patch.object(edz, "_SSL_CTX", None):
+            self.assertIsNone(edz._fetch("https://dzienniki.luw.pl/api/legalact", "dzienniki.luw.pl", soft=True))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_eli.py
+++ b/tools/test_eli.py
@@ -1,0 +1,1143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for eli.py pure functions (no network). Run: python3 tools/test_eli.py"""
+import argparse
+import contextlib
+import io
+import sys
+import importlib.util
+import pathlib
+import unittest
+import urllib.error
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "eli", ROOT / "plugins/prawo-pl-eli/skills/prawo-pl-eli/scripts/eli.py")
+eli = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(eli)
+
+
+class TestActPath(unittest.TestCase):
+    def test_signature_forms(self):
+        cases = [
+            (["DU", "2024", "18"], "/acts/DU/2024/18"),
+            (["DU/2024/18"], "/acts/DU/2024/18"),
+            (["Dz.U. 2024 poz. 18"], "/acts/DU/2024/18"),
+            (["Dz.U. 1997 nr 78 poz. 483"], "/acts/DU/1997/483"),
+            (["WDU20240000018"], "/acts/WDU20240000018"),
+            (["wdu20240000018"], "/acts/WDU20240000018"),
+            (["MP", "2023", "1"], "/acts/MP/2023/1"),
+            (["M.P. 2023 poz. 1"], "/acts/MP/2023/1"),
+        ]
+        for sig, want in cases:
+            self.assertEqual(eli.act_path(sig)[0], want, f"sygnatura: {sig}")
+
+    def test_invalid_signature_exits(self):
+        with self.assertRaises(SystemExit):
+            eli.act_path(["zupełnie błędna sygnatura"])
+
+
+class TestHtmlToText(unittest.TestCase):
+    def test_strips_script_and_style(self):
+        t = eli.html_to_text("<p>A</p><script>var x=1;</script><style>.c{}</style><p>B</p>")
+        self.assertIn("A", t)
+        self.assertIn("B", t)
+        self.assertNotIn("var x", t)
+        self.assertNotIn(".c{", t)
+
+    def test_normalizes_nbsp(self):
+        # API ELI używa NBSP: "Art.\xa0299." musi być wyszukiwalne jako "Art. 299."
+        self.assertEqual(eli.html_to_text("<p>Art.\xa0299.</p>"), "Art. 299.")
+
+    def test_collapses_blank_lines(self):
+        t = eli.html_to_text("<div><p>A</p><p></p><p></p><p>B</p></div>")
+        self.assertNotIn("\n\n\n", t)
+
+    def test_superscript_gets_space(self):
+        # Indeks górny w <sup> musi zostać rozdzielony spacją, żeby art. 21¹
+        # ("Art. 21 1.") był odróżnialny od art. 211 ("Art. 211.").
+        self.assertEqual(eli.html_to_text("<p>Art.\xa021<sup>1</sup>.</p>"), "Art. 21 1.")
+        self.assertEqual(eli.html_to_text("<p>Art.\xa0211.</p>"), "Art. 211.")
+
+    # treść przypisu (dymek) API wstawia inline w środek przepisu
+    HTML_PRZYPIS = ('<h3><b>Art.\xa066c<a class="gloss-link tooltip" href="#gloss-0:6:"><sup>6)</sup>'
+                    '<span class="tooltip-text"><span class="pro-gloss-inner">Dodany przez art. 3 pkt 2'
+                    ' ustawy z dnia 9 marca 2023 r.</span></span></a>.</b></h3>'
+                    '<p>Kto uporczywie nie stosuje się do obowiązków.</p>')
+
+    def test_przypis_w_osobnej_linii_z_etykieta(self):
+        t = eli.html_to_text(self.HTML_PRZYPIS)
+        # komentarz redakcyjny ≠ norma: własna linia z etykietą i numerem odsyłacza,
+        # a numer odsyłacza („6)") NIE wchodzi w nagłówek artykułu — ten kończy się kropką
+        self.assertIn("Art. 66c.\n[przypis 6)] Dodany przez", t)
+        self.assertTrue(t.startswith("Art. 66c."))
+        self.assertNotIn("66c 6)", t)
+        self.assertEqual(eli._hity_naglowka(t, "art. 66c"), [0])
+
+    def test_przypis_nie_udaje_naglowka_jednostki(self):
+        # Przypis potrafi zaczynać się od „Art. 598…"/„Tytuł działu…" (7 razy w k.p.c.);
+        # na początku linii udawałby granicę jednostki i tnąłby fragment w losowym miejscu.
+        html = self.HTML_PRZYPIS.replace("Dodany przez art. 3 pkt 2", "Art. 598 16 w związku z art.")
+        t = eli.html_to_text(html)
+        self.assertNotIn("\nArt. 598", t)
+        self.assertIn("[przypis 6)] Art. 598", t)
+
+    # D07 (audyt 2026-08): cyfra odsyłacza do przypisu wchodziła w numer jednostki —
+    # „2 1)" (pkt 2 czytało się jak pkt 21), „a 2)", „§ 1 12)" (bez kropki), „(uchylony) 5)"
+    HTML_PKT = ('<h3 CLASS="pro-align-padding-right">2<A class="gloss-link tooltip" href="#gloss-0:1:">'
+                '<sup>1)</sup><span class="tooltip-text"><span class="pro-gloss-inner">Ze zmianą wprowadzoną'
+                ' przez § 1 pkt 1 lit. a rozporządzenia.</span></span></A>)</h3>'
+                '<div class="unit-inner"><div CLASS="pro-text">„pomieszczeniach” - rozumie się szatnie;</div></div>'
+                '<h3 CLASS="pro-align-padding-right">a<A class="gloss-link tooltip" href="#gloss-0:2:"><sup>2)</sup>'
+                '<span class="tooltip-text"><span class="pro-gloss-inner">W brzmieniu ustalonym.</span></span></A>)</h3>'
+                '<div CLASS="pro-text">łączny czas przebywania.</div>'
+                '<h3 CLASS="pro-padding-right"><B CLASS="b">§&nbsp;1<A class="gloss-link tooltip" href="#gloss-0:12:">'
+                '<sup>12)</sup><span class="tooltip-text"><span class="pro-gloss-inner">Uznany za niezgodny z Konstytucją'
+                ' (Dz. U. poz. 739).</span></span></A>.</B></h3>'
+                '<div CLASS="pro-text">Jeżeli egzekucja przeciwko spółce okaże się bezskuteczna.</div>'
+                '<div CLASS="pro-text">§&nbsp;2. (uchylony)<A class="gloss-link tooltip" href="#gloss-0:5:"><sup>5)</sup>'
+                '<span class="tooltip-text"><span class="pro-gloss-inner">Przez art. 1 ustawy.</span></span></A></div>')
+
+    def test_numer_odsylacza_nie_wchodzi_w_numer_jednostki(self):
+        t = eli.html_to_text(self.HTML_PKT)
+        self.assertIn("2)\n[przypis 1)] Ze zmianą wprowadzoną przez § 1 pkt 1 lit. a rozporządzenia.\n", t)
+        self.assertNotIn("2 1)", t)
+        self.assertIn("a)\n[przypis 2)] W brzmieniu ustalonym.", t)
+        self.assertNotIn("a 2)", t)
+        self.assertIn("§ 1.\n[przypis 12)] Uznany za niezgodny", t)
+        self.assertNotIn("§ 1 12)", t)
+        self.assertIn("§ 2. (uchylony)\n[przypis 5)] Przez art. 1 ustawy.", t)
+        self.assertNotIn("..", t)          # kropka artykułu nie dubluje się z kropką przypisu
+        self.assertIn("\nJeżeli egzekucja", t)  # treść normy nienaruszona
+
+    def test_indeks_gorny_artykulu_nadal_odspacjowany(self):
+        # reguła „spacja przed <sup>" dla indeksu górnego artykułu zostaje (art. 449¹ ≠ art. 4491)
+        t = eli.html_to_text('<h3>Art.\xa0449<sup>1</sup>.</h3><p>Treść.</p><h3>Art.\xa04491.</h3>')
+        self.assertIn("Art. 449 1.", t)
+        self.assertIn("Art. 4491.", t)
+        self.assertEqual(len(eli._hity_naglowka(t, "art. 449(1)")), 1)
+        self.assertEqual(len(eli._hity_naglowka(t, "art. 4491")), 1)
+
+    def test_przypis_w_srodku_akapitu_wychodzi_za_akapit(self):
+        # odsyłacz w środku zdania: przypis czeka do końca bloku, norma zostaje w jednym kawałku
+        html = ('<div CLASS="pro-text">Strony wyrażą na to zgodę.<A class="gloss-link tooltip" href="#g">'
+                '<sup>20)</sup><span class="tooltip-text">Zdanie trzecie dodane przez art. 1.</span></A>'
+                ' Zdanie trzecie.</div><div>Art. 2.</div>')
+        t = eli.html_to_text(html)
+        self.assertIn("Strony wyrażą na to zgodę. Zdanie trzecie.\n[przypis 20)] Zdanie trzecie dodane przez art. 1.\nArt. 2.", t)
+
+
+class TestFragmenty(unittest.TestCase):
+    # Tekst po konwersji HTML→tekst: art. 21¹ (indeks górny w <sup>) renderuje się
+    # jako "Art. 21 1." (patrz _Stripper), a art. 211 jako "Art. 211." — odróżnialne.
+    TXT = ("Tytuł I\n\nArt. 1.\nPierwszy przepis.\n\n"
+           "Art. 2.\n§ 1. Drugi przepis o spółce.\n§ 2. Odesłanie, o którym mowa w art. 1.\n\n"
+           "Art. 21.\nDwudziesty pierwszy przepis.\n\n"
+           "Art. 21 1.\nPrzepis z indeksem górnym (art. 21 ze zn. 1).\n\n"
+           "Art. 211.\nDwieście jedenasty przepis.\n")
+
+    def _frag(self, fraza):
+        spans = eli._fragmenty(self.TXT, fraza)
+        return [self.TXT[s:e] for s, e in spans]
+
+    def test_artykul_po_naglowku_nie_po_odeslaniu(self):
+        frags = self._frag("art. 2")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("Drugi przepis", frags[0])
+        self.assertNotIn("Pierwszy", frags[0])
+        self.assertNotIn("Dwudziesty", frags[0])  # "Art. 21." to inny artykuł
+
+    def test_artykul_nie_lapie_dluzszego_numeru(self):
+        frags = self._frag("art. 21")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("Dwudziesty pierwszy", frags[0])
+        self.assertNotIn("indeksem górnym", frags[0])  # "Art. 21 1." to inny artykuł
+        self.assertNotIn("Dwieście", frags[0])          # "Art. 211." to inny artykuł
+
+    def test_artykul_z_indeksem_gornym(self):
+        # "art. 21(1)" oraz "art. 21¹" trafiają w "Art. 21 1." (indeks górny),
+        # a NIE w "Art. 21." ani "Art. 211.".
+        for fraza in ("art. 21(1)", "art. 21¹"):
+            frags = self._frag(fraza)
+            self.assertEqual(len(frags), 1, fraza)
+            self.assertIn("indeksem górnym", frags[0], fraza)
+            self.assertNotIn("Dwudziesty pierwszy", frags[0], fraza)
+            self.assertNotIn("Dwieście", frags[0], fraza)
+
+    def test_rozroznia_indeks_gorny_od_pelnego_numeru(self):
+        # "art. 211" trafia TYLKO w art. 211, nie w art. 21¹ (to był bug).
+        frags = self._frag("art. 211")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("Dwieście jedenasty", frags[0])
+        self.assertNotIn("indeksem górnym", frags[0])
+
+    def test_fraza_pelnotekstowa_docieta_do_artykulu(self):
+        frags = self._frag("o którym mowa")
+        self.assertEqual(len(frags), 1)
+        self.assertTrue(frags[0].startswith("Art. 2."))
+
+    def test_brak_trafien(self):
+        self.assertEqual(eli._fragmenty(self.TXT, "nie ma takiej frazy"), [])
+
+    def test_pusta_fraza(self):
+        self.assertEqual(eli._fragmenty(self.TXT, "   "), [])
+
+
+class TestFragmentyZPrzypisem(unittest.TestCase):
+    """Nagłówek z ODSYŁACZEM DO PRZYPISU (art. 66c Kodeksu wykroczeń — zgłoszenie z 2026-07-26).
+
+    W tekście jednolitym każdy niedawno dodany lub zmieniony przepis ma przy numerze odsyłacz
+    („Art. 66c 6)Dodany przez…"), a kropka artykułu stoi dopiero za treścią przypisu. Wymaganie
+    kropki tuż po numerze dawało fałszywy negatyw tam, gdzie prawo jest najświeższe.
+    """
+
+    TXT = ("Art. 66b 4)W brzmieniu ustalonym przez art. 2 ustawy z dnia 13 stycznia 2023 r..\n"
+           "Kto zawiadamia o niebezpieczeństwie.\n\n"
+           "Art. 66c 6)Dodany przez art. 3 pkt 2 ustawy z dnia 9 marca 2023 r..\n"
+           "Kto uporczywie nie stosuje się do obowiązków, podlega karze ograniczenia wolności.\n\n"
+           "Art. 66.\nKto ze złośliwości wywołuje niepotrzebną czynność.\n\n"
+           "Art. 107 10)W tym brzmieniu obowiązuje do dnia wejścia w życie zmiany..\n"
+           "Kto w celu dokuczenia innej osobie złośliwie wprowadza ją w błąd.\n\n"
+           "Art. 446 1 7)Zdanie drugie utraciło moc..\nPrzepis z indeksem górnym i przypisem.\n\n"
+           "Art. 446 1 a.\nPrzepis z indeksem górnym i literą (art. 446 ze zn. 1a).\n\n"
+           "Art. 669 101)W brzmieniu ustalonym przez art. 1..\nTreść z przypisem 101.\n")
+
+    def _frag(self, fraza):
+        return [self.TXT[s:e] for s, e in eli._fragmenty(self.TXT, fraza)]
+
+    def test_sufiks_literowy_z_przypisem(self):
+        # To był zgłoszony bug: --fragment "art. 66c" zwracało „nie znaleziono".
+        frags = self._frag("art. 66c")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("uporczywie", frags[0])
+        self.assertNotIn("zawiadamia", frags[0])      # art. 66b to inny artykuł
+        self.assertNotIn("złośliwości", frags[0])     # art. 66 to inny artykuł
+
+    def test_goly_numer_z_przypisem(self):
+        frags = self._frag("art. 107")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("dokuczenia", frags[0])
+
+    def test_indeks_gorny_z_przypisem(self):
+        frags = self._frag("art. 446(1)")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("indeksem górnym i przypisem", frags[0])
+        self.assertNotIn("i literą", frags[0])        # art. 446 ze zn. 1a to inny artykuł
+
+    def test_indeks_gorny_z_litera_rozdzielone_spacja(self):
+        # "Art. 446 1 a." — indeks górny i litera bywają w tekście rozdzielone
+        frags = self._frag("art. 446(1a)")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("i literą", frags[0])
+
+    def test_przypis_nie_udaje_indeksu_gornego(self):
+        # "art. 669¹" NIE może trafić w "Art. 669 101)" (art. 669 z przypisem 101)
+        self.assertEqual(eli._hity_naglowka(self.TXT, "art. 669(1)"), [])
+        frags = self._frag("art. 669")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("przypisem 101", frags[0])
+
+    def test_goly_numer_nie_lapie_sufiksu_literowego(self):
+        frags = self._frag("art. 66")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("złośliwości", frags[0])
+
+    def test_brak_naglowka_wraca_do_szukania_pelnotekstowego(self):
+        # Fałszywy negatyw jest gorszy niż odesłanie: bez nagłówka pokazujemy trafienia w treści.
+        self.assertEqual(eli._hity_naglowka(self.TXT, "art. 2"), [])
+        frags = self._frag("art. 2")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("art. 2 ustawy z dnia 13 stycznia 2023", frags[0])
+
+    def test_wielka_litera_w_zapytaniu(self):
+        # ze zgłoszenia: „Art. 66c" i „art. 66c" muszą dawać ten sam wynik
+        self.assertEqual(eli._fragmenty(self.TXT, "Art. 66c"), eli._fragmenty(self.TXT, "art. 66c"))
+
+    def test_warianty_myslnika(self):
+        # myślnik w akcie (U+2012) vs. zwykły "-" w zapytaniu — nie może to być fałszywy negatyw
+        txt = "Art. 5.\nProgram korekcyjno‒edukacyjny dla sprawców.\n"
+        self.assertEqual(len(eli._fragmenty(txt, "korekcyjno-edukacyjny")), 1)
+
+    def test_inwariant_spojnosci(self):
+        """§3.2 zgłoszenia: fraza widoczna w `tekst <akt>` NIGDY nie może dać „nie znaleziono"."""
+        for i in range(0, len(self.TXT) - 12):
+            fraza = self.TXT[i:i + 12 + (i % 25)].strip()
+            if len(fraza) >= 8:
+                self.assertTrue(eli._fragmenty(self.TXT, fraza), f"brak trafienia dla {fraza!r}")
+
+
+class TestTjZTekstem(unittest.TestCase):
+    """Fallback, gdy API zwraca 200 i 0 bajtów dla text.html świeżego tekstu jednolitego."""
+
+    REFS_TJ = {"Tekst jednolity dla aktu": [
+        {"act": {"ELI": "DU/1964/296", "displayAddress": "Dz.U. 1964 nr 43 poz. 296"}}]}
+    BASE_REFS = {"Inf. o tekście jednolitym": [
+        {"act": {"ELI": "DU/2026/468", "displayAddress": "Dz.U. 2026 poz. 468"}},
+        {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}},
+    ]}
+
+    def _z_fake_get(self, odpowiedzi, path, refs):
+        def fake_get(p, params=None, soft=False):
+            return odpowiedzi.get(p)
+        orig = eli._get
+        eli._get = fake_get
+        try:
+            return eli._tj_z_tekstem(path, refs)
+        finally:
+            eli._get = orig
+
+    def test_akt_jest_tj_bez_html_bierze_poprzedni_tj(self):
+        wynik = self._z_fake_get({
+            "/acts/DU/1964/296/references": self.BASE_REFS,
+            "/acts/DU/2024/1568/text.html": "<p>Art. 1. Treść.</p>",
+        }, "/acts/DU/2026/468", self.REFS_TJ)
+        self.assertIsNotNone(wynik)
+        act, txt, pominiete = wynik
+        self.assertEqual(act["ELI"], "DU/2024/1568")
+        self.assertIn("Art. 1.", txt)
+        self.assertEqual(pominiete, [])
+
+    def test_pomija_tj_z_pustym_html(self):
+        # najnowszy kandydat też bez HTML — idzie dalej po liście
+        refs_bazowe = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/468"}},
+            {"act": {"ELI": "DU/2024/1568"}},
+            {"act": {"ELI": "DU/2023/1550"}},
+        ]}
+        wynik = self._z_fake_get({
+            "/acts/DU/2026/468/text.html": "",
+            "/acts/DU/2024/1568/text.html": "",
+            "/acts/DU/2023/1550/text.html": "<p>Art. 1.</p>",
+        }, "/acts/DU/1964/296", refs_bazowe)
+        self.assertEqual(wynik[0]["ELI"], "DU/2023/1550")
+        # pominięte t.j. z pustym HTML są zwracane — nagłówek ma je wymienić (k.c.: 2025/1071)
+        self.assertEqual(wynik[2], ["DU/2026/468", "DU/2024/1568"])
+
+    def test_brak_kandydatow_zwraca_none(self):
+        self.assertIsNone(self._z_fake_get({}, "/acts/DU/2026/468", {}))
+
+    def test_nie_zwraca_aktu_biezacego(self):
+        # jedyny t.j. na liście to akt bieżący — fallback nie może zwrócić jego samego
+        wynik = self._z_fake_get({
+            "/acts/DU/1964/296/references": {"Inf. o tekście jednolitym": [
+                {"act": {"ELI": "DU/2026/468"}}]},
+        }, "/acts/DU/2026/468", self.REFS_TJ)
+        self.assertIsNone(wynik)
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj", "fraza"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, eli.cmd_szukaj
+        eli.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            eli.main()
+        finally:
+            sys.argv, eli.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
+
+class _Response:
+    def __init__(self, body, content_type="application/json"):
+        self.body = body
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class EliVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_soft_transport_error_is_unknown(self):
+        with mock.patch.object(eli._opener, "open", side_effect=urllib.error.URLError("offline")), \
+                mock.patch.object(eli.time, "sleep"):
+            with self.assertRaises(eli.VerificationUnknown):
+                eli._get("/acts/test/references", soft=True)
+
+    def test_successful_empty_json_is_verified_absent(self):
+        response = _Response(b"[]")
+        with mock.patch.object(eli._opener, "open", return_value=response):
+            self.assertEqual(eli._get("/acts/search", soft=True), [])
+
+    def test_soft_404_is_verified_absent(self):
+        # API ELI odpowiada 404 wyłącznie dla nieistniejącego zasobu — to zweryfikowany
+        # brak (None), nie awaria; "spróbuj ponownie" byłoby tu fałszywym komunikatem
+        err = urllib.error.HTTPError("u", 404, "Not Found", {}, None)
+        with mock.patch.object(eli._opener, "open", side_effect=err), \
+                mock.patch.object(eli.time, "sleep"):
+            self.assertIsNone(eli._get("/acts/DU/2024/999999/references", soft=True))
+
+    def test_tekst_dostarczony_mimo_awarii_odniesien(self):
+        # awaria POBOCZNEGO /references nie odbiera tekstu — tekst + GŁOŚNE ostrzeżenie
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                raise eli.VerificationUnknown("timeout")
+            return "<html><body><p>Art. 1. Treść przepisu.</p></body></html>"
+        args = argparse.Namespace(sygnatura=["DU", "2024", "18"], json=False,
+                                  pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            eli.cmd_tekst(args)
+        self.assertIn("Art. 1. Treść przepisu.", out.getvalue())
+        self.assertIn("nie udało się zweryfikować aktualności", out.getvalue())
+
+    def test_strict_blokuje_tekst_przy_awarii_odniesien(self):
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                raise eli.VerificationUnknown("timeout")
+            return "<html><body><p>Art. 1. Treść przepisu.</p></body></html>"
+        args = argparse.Namespace(sygnatura=["DU", "2024", "18"], json=False,
+                                  strict=True, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(eli.VerificationUnknown, "timeout"):
+                eli.cmd_tekst(args)
+        self.assertNotIn("Treść przepisu", out.getvalue())
+
+    def test_strict_nie_wypisuje_tj_przed_kontrola_aktualnosci(self):
+        refs = {"Tekst jednolity dla aktu": [
+            {"act": {"ELI": "DU/1964/296", "displayAddress": "Dz.U. 1964 poz. 296"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path == "/acts/DU/2024/1568/references":
+                return refs
+            raise eli.VerificationUnknown("timeout")
+
+        args = argparse.Namespace(sygnatura=["DU", "2024", "1568"], json=False, strict=True)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(eli.VerificationUnknown, "timeout"):
+                eli.cmd_tj(args)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_fallback_pomija_kandydata_z_awaria(self):
+        # awaria transportu na JEDNYM kandydacie t.j. nie zabija pętli zapasowej
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2023/100", "displayAddress": "Dz.U. 2023 poz. 100"}},
+            {"act": {"ELI": "DU/2020/50", "displayAddress": "Dz.U. 2020 poz. 50"}}]}
+        def fake_get(path, params=None, soft=False):
+            if "2023/100" in path:
+                raise eli.VerificationUnknown("zapora odrzuciła żądanie")
+            return "<html><body><p>Art. 1. Tekst z 2020 r.</p></body></html>"
+        with mock.patch.object(eli, "_get", side_effect=fake_get):
+            act, txt, _ = eli._tj_z_tekstem("/acts/DU/2024/18", refs)
+        self.assertEqual(act["ELI"], "DU/2020/50")
+        self.assertIn("Tekst z 2020", txt)
+
+    def test_fallback_unknown_gdy_zaden_kandydat_nie_dal_tekstu(self):
+        # gdy część kandydatów padła, a żaden nie dał tekstu — UNKNOWN, nie "braku t.j."
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2023/100"}}, {"act": {"ELI": "DU/2020/50"}}]}
+        def fake_get(path, params=None, soft=False):
+            if "2023/100" in path:
+                raise eli.VerificationUnknown("timeout")
+            return ""
+        with mock.patch.object(eli, "_get", side_effect=fake_get):
+            with self.assertRaises(eli.VerificationUnknown):
+                eli._tj_z_tekstem("/acts/DU/2024/18", refs)
+
+    def test_domyslnie_starszy_tj_ma_maszynowy_znacznik(self):
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return refs
+            if path == "/acts/DU/2026/468/text.html":
+                return ""
+            if path == "/acts/DU/2024/1568/text.html":
+                return "<p>Art. 1. Starsza treść.</p>"
+            if path in ("/acts/DU/2026/468", "/acts/DU/2024/1568"):
+                return {"texts": [], "legalStatusDate": "2024-10-01"}
+            raise AssertionError(path)
+
+        args = argparse.Namespace(sygnatura=["DU", "2026", "468"], json=False,
+                                  strict=False, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                mock.patch.object(eli, "pdftotext_dostepny", return_value=False), \
+                contextlib.redirect_stdout(out):
+            eli.cmd_tekst(args)
+        self.assertIn("ELI_TEXT_SOURCE_FALLBACK=DU/2024/1568", out.getvalue())
+        self.assertIn("NIEAKTUALNE BRZMIENIE MOŻLIWE", out.getvalue())
+        self.assertIn("Art. 1. Starsza treść.", out.getvalue())
+
+    def test_strict_blokuje_starszy_tj(self):
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return refs
+            if path == "/acts/DU/2026/468/text.html":
+                return ""
+            if path == "/acts/DU/2024/1568/text.html":
+                return "<p>Art. 1. Starsza treść.</p>"
+            if path == "/acts/DU/2026/468":
+                return {"texts": [{"type": "T", "fileName": "D20260468Lj.pdf"}]}
+            raise AssertionError(path)
+
+        args = argparse.Namespace(sygnatura=["DU", "2026", "468"], json=False,
+                                  strict=True, pdf=None, fragment=None)
+        out = io.StringIO()
+        # brak pdftotext → kompletności zastępczego tekstu nie da się zweryfikować → strict blokuje
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                mock.patch.object(eli, "pdftotext_dostepny", return_value=False), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(SystemExit, "brak programu pdftotext.*strict blokuje zastępczy"):
+                eli.cmd_tekst(args)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t01_strict_blokuje_poprawnie_wykryty_nowszy_tj_i_stdout_jest_pusty(self):
+        refs = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/500", "displayAddress": "Dz.U. 2026 poz. 500"}}]}
+
+        def fake_get(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return refs
+            return "<p>Art. 1. Starsza, ale niepusta treść.</p>"
+
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2024", "18", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eli.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t02_json_strict_nie_emituje_danych_gdy_kontrola_nie_przeszla(self):
+        komendy = [
+            ["szukaj", "kodeks"],
+            ["meta", "DU", "2024", "18"],
+            ["tekst", "DU", "2024", "18"],
+            ["struktura", "DU", "2024", "18"],
+            ["odniesienia", "DU", "2024", "18"],
+            ["tj", "DU", "2024", "18"],
+        ]
+        for komenda in komendy:
+            with self.subTest(komenda=komenda):
+                out = io.StringIO()
+                with mock.patch.object(eli, "_get", side_effect=eli.VerificationUnknown("timeout")), \
+                        mock.patch.object(sys, "argv", ["eli.py", *komenda, "--json", "--strict"]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        eli.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+
+    def test_t02b_tj_json_strict_kontroluje_nowszy_tj_przed_emisja(self):
+        refs_tj = {"Tekst jednolity dla aktu": [
+            {"act": {"ELI": "DU/1964/296", "displayAddress": "Dz.U. 1964 poz. 296"}}]}
+        refs_bazowe = {"Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/500", "displayAddress": "Dz.U. 2026 poz. 500"}},
+            {"act": {"ELI": "DU/2024/1568", "displayAddress": "Dz.U. 2024 poz. 1568"}},
+        ]}
+
+        def fake_get(path, params=None, soft=False):
+            if path == "/acts/DU/2024/1568/references":
+                return refs_tj
+            if path == "/acts/DU/1964/296/references":
+                return refs_bazowe
+            raise AssertionError(path)
+
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tj", "DU", "2024", "1568",
+                                                       "--json", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eli.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+
+class TestT03PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = eli.urllib.request.Request("https://api.sejm.gov.pl/eli/acts/DU/2024/18")
+        handler = eli._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://api.sejm.gov.pl/eli/acts/DU/2024/18/text.pdf")
+        self.assertEqual(nowy.full_url,
+                         "https://api.sejm.gov.pl/eli/acts/DU/2024/18/text.pdf")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/akt.pdf")
+
+
+class TestT04RecznaInstalacjaSkilli(unittest.TestCase):
+    WYDANE = ("prawo-pl-eli", "prawo-pl-edzienniki", "prawo-eu-eurlex", "prawo-pl-saos",
+              "prawo-pl-cbosa", "prawo-pl-uodo", "prawo-pl-rejestr-umow")
+
+    def test_wszystkie_skille_maja_lokalny_fallback_bez_sieci_i_find(self):
+        # helper wyłącznie z bieżącego pakietu: ścieżka podstawiana przez Claude Code
+        # (${CLAUDE_PLUGIN_ROOT}) albo katalog tego SKILL.md — bez find po dysku i bez curl z main
+        for plugin in self.WYDANE:
+            skill = ROOT / f"plugins/{plugin}/skills/{plugin}/SKILL.md"
+            text = skill.read_text(encoding="utf-8")
+            with self.subTest(skill=skill):
+                self.assertIn(f'="${{CLAUDE_PLUGIN_ROOT}}/skills/{plugin}/scripts/', text)
+                self.assertIn('="<katalog skilla>/scripts/', text)
+                self.assertIn("Nie pobieraj helpera z sieci", text)
+                self.assertIn("nie szukaj go przez `find`", text)
+                self.assertNotIn("curl -fsSL", text)
+                self.assertNotIn('find "$HOME', text)
+                self.assertIn("`--strict`", text)
+
+
+class TestT11NowszyTjNaStarszymTj(unittest.TestCase):
+    """Akt, który SAM jest (starszym) t.j., nie ma listy t.j. we własnych odniesieniach —
+    aktualność trzeba sprawdzić na akcie bazowym, inaczej przestarzały t.j. wygląda jak aktualny."""
+    REFS_TJ = {"Tekst jednolity dla aktu": [
+        {"act": {"ELI": "DU/1964/93", "displayAddress": "Dz.U. 1964 nr 16 poz. 93"}}]}
+    REFS_BAZOWE = {"Inf. o tekście jednolitym": [
+        {"act": {"ELI": "DU/2024/1061", "displayAddress": "Dz.U. 2024 poz. 1061"}},
+        {"act": {"ELI": "DU/2026/795", "displayAddress": "Dz.U. 2026 poz. 795"}}]}
+
+    def _fake_get(self, path, params=None, soft=False):
+        if path == "/acts/DU/2024/1061/references" or path == "/acts/DU/2026/795/references":
+            return self.REFS_TJ
+        if path == "/acts/DU/1964/93/references":
+            return self.REFS_BAZOWE
+        if path in ("/acts/DU/2024/1061", "/acts/DU/2026/795"):
+            return {"legalStatusDate": "2026-05-19", "textHTML": True}
+        if path.endswith("/text.html"):
+            return "<p>Art. 1. Kodeks niniejszy reguluje stosunki cywilnoprawne.</p>"
+        raise AssertionError(path)
+
+    def test_strict_blokuje_tekst_starszego_tj_i_stdout_jest_pusty(self):
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=self._fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2024", "1061", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(SystemExit, "nowszy tekst jednolity: Dz.U. 2026 poz. 795"):
+                eli.main()
+        self.assertEqual(out.getvalue(), "")
+
+    def test_domyslnie_tekst_starszego_tj_ma_ostrzezenie_o_nowszym(self):
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=self._fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2024", "1061"]), \
+                contextlib.redirect_stdout(out):
+            eli.main()
+        self.assertIn("NIEAKTUALNY tekst jednolity", out.getvalue())
+        self.assertIn("Dz.U. 2026 poz. 795", out.getvalue())
+        self.assertIn("tekst DU 2026 795", out.getvalue())
+        self.assertIn("Art. 1.", out.getvalue())
+
+    def test_najnowszy_tj_przechodzi_w_strict_bez_ostrzezenia(self):
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=self._fake_get), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2026", "795", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            eli.main()
+        self.assertNotIn("NIEAKTUALNY", out.getvalue())
+        self.assertIn("Art. 1.", out.getvalue())
+
+    def test_awaria_kontroli_na_akcie_bazowym_strict_blokuje_a_domyslnie_ostrzega(self):
+        def fake(path, params=None, soft=False):
+            if path == "/acts/DU/1964/93/references":
+                raise eli.VerificationUnknown("timeout")
+            return self._fake_get(path, params, soft)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2024", "1061", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eli.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake), \
+                mock.patch.object(sys, "argv", ["eli.py", "tekst", "DU", "2024", "1061"]), \
+                contextlib.redirect_stdout(out):
+            eli.main()
+        self.assertIn("nie udało się sprawdzić, czy istnieje nowszy tekst jednolity", out.getvalue())
+        self.assertIn("Art. 1.", out.getvalue())
+
+
+class TestAudyt2026DatyIMeta(unittest.TestCase):
+    """D02/D03: „Ogłoszono" musi być datą publikacji w Dz.U. (promulgation), nie datą aktu
+    (announcementDate = „z dnia" w tytule); `comments` (rozłożone wejście w życie) nie może zniknąć."""
+
+    META = {"title": "Ustawa z dnia 14 czerwca 2024 r. o ochronie sygnalistów", "displayAddress": "Dz.U. 2024 poz. 928",
+            "type": "Ustawa", "status": "obowiązujący", "inForce": "IN_FORCE", "announcementDate": "2024-06-14",
+            "promulgation": "2024-06-24", "entryIntoForce": "2024-09-25", "legalStatusDate": None,
+            "comments": "art. 5 ust. 4, art. 25 ust. 1 pkt 8 oraz przepisy rozdziału 4 wchodzą w życie z dniem 25 grudnia 2024 r.",
+            "ELI": "DU/2024/928", "texts": [], "textHTML": True}
+
+    def _meta(self, meta):
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", return_value=meta), contextlib.redirect_stdout(out):
+            eli.cmd_meta(argparse.Namespace(sygnatura=["DU", "2024", "928"], json=False))
+        return out.getvalue()
+
+    def test_ogloszono_to_promulgation_a_data_aktu_osobno(self):
+        out = self._meta(self.META)
+        self.assertRegex(out, r"Ogłoszono: 2024-06-24")
+        self.assertRegex(out, r"Data aktu: 2024-06-14")
+        self.assertNotRegex(out, r"Ogłoszono: 2024-06-14")
+        self.assertIn("WEJŚCIE W ŻYCIE: 2024-09-25", out)
+
+    def test_uwagi_z_api_wypisane_doslownie(self):
+        self.assertIn("Uwagi:   art. 5 ust. 4, art. 25 ust. 1 pkt 8 oraz przepisy rozdziału 4 wchodzą w życie "
+                      "z dniem 25 grudnia 2024 r.", self._meta(self.META))
+
+    def test_stan_prawny_tylko_gdy_jest_i_brak_promulgation(self):
+        tj = dict(self.META, legalStatusDate="2026-05-19", promulgation=None, textHTML=False, comments=None)
+        out = self._meta(tj)
+        self.assertIn("Stan prawny na: 2026-05-19", out)
+        self.assertIn("Ogłoszono: — (brak w API)", out)
+        self.assertNotIn("Uwagi:", out)
+        self.assertIn("BRAK w API (textHTML=false)", out)
+        self.assertNotIn("Stan prawny na", self._meta(self.META))
+
+
+class TestAudyt2026Szukaj(unittest.TestCase):
+    """D04: „Znaleziono" = totalCount z API, nie rozmiar strony; zero trafień = exit ≠ 0 także z --json."""
+
+    ODP = {"count": 2, "totalCount": 58, "offset": 0,
+           "items": [{"address": "WDU20260001046", "ELI": "DU/2026/1046", "title": "Ustawa A", "status": "obowiązujący"},
+                     {"address": "WDU20260000473", "ELI": "DU/2026/473", "title": "Ustawa B", "status": "obowiązujący"}]}
+
+    def _szukaj(self, odp, **kw):
+        args = dict(fraza="Kodeks pracy", typ="Ustawa", rok=None, wyd=None, haslo=None, obowiazujace=False,
+                    limit=2, offset=0, json=False)
+        args.update(kw)
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", return_value=odp), contextlib.redirect_stdout(out):
+            eli.cmd_szukaj(argparse.Namespace(**args))
+        return out.getvalue()
+
+    def test_total_count_i_instrukcja_stronicowania(self):
+        out = self._szukaj(self.ODP)
+        self.assertIn("Znaleziono: 58 (pokazuję 2, offset 0)", out)
+        self.assertIn("pozostało 56", out)
+        self.assertIn("--offset 2 --limit 2", out)
+
+    def test_komplet_bez_ostrzezenia(self):
+        out = self._szukaj(dict(self.ODP, totalCount=2))
+        self.assertIn("Znaleziono: 2 (pokazuję 2, offset 0)", out)
+        self.assertNotIn("NIE wszystkie", out)
+
+    def test_zero_trafien_konczy_sie_bledem_takze_z_json(self):
+        pusty = {"count": 0, "totalCount": 0, "offset": 0, "items": []}
+        for js in (False, True):
+            with self.subTest(json=js):
+                out = io.StringIO()
+                with mock.patch.object(eli, "_get", return_value=pusty), contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        eli.cmd_szukaj(argparse.Namespace(fraza="xyz", typ=None, rok=None, wyd=None, haslo=None,
+                                                          obowiazujace=False, limit=10, offset=0, json=js))
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertIn("Brak wyników", str(caught.exception.code))
+                self.assertEqual(out.getvalue(), "")
+
+
+class TestAudyt2026Struktura(unittest.TestCase):
+    """D08: 404 na /struct to zweryfikowany brak → komunikat „Brak struktury", nie surowy błąd HTTP."""
+
+    def test_404_daje_komunikat_o_braku_struktury(self):
+        def fake_get(path, params=None, soft=False):
+            self.assertTrue(soft, "struct musi być pobierany soft (404 = brak, nie awaria)")
+            return None
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake_get), contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(SystemExit, "Brak struktury dla tego aktu \(DU 2026 poz. 694\)"):
+                eli.cmd_struktura(argparse.Namespace(sygnatura=["DU", "2026", "694"], json=False, filtr=None, poziom=None))
+        self.assertEqual(out.getvalue(), "")
+
+
+class TestAudyt2026NowelizacjePoTj(unittest.TestCase):
+    """D05: lista „Nowelizacje po tekście jednolitym" uzupełniana o „Akty zmieniające" aktu bazowego
+    po legalStatusDate t.j., bez duplikatów, z jednoznacznymi etykietami dat."""
+
+    REFS_TJ = {
+        "Tekst jednolity dla aktu": [{"act": {"ELI": "DU/1964/296", "displayAddress": "Dz.U. 1964 nr 43 poz. 296"}}],
+        "Nowelizacje po tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/830", "displayAddress": "Dz.U. 2026 poz. 830", "title": "Ustawa o ochronie debaty",
+                     "announcementDate": "2026-05-29", "promulgation": "2026-06-23"}},
+            {"act": {"ELI": "DU/2026/473", "displayAddress": "Dz.U. 2026 poz. 473", "title": "Ustawa o PIP",
+                     "announcementDate": "2026-03-11", "promulgation": "2026-04-07"}, "date": "2026-03-11"},
+        ]}
+    REFS_BAZOWE = {"Akty zmieniające": [
+        {"act": {"ELI": "DU/2026/1046", "displayAddress": "Dz.U. 2026 poz. 1046", "title": "Ustawa o zmianie k.p. i k.p.c.",
+                 "announcementDate": "2026-06-19", "promulgation": "2026-08-04"}, "date": "2026-11-05"},
+        {"act": {"ELI": "DU/2026/1003", "displayAddress": "Dz.U. 2026 poz. 1003", "title": "Ustawa o systemach AI",
+                 "announcementDate": "2026-07-03", "promulgation": "2026-07-27"}, "date": "2026-10-28"},
+        {"act": {"ELI": "DU/2026/830", "displayAddress": "Dz.U. 2026 poz. 830", "title": "Ustawa o ochronie debaty",
+                 "announcementDate": "2026-05-29", "promulgation": "2026-06-23"}, "date": "2026-07-08"},
+        {"act": {"ELI": "DU/2026/473", "displayAddress": "Dz.U. 2026 poz. 473", "title": "Ustawa o PIP",
+                 "announcementDate": "2026-03-11", "promulgation": "2026-04-07"}, "date": "2026-07-08"},
+        {"act": {"ELI": "DU/2025/1500", "displayAddress": "Dz.U. 2025 poz. 1500", "title": "Stara nowelizacja",
+                 "announcementDate": "2025-11-01", "promulgation": "2025-11-20"}, "date": "2026-01-01"},
+    ]}
+    META_TJ = {"ELI": "DU/2026/468", "legalStatusDate": "2026-03-25", "promulgation": "2026-04-07"}
+
+    def _fake_get(self, path, params=None, soft=False):
+        if path == "/acts/DU/2026/468":
+            return self.META_TJ
+        if path == "/acts/DU/1964/296/references":
+            return self.REFS_BAZOWE
+        raise AssertionError(path)
+
+    def test_uzupelnia_z_aktu_bazowego_i_deduplikuje(self):
+        with mock.patch.object(eli, "_get", side_effect=self._fake_get):
+            linie, uwagi = eli._nowelizacje_po_tj(self.REFS_TJ, "/acts/DU/2026/468")
+        self.assertEqual(uwagi, [])
+        self.assertIn("odnotowano zmiany (4)", linie[0])
+        self.assertIn("stan prawny na 2026-03-25", linie[0])
+        pozycje = [l for l in linie[1:] if l.startswith("  - ")]
+        self.assertEqual([l.split()[1:4] for l in pozycje],
+                         [["Dz.U.", "2026", "poz."]] * 4)
+        self.assertEqual(len(pozycje), 4)
+        self.assertIn("Dz.U. 2026 poz. 1046", "\n".join(pozycje))      # z aktu bazowego (brakowało)
+        self.assertIn("Dz.U. 2026 poz. 1003", "\n".join(pozycje))
+        self.assertNotIn("Dz.U. 2025 poz. 1500", "\n".join(pozycje))   # w całości przed stanem prawnym t.j.
+        self.assertEqual("\n".join(pozycje).count("poz. 830"), 1)       # bez duplikatu
+        linia_830 = next(l for l in pozycje if "poz. 830" in l)
+        self.assertIn("data aktu 2026-05-29", linia_830)
+        self.assertIn("ogłoszono 2026-06-23", linia_830)
+        self.assertIn("wejście w życie zmiany 2026-07-08", linia_830)
+        self.assertNotIn("(data 2026", linia_830)                       # stara, dwuznaczna etykieta
+
+    def test_awaria_aktu_bazowego_strict_blokuje_a_domyslnie_ostrzega(self):
+        def fake(path, params=None, soft=False):
+            if path == "/acts/DU/1964/296/references":
+                raise eli.VerificationUnknown("timeout")
+            if path in ("/acts/DU/2026/830", "/acts/DU/2026/473"):
+                return {"entryIntoForce": None}       # dopytanie o wejście w życie bez daty
+            return self._fake_get(path, params, soft)
+        with mock.patch.object(eli, "_get", side_effect=fake):
+            with self.assertRaises(eli.VerificationUnknown):
+                eli._nowelizacje_po_tj(self.REFS_TJ, "/acts/DU/2026/468", strict=True)
+            linie, uwagi = eli._nowelizacje_po_tj(self.REFS_TJ, "/acts/DU/2026/468", strict=False)
+        self.assertTrue(uwagi and "NIEPEŁNA" in uwagi[0])
+        self.assertIn("odnotowano zmiany (2)", linie[0])
+        self.assertIn("wejście w życie aktu — sprawdź: meta DU 2026 830", linie[1])
+
+    def test_dopytanie_o_wejscie_w_zycie_jest_ograniczone(self):
+        # pozycje tylko z listy t.j. bez daty wejścia w życie → meta aktu, ale nie więcej niż _MAKS_DOPYTAN
+        wlasne = [{"act": {"ELI": f"DU/2026/{n}", "displayAddress": f"Dz.U. 2026 poz. {n}", "title": "x",
+                           "announcementDate": "2026-01-01", "promulgation": "2026-01-02"}} for n in range(1, 15)]
+        refs = {"Tekst jednolity dla aktu": self.REFS_TJ["Tekst jednolity dla aktu"],
+                "Nowelizacje po tekście jednolitym": wlasne}
+        zapytania = []
+        def fake(path, params=None, soft=False):
+            zapytania.append(path)
+            if path == "/acts/DU/2026/468":
+                return self.META_TJ
+            if path == "/acts/DU/1964/296/references":
+                return {"Akty zmieniające": []}
+            return {"entryIntoForce": "2026-09-01", "comments": "art. 5 wchodzi w życie z dniem 1 stycznia 2027 r."}
+        with mock.patch.object(eli, "_get", side_effect=fake):
+            linie, uwagi = eli._nowelizacje_po_tj(refs, "/acts/DU/2026/468")
+        self.assertEqual(sum(1 for p in zapytania if p.startswith("/acts/DU/2026/") and p != "/acts/DU/2026/468"),
+                         eli._MAKS_DOPYTAN)
+        self.assertIn("wejście w życie aktu 2026-09-01", linie[1])
+        self.assertIn("uwagi: art. 5 wchodzi w życie", linie[2])
+        self.assertTrue(any("sprawdź: meta DU 2026" in l for l in linie))
+
+    def test_fmt_ref_etykiety_dat_zalezne_od_kategorii(self):
+        ref = {"act": {"ELI": "DU/2026/830", "displayAddress": "Dz.U. 2026 poz. 830", "title": "T",
+                       "announcementDate": "2026-05-29", "promulgation": "2026-06-23"}, "date": "2026-07-08"}
+        self.assertIn("wejście w życie zmiany 2026-07-08", eli._fmt_ref(ref, "Akty zmieniające"))
+        ref2 = dict(ref, date="2026-05-29")
+        linia = eli._fmt_ref(ref2, "Nowelizacje po tekście jednolitym")
+        self.assertIn("data aktu 2026-05-29", linia)
+        self.assertEqual(linia.count("2026-05-29"), 1)
+        self.assertIn("data wg API 2026-07-08", eli._fmt_ref(ref, "Orzeczenie TK"))
+        self.assertNotIn("(data 2026", eli._fmt_ref(ref, "Akty zmieniające"))
+
+
+PDF_LAYOUT = (
+    "     ©Kancelaria Sejmu                                                        s. 1/3\n"
+    "\n"
+    "                                        Dz. U. 2026 poz. 795\n"
+    "\n"
+    "                                   O B W IE S Z CZ E N I E\n"
+    "                                      z dnia 27 maja 2026 r.\n"
+    "     w sprawie ogłoszenia jednolitego tekstu ustawy – Kodeks cywilny\n"
+    "     1. Na podstawie art. 16 ust. 1 ogłasza się jednolity tekst ustawy, z uwzględnieniem stanu prawnego\n"
+    "na dzień 19 maja 2026 r. Tekst nie obejmuje art. 3 ustawy, który stanowi:\n"
+    "     „Art. 3. Ustawa wchodzi w życie po upływie miesiąca od dnia ogłoszenia.”\n"
+    "                                                                                     2026-06-22\n"
+    "\f"
+    "Dziennik Ustaw                               – 2 –                                   Poz. 795\n"
+    "\n"
+    "                                 Załącznik do obwieszczenia Marszałka Sejmu\n"
+    "\n"
+    "                                             US T AW A\n"
+    "                                      z dnia 23 kwietnia 1964 r.\n"
+    "                                          Kodeks cywilny\n"
+    "      Art. 3. Ustawa nie ma mocy wstecznej, chyba że to wynika z jej brzmienia lub celu.\n"
+    "      Art. 68[1]. § 1. W stosunkach między przedsiębiorcami odpowiedź na ofertę z zastrzeżeniem nie-\n"
+    "zmieniających istotnie treści oferty poczytuje się za jej przyjęcie.\n"
+    "      Art. 187. § 1.3) Rzecz znaleziona, która nie zostanie odebrana w ciągu 6 miesięcy od dnia\n"
+    "doręczenia wezwania, staje się własnością znalazcy.\n"
+    "      § 2. (uchylony)5)\n"
+    "\n"
+    "3)   W brzmieniu ustalonym przez art. 2 ustawy z dnia 23 stycznia 2026 r. (Dz. U. poz. 184), która\n"
+    "     weszła w życie z dniem 19 maja 2026 r.\n"
+    "5)\n"
+    "     Uchylony przez art. 1 ustawy.\n"
+    "                                                                                     2026-06-22\n"
+    "\f"
+    "Dziennik Ustaw                               – 3 –                                   Poz. 795\n"
+    "\n"
+    "      Art. 385[3]. W razie wątpliwości uważa się, że niedozwolonymi są te, które w szczególności:\n"
+    "1)   wyłączają lub ograniczają odpowiedzialność względem konsumenta za szkody na osobie;\n"
+    "2)   wyłączają lub istotnie ograniczają odpowiedzialność za niewykonanie lub nienależyte wyko-\n"
+    "     nanie zobowiązania;\n"
+    "\n"
+    "                                                           DZIAŁ IV\n"
+    "                                                        Współwłasność\n"
+    "      Art. 195. Własność tej samej rzeczy może przysługiwać niepodzielnie kilku osobom (współwłasność).\n"
+    "                                                                                     2026-06-22\n"
+    "\f")
+
+
+class TestAudyt2026PdfLayout(unittest.TestCase):
+    """D01/D06: tekst z urzędowego PDF (pdftotext -layout) — nagłówki/stopki usunięte, wiersze sklejone,
+    odsyłacze do przypisów poza numeracją, przypisy z dołu strony pod akapitem, jednostki na początku linii."""
+
+    def setUp(self):
+        self.t = eli.pdf_layout_do_tekstu(PDF_LAYOUT)
+
+    def test_naglowki_i_stopki_usuniete(self):
+        for smiec in ("Kancelaria Sejmu", "s. 1/3", "– 2 –", "2026-06-22", "Dziennik Ustaw"):
+            self.assertNotIn(smiec, self.t, smiec)
+
+    def test_wiersze_sklejone_i_dzielenie_wyrazow(self):
+        self.assertIn("z zastrzeżeniem niezmieniających istotnie treści oferty", self.t)   # „nie-" + „zmieniających"
+        self.assertIn("nienależyte wykonanie zobowiązania;", self.t)
+        self.assertIn("w ciągu 6 miesięcy od dnia doręczenia wezwania, staje się", self.t)  # zwykła kontynuacja
+
+    def test_odsylacz_do_przypisu_poza_numeracja_a_tresc_pod_akapitem(self):
+        self.assertIn("Art. 187. § 1. Rzecz znaleziona", self.t)
+        self.assertNotIn("§ 1.3)", self.t)
+        self.assertIn("\n[przypis 3)] W brzmieniu ustalonym przez art. 2 ustawy z dnia 23 stycznia 2026 r. "
+                      "(Dz. U. poz. 184), która weszła w życie z dniem 19 maja 2026 r.\n", self.t)
+        self.assertIn("§ 2. (uchylony)\n[przypis 5)] Uchylony przez art. 1 ustawy.", self.t)
+        self.assertNotIn("(uchylony)5)", self.t)
+
+    def test_indeks_gorny_jak_w_html_i_fragmenty(self):
+        self.assertIn("Art. 68 1. § 1.", self.t)
+        frag = [self.t[s:e] for s, e in eli._fragmenty(self.t, "art. 68(1)")]
+        self.assertEqual(len(frag), 1)
+        self.assertIn("niezmieniających", frag[0])
+        frag = [self.t[s:e] for s, e in eli._fragmenty(self.t, "art. 187")]
+        self.assertEqual(len(frag), 1)
+        self.assertIn("6 miesięcy", frag[0])
+        self.assertIn("[przypis 3)]", frag[0])
+        self.assertNotIn("Art. 195", frag[0])
+
+    def test_obwieszczenie_oznaczone_i_nie_udaje_artykulu(self):
+        # „Art. 3." cytowany w obwieszczeniu NIE może trafić jako nagłówek artykułu k.c.
+        frag = [self.t[s:e] for s, e in eli._fragmenty(self.t, "art. 3")]
+        self.assertEqual(len(frag), 1)
+        self.assertIn("mocy wstecznej", frag[0])
+        self.assertIn("» „Art. 3. Ustawa wchodzi w życie", self.t)
+        self.assertIn("NIE są treścią aktu", self.t)
+        self.assertIn("OBWIESZCZENIE", self.t)     # rozstrzelony tytuł złączony
+        self.assertIn("\nUSTAWA\n", self.t)
+
+    def test_pkt_i_naglowki_dzialu(self):
+        self.assertIn("\n1) wyłączają lub ograniczają", self.t)
+        self.assertIn("\n2) wyłączają lub istotnie", self.t)
+        self.assertIn("\nDZIAŁ IV\n\nWspółwłasność\n", self.t)
+        self.assertTrue(any(b == self.t.index("DZIAŁ IV") for b in
+                            [m.start() for m in eli.re.finditer(eli._GRANICE, self.t)]))
+
+    def test_pdftotext_awaria_daje_pusty_tekst(self):
+        with mock.patch.object(eli.subprocess, "run", side_effect=OSError("brak")):
+            self.assertEqual(eli.pdf_do_tekstu_layout(b"%PDF-1.4"), "")
+        with mock.patch.object(eli.subprocess, "run", return_value=mock.Mock(returncode=1, stdout=b"")):
+            self.assertEqual(eli.pdf_do_tekstu_layout(b"%PDF-1.4"), "")
+
+
+class TestAudyt2026TekstZPdf(unittest.TestCase):
+    """D01/D06/strict: przy textHTML=false `tekst` czyta WŁASNY PDF aktu (strict przepuszcza);
+    gdy pdftotext nie działa — strict blokuje, a domyślnie starszy t.j. z pełnym ostrzeżeniem."""
+
+    REFS_TJ = {"Tekst jednolity dla aktu": [{"act": {"ELI": "DU/1964/93", "displayAddress": "Dz.U. 1964 nr 16 poz. 93"}}]}
+    REFS_BAZOWE = {
+        "Inf. o tekście jednolitym": [
+            {"act": {"ELI": "DU/2026/795", "displayAddress": "Dz.U. 2026 poz. 795"}},
+            {"act": {"ELI": "DU/2025/1071", "displayAddress": "Dz.U. 2025 poz. 1071"}},
+            {"act": {"ELI": "DU/2024/1061", "displayAddress": "Dz.U. 2024 poz. 1061"}}],
+        "Akty zmieniające": [
+            {"act": {"ELI": "DU/2026/184", "displayAddress": "Dz.U. 2026 poz. 184", "title": "Ustawa o rzeczach znalezionych",
+                     "announcementDate": "2026-01-23", "promulgation": "2026-02-18"}, "date": "2026-05-19"},
+            {"act": {"ELI": "DU/2026/507", "displayAddress": "Dz.U. 2026 poz. 507", "title": "Ustawa o CEIDG",
+                     "announcementDate": "2026-03-13", "promulgation": "2026-04-13"}, "date": "2028-11-01"},
+            {"act": {"ELI": "DU/2023/1", "displayAddress": "Dz.U. 2023 poz. 1", "title": "Stara",
+                     "announcementDate": "2023-01-01", "promulgation": "2023-01-02"}, "date": "2023-02-01"}]}
+    META = {"DU/2026/795": {"ELI": "DU/2026/795", "legalStatusDate": "2026-05-19", "textHTML": False, "textPDF": True,
+                            "displayAddress": "Dz.U. 2026 poz. 795",
+                            "texts": [{"fileName": "D20260795.pdf", "type": "O"}, {"fileName": "D20260795L.pdf", "type": "T"}]},
+            "DU/2025/1071": {"ELI": "DU/2025/1071", "legalStatusDate": "2025-07-24"},
+            "DU/2024/1061": {"ELI": "DU/2024/1061", "legalStatusDate": "2024-06-19"}}
+    HTML = {"DU/2026/795": "", "DU/2025/1071": "", "DU/2024/1061": "<p>Art. 187.</p><p>§ 1. Rzecz znaleziona w ciągu roku.</p>"}
+
+    def _fake_get(self, path, params=None, soft=False):
+        m = eli.re.match(r"^/acts/(DU/\d+/\d+)(/references|/text\.html)?$", path)
+        eli_id, co = m.group(1), m.group(2)
+        if co == "/references":
+            return self.REFS_BAZOWE if eli_id == "DU/1964/93" else self.REFS_TJ
+        if co == "/text.html":
+            return self.HTML[eli_id]
+        return self.META[eli_id]
+
+    def _tekst(self, argv, pdftotext=True, raw=PDF_LAYOUT):
+        out = io.StringIO()
+        pobrane = []
+        with mock.patch.object(eli, "_get", side_effect=self._fake_get), \
+                mock.patch.object(eli, "_get_bytes", side_effect=lambda url, soft=False: pobrane.append(url) or b"%PDF"), \
+                mock.patch.object(eli, "pdftotext_dostepny", return_value=pdftotext), \
+                mock.patch.object(eli, "pdf_do_tekstu_layout", return_value=raw), \
+                mock.patch.object(sys, "argv", ["eli.py"] + argv), \
+                contextlib.redirect_stdout(out):
+            eli.main()
+        return out.getvalue(), pobrane
+
+    def test_pdf_wlasnego_aktu_zamiast_starszego_tj_i_strict_przepuszcza(self):
+        out, pobrane = self._tekst(["tekst", "DU", "2026", "795", "--fragment", "art. 187", "--strict"])
+        self.assertEqual(pobrane, ["https://api.sejm.gov.pl/eli/acts/DU/2026/795/text/T/D20260795L.pdf"])
+        self.assertIn("(tekst z urzędowego PDF przez pdftotext", out.replace("— tekst (z urzędowego", "(tekst z urzędowego"))
+        self.assertIn("ELI_TEXT_SOURCE_PDF=https://api.sejm.gov.pl/eli/acts/DU/2026/795/text/T/D20260795L.pdf", out)
+        self.assertIn("w ciągu 6 miesięcy", out)
+        self.assertNotIn("w ciągu roku", out)                   # stare brzmienie z 2024/1061 NIE wchodzi
+        self.assertNotIn("NIEAKTUALNE", out)
+        self.assertNotIn("ELI_TEXT_SOURCE_FALLBACK", out)
+        self.assertIn("odnotowano zmiany (1)", out)               # 2026/507 wchodzi w życie po stanie prawnym
+        self.assertIn("Dz.U. 2026 poz. 507", out)
+
+    def test_bez_pdftotext_starszy_tj_z_pelnym_ostrzezeniem_i_zmianami_inline(self):
+        out, pobrane = self._tekst(["tekst", "DU", "2026", "795", "--fragment", "art. 187"], pdftotext=False)
+        self.assertEqual(pobrane, [])
+        self.assertIn("NIEAKTUALNE BRZMIENIE MOŻLIWE", out.split("\n")[0])
+        self.assertIn("ELI_TEXT_SOURCE_FALLBACK=DU/2024/1061", out)
+        self.assertIn("Pominięto t.j. z pustym text.html: DU/2025/1071", out)
+        self.assertIn("brak programu pdftotext", out)
+        self.assertIn("po 2024-06-19 (2) — NIE ma ich w poniższym tekście", out)
+        self.assertIn("Dz.U. 2026 poz. 184", out)
+        self.assertIn("wejście w życie zmiany 2026-05-19", out)
+        self.assertNotIn("Dz.U. 2023 poz. 1 ", out)
+        self.assertNotIn("odniesienia DU 2024 1061", out)        # martwa instrukcja usunięta
+        self.assertNotIn("opóźnieniem", out)
+        self.assertIn("w ciągu roku", out)
+
+    def test_strict_blokuje_gdy_pdftotext_zawodzi(self):
+        for pdftotext, raw, blad in ((False, PDF_LAYOUT, "brak programu pdftotext"),
+                                     (True, "", "pdftotext nie zwrócił tekstu")):
+            with self.subTest(blad=blad):
+                with self.assertRaises(SystemExit) as caught:
+                    self._tekst(["tekst", "DU", "2026", "795", "--strict"], pdftotext=pdftotext, raw=raw)
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertIn(blad, str(caught.exception.code))
+                self.assertIn("strict blokuje zastępczy", str(caught.exception.code))
+
+    def test_konstytucja_bez_html_i_bez_pdftotext_komunikat_bez_opoznienia(self):
+        meta = {"DU/1997/483": {"ELI": "DU/1997/483", "textHTML": False,
+                                "texts": [{"fileName": "D19970483Lj.pdf", "type": "U"}]}}
+        def fake(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return {"Podstawa prawna": []}
+            if path.endswith("/text.html"):
+                return ""
+            return meta["DU/1997/483"]
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake), \
+                mock.patch.object(eli, "pdftotext_dostepny", return_value=False), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eli.cmd_tekst(argparse.Namespace(sygnatura=["DU", "1997", "483"], json=False, strict=False,
+                                                 pdf=None, fragment="Art. 45"))
+        self.assertNotIn("opóźnieniem", str(caught.exception.code))
+        self.assertIn("textHTML=false", str(caught.exception.code))
+        self.assertIn("pdftotext", str(caught.exception.code))
+        self.assertEqual(out.getvalue(), "")
+
+    def test_konstytucja_przez_pdf(self):
+        raw = ("©Kancelaria Sejmu                                                       s. 1/2\n\n"
+               "      Art. 45. 1. Każdy ma prawo do sprawiedliwego i jawnego rozpatrzenia sprawy\n"
+               "bez nieuzasadnionej zwłoki przez właściwy, niezależny, bezstronny i niezawisły sąd.\n"
+               "      2. Wyłączenie jawności rozprawy może nastąpić ze względu na moralność.\n"
+               "      Art. 46. Przepadek rzeczy może nastąpić tylko w przypadkach określonych w ustawie.\n"
+               "                                                                        2015-01-07\n\f")
+        meta = {"ELI": "DU/1997/483", "textHTML": False, "texts": [{"fileName": "D19970483Lj.pdf", "type": "U"}]}
+        def fake(path, params=None, soft=False):
+            if path.endswith("/references"):
+                return {"Podstawa prawna": []}
+            if path.endswith("/text.html"):
+                return ""
+            return meta
+        out = io.StringIO()
+        with mock.patch.object(eli, "_get", side_effect=fake), \
+                mock.patch.object(eli, "_get_bytes", return_value=b"%PDF"), \
+                mock.patch.object(eli, "pdftotext_dostepny", return_value=True), \
+                mock.patch.object(eli, "pdf_do_tekstu_layout", return_value=raw), \
+                contextlib.redirect_stdout(out):
+            eli.cmd_tekst(argparse.Namespace(sygnatura=["DU", "1997", "483"], json=False, strict=True,
+                                             pdf=None, fragment="Art. 45"))
+        self.assertIn("Art. 45. 1. Każdy ma prawo do sprawiedliwego i jawnego rozpatrzenia sprawy bez "
+                      "nieuzasadnionej zwłoki przez właściwy, niezależny, bezstronny i niezawisły sąd.\n"
+                      "2. Wyłączenie jawności", out.getvalue())
+        self.assertNotIn("Art. 46", out.getvalue())
+        self.assertIn("/text/U/D19970483Lj.pdf", out.getvalue())
+
+
+class TestAudyt2026Cache(unittest.TestCase):
+    def test_get_bez_parametrow_jest_cache_owany_a_z_parametrami_nie(self):
+        eli._CACHE.clear()
+        wywolania = []
+        def fake(url, soft):
+            wywolania.append(url)
+            return {"ok": len(wywolania)}
+        with mock.patch.object(eli, "_pobierz", side_effect=fake):
+            self.assertEqual(eli._get("/acts/DU/2024/18"), {"ok": 1})
+            self.assertEqual(eli._get("/acts/DU/2024/18"), {"ok": 1})
+            eli._get("/acts/search", {"title": "x"})
+            eli._get("/acts/search", {"title": "x"})
+        self.assertEqual(len(wywolania), 3)
+        eli._CACHE.clear()
+
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_saos.py
+++ b/tools/test_saos.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for saos.py pure functions (no network). Run: python3 tools/test_saos.py"""
+import argparse
+import contextlib
+import io
+import sys
+import importlib.util
+import pathlib
+import unittest
+import urllib.error
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "saos", ROOT / "plugins/prawo-pl-saos/skills/prawo-pl-saos/scripts/saos.py")
+saos = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(saos)
+
+
+class TestCourtType(unittest.TestCase):
+    def test_aliases(self):
+        cases = [
+            ("SN", "SUPREME"), ("sn", "SUPREME"),
+            ("TK", "CONSTITUTIONAL_TRIBUNAL"), ("trybunał", "CONSTITUTIONAL_TRIBUNAL"),
+            ("powszechne", "COMMON"), ("SA", "COMMON"), ("SO", "COMMON"), ("SR", "COMMON"),
+            ("admin", "ADMINISTRATIVE"), ("NSA", "ADMINISTRATIVE"), ("WSA", "ADMINISTRATIVE"),
+            ("KIO", "NATIONAL_APPEAL_CHAMBER"),
+            ("SUPREME", "SUPREME"),  # forma kanoniczna też przechodzi
+        ]
+        for inp, want in cases:
+            self.assertEqual(saos._court_type(inp), want, f"sąd: {inp!r}")
+
+    def test_none_passes_through(self):
+        self.assertIsNone(saos._court_type(None))
+
+    def test_invalid_exits(self):
+        with self.assertRaises(SystemExit):
+            saos._court_type("kosmiczny")
+
+
+class TestJType(unittest.TestCase):
+    def test_aliases(self):
+        cases = [
+            ("wyrok", "SENTENCE"), ("postanowienie", "DECISION"), ("uchwala", "RESOLUTION"),
+            ("uchwała", "RESOLUTION"), ("zarzadzenie", "REGULATION"), ("uzasadnienie", "REASONS"),
+            ("SENTENCE", "SENTENCE"),
+        ]
+        for inp, want in cases:
+            self.assertEqual(saos._jtype(inp), want, f"typ: {inp!r}")
+
+    def test_none_passes_through(self):
+        self.assertIsNone(saos._jtype(None))
+
+    def test_invalid_exits(self):
+        with self.assertRaises(SystemExit):
+            saos._jtype("apelacja")
+
+
+class TestHtmlToText(unittest.TestCase):
+    def test_strips_em_highlight(self):
+        # snippety SAOS podświetlają trafienie znacznikiem <em>
+        t = saos.html_to_text("…trudno przyjąć, by <em>rękojmia</em> wiary publicznej…")
+        self.assertIn("rękojmia", t)
+        self.assertNotIn("<em>", t)
+
+    def test_strips_script(self):
+        t = saos.html_to_text("<p>A</p><script>var x=1;</script><p>B</p>")
+        self.assertIn("A", t)
+        self.assertIn("B", t)
+        self.assertNotIn("var x", t)
+
+    def test_normalizes_nbsp(self):
+        self.assertEqual(saos.html_to_text("<p>art.\xa0299</p>"), "art. 299")
+
+    def test_collapses_blank_lines(self):
+        t = saos.html_to_text("<div><p>A</p><p></p><p></p><p>B</p></div>")
+        self.assertNotIn("\n\n\n", t)
+
+
+class TestFragmenty(unittest.TestCase):
+    def test_okno_wokol_frazy(self):
+        txt = ("X" * 50) + "FRAZA" + ("Y" * 50)
+        spans = saos._fragmenty(txt, "fraza")
+        self.assertEqual(len(spans), 1)
+        wycinek = txt[spans[0][0]:spans[0][1]]
+        self.assertIn("FRAZA", wycinek)
+
+    def test_dwa_odlegle_trafienia_dwa_okna(self):
+        txt = "AAA cel " + ("Z" * 2000) + " cel BBB"
+        spans = saos._fragmenty(txt, "cel")
+        self.assertEqual(len(spans), 2)
+
+    def test_bliskie_trafienia_scalone(self):
+        txt = "start cel oraz cel koniec"  # oba trafienia w jednym oknie
+        spans = saos._fragmenty(txt, "cel")
+        self.assertEqual(len(spans), 1)
+
+    def test_brak_trafien(self):
+        self.assertEqual(saos._fragmenty("dowolny tekst", "nie ma takiej frazy"), [])
+
+    def test_pusta_fraza(self):
+        self.assertEqual(saos._fragmenty("cokolwiek", "   "), [])
+
+    def test_limit_okien(self):
+        txt = (" cel " + "Q" * 2000) * 10
+        spans = saos._fragmenty(txt, "cel", maks=3)
+        self.assertLessEqual(len(spans), 3)
+
+    def test_okno_dosuwane_do_granicy_zdania(self):  # D10: nie ucinamy w pół słowa
+        przed = "Pierwsze zdanie o niczym. " * 12
+        txt = (przed + "Drugie zdanie zaczyna się tu i mówi o rękojmi za wady. Trzecie zdanie kończy. "
+               + "Czwarte zdanie jest dalej. " * 12)
+        (s, e), = saos._fragmenty(txt, "rękojmi", okno=60)
+        self.assertTrue(txt[s:].startswith("Drugie zdanie"), txt[s:s + 30])
+        self.assertTrue(txt[:e].endswith("."), txt[e - 30:e])  # koniec okna = koniec zdania
+        self.assertTrue(txt[e:].startswith(" Czwarte") or txt[e:].startswith(" Trzecie"), txt[e:e + 20])
+
+    def test_okno_bez_zdan_dosuwane_do_slowa(self):
+        txt = "alfa " * 100 + "cel " + "beta " * 100
+        (s, e), = saos._fragmenty(txt, "cel", okno=30)
+        self.assertTrue(s == 0 or txt[s - 1] == " ", repr(txt[s - 3:s + 3]))
+        self.assertTrue(e == len(txt) or txt[e] == " " or txt[e - 1] == " ", repr(txt[e - 3:e + 3]))
+
+
+class TestCourtLabel(unittest.TestCase):
+    def test_common_court_name_and_division(self):
+        it = {"division": {"name": "I Wydział Cywilny",
+                           "court": {"name": "Sąd Apelacyjny w Krakowie"}}}
+        self.assertEqual(saos._court_label(it), "Sąd Apelacyjny w Krakowie, I Wydział Cywilny")
+
+    def test_supreme_chambers_list(self):  # kształt z /search
+        it = {"division": {"name": "Wydział III", "chambers": [{"name": "Izba Cywilna"}]}}
+        self.assertEqual(saos._court_label(it), "Izba Cywilna")
+
+    def test_supreme_chamber_single(self):  # kształt z /judgments/{id}
+        it = {"division": {"chamber": {"name": "Izba Karna"}}}
+        self.assertEqual(saos._court_label(it), "Izba Karna")
+
+    def test_fallback_division_name(self):
+        self.assertEqual(saos._court_label({"division": {"name": "Wydział X"}}), "Wydział X")
+
+    def test_empty(self):
+        self.assertEqual(saos._court_label({}), "")
+
+
+class TestCaseNumbers(unittest.TestCase):
+    def test_joins_case_numbers(self):
+        it = {"courtCases": [{"caseNumber": "III CSK 203/09"}, {"caseNumber": "I CSK 70/07"}]}
+        self.assertEqual(saos._case_numbers(it), "III CSK 203/09, I CSK 70/07")
+
+    def test_empty(self):
+        self.assertEqual(saos._case_numbers({}), "")
+
+
+class TestForma(unittest.TestCase):
+    def test_string_form_from_search(self):  # /search zwraca string
+        self.assertEqual(saos._forma({"judgmentType": "SENTENCE", "judgmentForm": "wyrok SN"}),
+                         "wyrok (wyrok SN)")
+        self.assertEqual(saos._forma({"judgmentForm": "wyrok SN"}), "wyrok SN")
+
+    def test_dict_form_from_detail(self):  # /judgments/{id} zwraca obiekt {'name': …}
+        self.assertEqual(saos._forma({"judgmentForm": {"name": "wyrok SN"}}), "wyrok SN")
+
+    def test_fallback_to_judgment_type(self):  # surowy enum API → polska nazwa (D09)
+        self.assertEqual(saos._forma({"judgmentType": "SENTENCE"}), "wyrok")
+
+    def test_enum_po_polsku_dla_kazdego_sadu(self):
+        for enum, pl in (("SENTENCE", "wyrok"), ("DECISION", "postanowienie"), ("RESOLUTION", "uchwała"),
+                         ("REGULATION", "zarządzenie"), ("REASONS", "uzasadnienie")):
+            self.assertEqual(saos._forma({"judgmentType": enum}), pl, enum)
+        self.assertNotIn("SENTENCE", saos._forma({"judgmentType": "SENTENCE", "courtType": "COMMON"}))
+
+    def test_forma_sn_dopisana_gdy_dokladniejsza(self):
+        self.assertEqual(saos._forma({"judgmentType": "RESOLUTION",
+                                      "judgmentForm": "uchwała składu 7 sędziów SN"}),
+                         "uchwała (uchwała składu 7 sędziów SN)")
+        self.assertEqual(saos._forma({"judgmentType": "SENTENCE", "judgmentForm": "wyrok"}), "wyrok")
+
+    def test_empty(self):
+        self.assertEqual(saos._forma({}), "")
+
+
+class TestZasiegZbiorow(unittest.TestCase):
+    """SAOS przestał zasilać SN/TK/KIO — bez ostrzeżenia zero trafień udaje brak orzecznictwa.
+    Granica jest znana do DNIA (D01): SN 2016-06-22, TK 2015-12-09, KIO 2018-09-06."""
+
+    def test_granice_do_dnia(self):
+        self.assertEqual(saos.ZASIEG["SUPREME"][0], "2016-06-22")
+        self.assertEqual(saos.ZASIEG["CONSTITUTIONAL_TRIBUNAL"][0], "2015-12-09")
+        self.assertEqual(saos.ZASIEG["NATIONAL_APPEAL_CHAMBER"][0], "2018-09-06")
+
+    def test_sn_ma_granice(self):
+        k = saos._ostrzezenie_zasiegu("SUPREME")
+        self.assertIn("22.06.2016", k)
+        self.assertNotIn("na 2016 r.", k)
+        self.assertIn("Sąd Najwyższy", k)
+        self.assertIn("nie ma górnej granicy", k)
+
+    def test_zakres_poza_zbiorem_dopisuje_powod(self):
+        k = saos._ostrzezenie_zasiegu("NATIONAL_APPEAL_CHAMBER", "2021-01-01")
+        self.assertIn("06.09.2018", k)
+        self.assertIn("POZA zbiorem", k)
+
+    def test_zakres_w_tym_samym_roku_po_granicy_jest_poza_zbiorem(self):  # D01: Q4-2018 KIO
+        k = saos._ostrzezenie_zasiegu("NATIONAL_APPEAL_CHAMBER", "2018-10-01", "2018-12-31")
+        self.assertIn("POZA zbiorem", k)
+        k = saos._ostrzezenie_zasiegu("SUPREME", "2016-07-01", "2016-12-31")
+        self.assertIn("POZA zbiorem", k)
+
+    def test_zakres_siegajacy_poza_granice_ostrzega(self):
+        k = saos._ostrzezenie_zasiegu("SUPREME", "2016-01-01", "2016-12-31")
+        self.assertNotIn("POZA zbiorem", k)
+        self.assertIn("po 22.06.2016 SAOS nie ma NIC", k)
+
+    def test_zakres_w_zbiorze_bez_dopisku(self):
+        k = saos._ostrzezenie_zasiegu("CONSTITUTIONAL_TRIBUNAL", "2010-01-01", "2015-12-09")
+        self.assertNotIn("POZA zbiorem", k)
+        self.assertNotIn("nie ma NIC", k)
+
+    def test_granica_potwierdzona_na_zywo_w_komunikacie(self):
+        k = saos._ostrzezenie_zasiegu("SUPREME", None, None, "2016-06-22", True)
+        self.assertIn("potwierdzone na żywo", k)
+
+    def test_sady_powszechne_bez_ostrzezenia(self):
+        self.assertIsNone(saos._ostrzezenie_zasiegu("COMMON"))
+        self.assertIsNone(saos._ostrzezenie_zasiegu(None))
+
+
+class TestNormaData(unittest.TestCase):
+    def test_rok_i_miesiac(self):
+        self.assertEqual(saos._norma_data("2016"), "2016-01-01")
+        self.assertEqual(saos._norma_data("2016", koniec=True), "2016-12-31")
+        self.assertEqual(saos._norma_data("2016-02", koniec=True), "2016-02-29")
+        self.assertEqual(saos._norma_data("2015-02", koniec=True), "2015-02-28")
+        self.assertEqual(saos._norma_data("2018-09-06"), "2018-09-06")
+        self.assertIsNone(saos._norma_data(None))
+
+    def test_zly_format_konczy_bledem(self):
+        with self.assertRaisesRegex(SystemExit, "RRRR-MM-DD"):
+            saos._norma_data("06.09.2018")
+
+
+class TestGranicaNaZywo(unittest.TestCase):
+    """Granica zbioru jest samoweryfikująca: tanie zapytanie o najnowsze orzeczenie (cache w procesie)."""
+
+    def setUp(self):
+        saos._granice_na_zywo.clear()
+
+    def test_potwierdzenie_na_zywo_i_cache(self):
+        odp = {"items": [{"id": 245360, "judgmentDate": "2016-06-22"}], "info": {"totalResults": 38081}}
+        with mock.patch.object(saos, "_get", return_value=odp) as get:
+            self.assertEqual(saos._granica_zbioru("SUPREME"), ("2016-06-22", True))
+            self.assertEqual(saos._granica_zbioru("SUPREME"), ("2016-06-22", True))
+        get.assert_called_once()
+        self.assertTrue(get.call_args.kwargs.get("soft"))
+        self.assertEqual(get.call_args.args[1]["pageSize"], 1)
+
+    def test_wznowione_zasilanie_przesuwa_granice(self):
+        odp = {"items": [{"id": 1, "judgmentDate": "2024-03-01"}], "info": {"totalResults": 1}}
+        with mock.patch.object(saos, "_get", return_value=odp):
+            self.assertEqual(saos._granica_zbioru("NATIONAL_APPEAL_CHAMBER"), ("2024-03-01", True))
+
+    def test_awaria_transportu_zostawia_znana_granice(self):
+        with mock.patch.object(saos, "_get", side_effect=saos.VerificationUnknown("przerwa")):
+            self.assertEqual(saos._granica_zbioru("CONSTITUTIONAL_TRIBUNAL"), ("2015-12-09", False))
+
+
+class TestIndeksyGorne(unittest.TestCase):
+    """D04: <sup> w tekstach sądów powszechnych ma być indeksem górnym w jednej linii, nie łamaniem."""
+
+    def test_sup_z_artefaktem_saos(self):
+        html = ('Stosownie do treści <a href="x">art. 556<sup>\n<!-- -->1</sup> § 1 k.c.</a> wada fizyczna '
+                'polega')
+        self.assertEqual(saos.html_to_text(html), "Stosownie do treści art. 556¹ § 1 k.c. wada fizyczna polega")
+
+    def test_sup_wielocyfrowy_i_spacja_koncowa(self):
+        self.assertEqual(saos.html_to_text("art. 479<sup>45</sup> § 1"), "art. 479⁴⁵ § 1")
+        self.assertEqual(saos.html_to_text("art. 556<sup>\n<!-- --> 5 </sup>k.c."), "art. 556⁵ k.c.")
+        self.assertEqual(saos.html_to_text("2461 cm<sup>\n<!-- -->3</sup> i moc"), "2461 cm³ i moc")
+
+    def test_artefakt_nowej_linii_w_em(self):
+        self.assertEqual(saos.html_to_text("możliwe <em>\n<!-- -->(art. 561<sup>\n<!-- --> 2</sup> § 2 k.c.)</em>"),
+                         "możliwe (art. 561² § 2 k.c.)")
+
+    def test_akapity_nadal_lamane(self):
+        self.assertEqual(saos.html_to_text("<p>A</p><p>B</p>"), "A\nB")
+
+
+class TestWpisPrzepisu(unittest.TestCase):
+    """D11: uszkodzone wpisy z referencedRegulations są oznaczane, czyste nie."""
+
+    def _w(self, text):
+        return saos._wpis_przepisu({"text": text})
+
+    def test_sklejony_numer(self):
+        self.assertIn("uszkodzony", self._w("Kodeks postępowania cywilnego (… art. 479(45) § 1-3, art. 4793647945)"))
+
+    def test_nr_0(self):
+        self.assertIn("„Nr 0”", self._w("Obwieszczenie … (Dz. U. z 2015 r. Nr 0 poz. 184 - art. 24 ust. 2)"))
+
+    def test_sklejone_slowa(self):
+        self.assertIn("sklejone słowa", self._w("Konstytucja (… art. 180 ust. 2oraz, art. 2oraz)"))
+        self.assertIn("sklejone słowa", self._w("Konstytucja (… art. 194 ust. atakże)"))
+
+    def test_art_n(self):
+        self.assertIn("„art. n”", self._w("Ustawa (… art. 6; art. n)"))
+
+    def test_czysty_wpis_bez_oznaczenia(self):
+        t = "Ustawa z dnia 23 kwietnia 1964 r. - Kodeks cywilny (Dz. U. z 1964 r. Nr 16 poz. 93 - art. 417, art. 417(1) § 1, art. 442(1))"
+        self.assertEqual(self._w({"text": t}["text"]), t)
+
+
+class TestZrodlaUrzedowe(unittest.TestCase):
+    """D07: link z SAOS dla SN/TK/KIO jest martwy — pokazujemy działający wzorzec / wyszukiwarkę."""
+
+    def test_sn_wzorzec_pdf(self):
+        linie = saos._zrodla_urzedowe({"courtType": "SUPREME", "courtCases": [{"caseNumber": "II KK 56/16"}],
+                                       "source": {"judgmentUrl": "http://www.sn.pl/orzecznictwo/SitePages/Baza_orzeczen"}})
+        self.assertIn("https://www.sn.pl/sites/orzecznictwo/Orzeczenia3/II%20KK%2056-16.pdf", linie[0])
+        self.assertIn("sprawdź — wzorzec adresu", linie[0])
+        self.assertIn("nie służy do weryfikacji", linie[1])
+        self.assertFalse(any(l.startswith("  Źródło oryginalne") for l in linie))
+
+    def test_tk_i_kio_wyszukiwarki(self):
+        tk = saos._zrodla_urzedowe({"courtType": "CONSTITUTIONAL_TRIBUNAL", "courtCases": [{"caseNumber": "K 35/15"}]})
+        self.assertIn("ipo.trybunal.gov.pl", tk[0]); self.assertIn("K 35/15", tk[0])
+        kio = saos._zrodla_urzedowe({"courtType": "NATIONAL_APPEAL_CHAMBER", "courtCases": [{"caseNumber": "KIO 1564/18"}]})
+        self.assertIn("orzeczenia.uzp.gov.pl", kio[0]); self.assertIn("KIO 1564/18", kio[0])
+
+    def test_sad_powszechny_zachowuje_link(self):
+        url = "https://apiorzeczenia.wroclaw.sa.gov.pl/ncourt-api/judgement/details?id=1"
+        linie = saos._zrodla_urzedowe({"courtType": "COMMON", "courtCases": [{"caseNumber": "I C 374/25"}],
+                                       "source": {"judgmentUrl": url}})
+        self.assertEqual(linie, [f"  Źródło oryginalne: {url}"])
+
+
+class TestSygnaturaZero(unittest.TestCase):
+    """D02: sygnatura z rocznika granicy nie może dostać „nie ma" — tylko „może być późniejsze"."""
+
+    def test_sn_z_rocznika_granicy(self):
+        msg = "\n".join(saos._wyjasnienie_zera_sygnatury("III CZP 81/16"))
+        self.assertIn("może być późniejsze niż koniec zbioru 22.06.2016", msg)
+        self.assertNotIn("NIE MA", msg)
+        self.assertNotIn("Trybunał", msg)
+
+    def test_kio_z_rocznika_granicy(self):
+        msg = "\n".join(saos._wyjasnienie_zera_sygnatury("KIO 2577/18"))
+        self.assertIn("może być późniejsze niż koniec zbioru 06.09.2018", msg)
+
+    def test_kio_po_granicy(self):
+        msg = "\n".join(saos._wyjasnienie_zera_sygnatury("KIO 12/19"))
+        self.assertIn("NIE MA z założenia", msg)
+
+    def test_tk_przed_granica(self):
+        msg = "\n".join(saos._wyjasnienie_zera_sygnatury("K 1/10"))
+        self.assertIn("mieści się w zbiorze", msg)
+
+    def test_nierozpoznana_sygnatura_nie_twierdzi_ze_nie_ma(self):
+        msg = "\n".join(saos._wyjasnienie_zera_sygnatury("I C 374/25"))
+        self.assertIn("sąd powszechny", msg)
+        self.assertIn("jeśli to Sąd Najwyższy", msg)
+
+    def test_cmd_sygnatura_zero_uzywa_granicy_do_dnia(self):
+        args = argparse.Namespace(sygnatura=["III", "CZP", "81/16"], json=False)
+        with mock.patch.object(saos, "_get", return_value={"items": [], "info": {"totalResults": 0}}):
+            with self.assertRaises(SystemExit) as caught:
+                saos.cmd_sygnatura(args)
+        self.assertIn("może być późniejsze niż koniec zbioru 22.06.2016", str(caught.exception))
+        self.assertNotIn("na 2016 r.", str(caught.exception))
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj", "fraza"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, saos.cmd_szukaj
+        saos.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            saos.main()
+        finally:
+            sys.argv, saos.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
+
+class _Response:
+    headers = {"Content-Type": "application/json"}
+
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class SaosVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_limit_czasu_90s_i_timeout_to_blad_sieci(self):  # API bywa wolne (40–60 s na /search)
+        import socket
+        with mock.patch.object(saos._opener, "open", side_effect=socket.timeout("timed out")) as op, \
+                mock.patch.object(saos.time, "sleep"):
+            with self.assertRaisesRegex(SystemExit, "BŁĄD sieci"):
+                saos._get("/search/judgments", {"courtType": "SUPREME"})
+        self.assertEqual(op.call_args.kwargs.get("timeout"), 90)
+
+    def test_przerwa_techniczna_html_to_unknown(self):
+        html = _Response(b"<!DOCTYPE html><html><head><title>Przerwa techniczna</title></head></html>")
+        with mock.patch.object(saos._opener, "open", return_value=html), mock.patch.object(saos.time, "sleep"):
+            with self.assertRaisesRegex(saos.VerificationUnknown, "przerw"):
+                saos._get("/search/judgments", soft=True)
+            with self.assertRaisesRegex(SystemExit, "przerwę techniczną"):
+                saos._get("/search/judgments")
+
+    def test_soft_transport_error_is_unknown(self):
+        with mock.patch.object(saos._opener, "open", side_effect=urllib.error.URLError("offline")), \
+                mock.patch.object(saos.time, "sleep"):
+            with self.assertRaises(saos.VerificationUnknown):
+                saos._get("/search/judgments", soft=True)
+
+    def test_successful_zero_results_is_verified_absent(self):
+        response = _Response(b'{"items": [], "info": {"totalResults": 0}}')
+        with mock.patch.object(saos._opener, "open", return_value=response):
+            result = saos._get("/search/judgments", soft=True)
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["info"]["totalResults"], 0)
+
+    def test_malformed_api_response_is_not_no_results(self):
+        args = argparse.Namespace(sygnatura=["III", "CSK", "203/09"], json=False)
+        with mock.patch.object(saos, "_get", return_value={"message": "maintenance"}):
+            with self.assertRaisesRegex(SystemExit, "nie udało się zweryfikować") as caught:
+                saos.cmd_sygnatura(args)
+        self.assertNotIn("Nie znaleziono orzeczenia", str(caught.exception))
+
+    def setUp(self):
+        saos._granice_na_zywo.clear()
+
+    def test_t08_strict_blokuje_zakres_poza_zamknietym_zbiorem_i_stdout_jest_pusty(self):
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv",
+                               ["saos.py", "szukaj", "--sad", "SN", "--od", "2024-01-01", "--strict"]), \
+                mock.patch.object(saos, "_get") as get, contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                saos.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+        # jedyne zapytanie to miękkie potwierdzenie granicy zbioru — nie właściwe wyszukiwanie
+        get.assert_called_once()
+        self.assertTrue(get.call_args.kwargs.get("soft"))
+
+    def test_zero_trafien_szukaj_konczy_bledem_takze_z_json(self):  # D06 / C17
+        odp = {"items": [], "info": {"totalResults": 0}}
+        for argv in (["szukaj", "--sad", "KIO", "--od", "2019-01-01", "--json"],
+                     ["szukaj", "--sad", "SN", "--od", "2017-01-01"],
+                     ["szukaj", "rękojmia", "--sad", "powszechne", "--json"]):
+            with self.subTest(argv=argv):
+                saos._granice_na_zywo.clear()
+                out = io.StringIO()
+                with mock.patch.object(saos, "_get", return_value=odp), \
+                        mock.patch.object(sys, "argv", ["saos.py", *argv]), contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        saos.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+                msg = str(caught.exception)
+                self.assertIn("Brak trafień", msg)
+                if "--sad" in argv and argv[argv.index("--sad") + 1] in ("KIO", "SN"):
+                    self.assertIn("POZA zbiorem", msg)
+                    self.assertRegex(msg, r"06\.09\.2018|22\.06\.2016")
+
+    def test_json_z_wynikami_ostrzega_na_stderr(self):
+        odp = {"items": [{"id": 1, "judgmentDate": "2016-06-22", "courtType": "SUPREME", "courtCases": []}],
+               "info": {"totalResults": 1}}
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(saos, "_get", return_value=odp), \
+                mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "SN", "--json"]), \
+                contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            saos.main()
+        self.assertIn('"totalResults": 1', out.getvalue())
+        self.assertIn("22.06.2016", err.getvalue())
+
+    def test_przepis_luzne_dopasowanie_ostrzezenie(self):  # D08
+        odp = {"items": [{"id": 1, "judgmentDate": "2016-01-01", "courtType": "SUPREME", "courtCases": [],
+                          "judgmentType": "SENTENCE"}], "info": {"totalResults": 810}}
+        out = io.StringIO()
+        with mock.patch.object(saos, "_get", return_value=odp), \
+                mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "SN", "--przepis", "art. 415",
+                                                "--do", "2016-06-22"]), contextlib.redirect_stdout(out):
+            saos.main()
+        self.assertIn("LUŹNE dopasowanie", out.getvalue())
+        self.assertIn("Kodeks cywilny art. 415", out.getvalue())
+        self.assertIn("· wyrok", out.getvalue())
+
+    def test_t09_json_strict_nie_emituje_wyniku_gdy_kontrola_nie_przeszla(self):
+        przypadki = [
+            (["szukaj", "--sad", "SN", "--od", "2024-01-01"], None),
+            (["orzeczenie", "123"], {"message": "maintenance"}),
+            (["sygnatura", "III", "CSK", "203/09"],
+             {"items": [], "info": {"totalResults": 0}}),
+        ]
+        for komenda, odpowiedz in przypadki:
+            with self.subTest(komenda=komenda):
+                out = io.StringIO()
+                with mock.patch.object(saos, "_get", return_value=odpowiedz), \
+                        mock.patch.object(sys, "argv", ["saos.py", *komenda, "--json", "--strict"]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        saos.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+
+
+class TestT13StrictZasiegKomunikat(unittest.TestCase):
+    """Blokada zakresu jest deterministyczna — komunikat nie może sugerować ponowienia,
+    tylko jak zawęzić zakres (--do) albo gdzie szukać nowszych orzeczeń."""
+
+    NAJNOWSZE = {"SUPREME": "2016-06-22", "CONSTITUTIONAL_TRIBUNAL": "2015-12-09",
+                 "NATIONAL_APPEAL_CHAMBER": "2018-09-06"}
+
+    def setUp(self):
+        saos._granice_na_zywo.clear()
+
+    def _odp_granicy(self, path, params=None, soft=False):
+        """Atrapa API: tylko miękkie zapytanie o najnowsze orzeczenie (pageSize=1) jest dozwolone."""
+        self.assertTrue(soft)
+        self.assertEqual(params["pageSize"], 1)
+        return {"items": [{"id": 1, "judgmentDate": self.NAJNOWSZE[params["courtType"]]}],
+                "info": {"totalResults": 1}}
+
+    def _blokada(self, argv):
+        saos._granice_na_zywo.clear()
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", ["saos.py", *argv, "--strict"]), \
+                mock.patch.object(saos, "_get", side_effect=self._odp_granicy) as get, \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                saos.main()
+        get.assert_called_once()
+        self.assertEqual(out.getvalue(), "")
+        return str(caught.exception)
+
+    def test_bez_gornej_granicy_podpowiada_do(self):
+        msg = self._blokada(["szukaj", "--sad", "SN", "--przepis", "art. 415"])
+        self.assertIn("--do 2016-06-22", msg)
+        self.assertIn("22.06.2016", msg)
+        self.assertIn("granica potwierdzona na żywo", msg)
+        self.assertNotIn("ponownie", msg)
+
+    def test_zakres_od_po_koncu_zbioru_wskazuje_portal(self):
+        msg = self._blokada(["szukaj", "--sad", "TK", "--od", "2024-01-01"])
+        self.assertIn("zaczyna się 01.01.2024", msg)
+        self.assertIn("ipo.trybunal.gov.pl", msg)
+        self.assertNotIn("ponownie", msg)
+
+    def test_ten_sam_rocznik_po_granicy_jest_blokowany(self):  # D01 / C03
+        msg = self._blokada(["szukaj", "--sad", "SN", "--od", "2016-07-01", "--do", "2016-12-31"])
+        self.assertIn("zaczyna się 01.07.2016", msg)
+        msg = self._blokada(["szukaj", "--sad", "KIO", "--od", "2018-10-01", "--do", "2018-12-31"])
+        self.assertIn("06.09.2018", msg)
+        msg = self._blokada(["szukaj", "--sad", "SN", "--od", "2016-01-01", "--do", "2016-12-31"])
+        self.assertIn("sięga 31.12.2016", msg)
+        self.assertIn("--do 2016-06-22", msg)
+
+    def test_blokada_bez_potwierdzenia_na_zywo(self):
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "SN", "--strict"]), \
+                mock.patch.object(saos, "_get", side_effect=saos.VerificationUnknown("przerwa")), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                saos.main()
+        self.assertIn("nie udało się potwierdzić granicy na żywo", str(caught.exception))
+        self.assertIn("--do 2016-06-22", str(caught.exception))
+        self.assertEqual(out.getvalue(), "")
+
+    def test_wznowione_zasilanie_odblokowuje_zakres(self):
+        """Gdyby SAOS znów zasilał SN, granica na żywo przesuwa się i zakres w niej nie jest blokowany."""
+        odpowiedzi = iter([
+            {"items": [{"id": 1, "judgmentDate": "2025-01-15"}], "info": {"totalResults": 1}},
+            {"items": [{"id": 2, "judgmentDate": "2024-06-01", "courtType": "SUPREME", "courtCases": [],
+                        "judgmentType": "SENTENCE"}], "info": {"totalResults": 1}},
+        ])
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "SN", "--od", "2024-01-01",
+                                             "--do", "2024-12-31", "--strict"]), \
+                mock.patch.object(saos, "_get", side_effect=lambda *a, **k: next(odpowiedzi)), \
+                contextlib.redirect_stdout(out):
+            saos.main()
+        self.assertIn("Znaleziono: 1", out.getvalue())
+        self.assertIn("15.01.2025", out.getvalue())
+        self.assertNotIn("POZA zbiorem", out.getvalue())
+
+    def test_wynik_nowszy_niz_granica_przesuwa_granice(self):
+        """Sam wynik (sort po dacie malejąco) dowodzi wznowienia zasilania — ostrzeżenie nie może
+        twierdzić, że zbiór kończy się wcześniej niż pokazane orzeczenie."""
+        odp = {"items": [{"id": 9, "judgmentDate": "2021-03-03", "courtType": "NATIONAL_APPEAL_CHAMBER",
+                          "courtCases": [{"caseNumber": "KIO 1/21"}], "judgmentType": "SENTENCE"}],
+               "info": {"totalResults": 1}}
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "KIO", "--od", "2021-01-01",
+                                             "--do", "2021-12-31"]), \
+                mock.patch.object(saos, "_get", return_value=odp), contextlib.redirect_stdout(out):
+            saos.main()
+        self.assertIn("03.03.2021", out.getvalue())
+        self.assertNotIn("POZA zbiorem", out.getvalue())
+        self.assertNotIn("06.09.2018", out.getvalue())
+
+    def test_zakres_w_granicach_zbioru_przechodzi(self):
+        """Zakres mieszczący się w zbiorze nie jest blokowany przez strict (bez zapytania o granicę);
+        zero trafień to zwykły komunikat „Brak trafień", nie blokada zbioru."""
+        out = io.StringIO()
+        odp = {"items": [], "info": {"totalResults": 0}}
+        with mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "KIO",
+                                             "--od", "2017-01-01", "--do", "2018-09-06", "--strict"]), \
+                mock.patch.object(saos, "_get", return_value=odp) as get, contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                saos.main()
+        self.assertNotIn("BŁĄD: zbiór", str(caught.exception))
+        self.assertIn("Brak trafień", str(caught.exception))
+        self.assertEqual(get.call_args_list[0].args[0], "/search/judgments")
+        self.assertFalse(get.call_args_list[0].kwargs.get("soft"))
+        self.assertEqual(out.getvalue(), "")
+
+    def test_zakres_z_wynikami_w_granicach_zbioru(self):
+        out = io.StringIO()
+        odp = {"items": [{"id": 354889, "judgmentDate": "2018-08-27", "courtType": "NATIONAL_APPEAL_CHAMBER",
+                          "courtCases": [{"caseNumber": "KIO 1564/18"}], "judgmentType": "SENTENCE"}],
+               "info": {"totalResults": 1}}
+        with mock.patch.object(sys, "argv", ["saos.py", "szukaj", "--sad", "KIO",
+                                             "--od", "2018-08-01", "--do", "2018-09-06", "--strict"]), \
+                mock.patch.object(saos, "_get", return_value=odp) as get, contextlib.redirect_stdout(out):
+            saos.main()
+        get.assert_called_once()
+        self.assertIn("Znaleziono: 1", out.getvalue())
+        self.assertIn("· wyrok", out.getvalue())
+        self.assertNotIn("SENTENCE", out.getvalue())
+
+
+class TestOrzeczenieWyjscie(unittest.TestCase):
+    """cmd_orzeczenie: źródła, nota o indeksach górnych, etykieta listy przepisów, okna z „…"."""
+
+    def _uruchom(self, data, argv_extra=()):
+        out = io.StringIO()
+        with mock.patch.object(saos, "_get", return_value={"data": data}), \
+                mock.patch.object(sys, "argv", ["saos.py", "orzeczenie", str(data["id"]), *argv_extra]), \
+                contextlib.redirect_stdout(out):
+            saos.main()
+        return out.getvalue()
+
+    SN = {"id": 245229, "courtType": "SUPREME", "judgmentType": "SENTENCE", "judgmentDate": "2016-05-06",
+          "courtCases": [{"caseNumber": "I CSK 364/15"}], "judgmentForm": {"name": "wyrok SN"},
+          "source": {"judgmentUrl": "http://www.sn.pl/orzecznictwo/SitePages/Baza_orzeczen"},
+          "referencedRegulations": [{"text": "Kodeks cywilny (Dz. U. z 1964 r. Nr 16 poz. 93 - art. 417(1))"},
+                                    {"text": "Kodeks postępowania cywilnego (… art. 4793647945)"}],
+          "textContent": "<p>Sąd zważył, że art. 4171 k.c. ma zastosowanie.</p>"}
+    SP = {"id": 549939, "courtType": "COMMON", "judgmentType": "SENTENCE", "judgmentDate": "2026-06-24",
+          "courtCases": [{"caseNumber": "I C 374/25"}],
+          "source": {"judgmentUrl": "https://apiorzeczenia.wroclaw.sa.gov.pl/ncourt-api/judgement/details?id=1"},
+          "textContent": ("<p>" + "Zdanie wstępu bez trafienia, które ma wypełnić okno. " * 20
+                          + "</p><p>Pierwsze zdanie akapitu. Stosownie do treści "
+                          "art. 556<sup>\n<!-- -->1</sup> § 1 k.c. wada fizyczna polega na niezgodności z umową. "
+                          "Kolejne zdanie o rękojmi za wady fizyczne. Ostatnie zdanie akapitu.</p>"
+                          "<p>" + "Inny akapit bez trafienia. " * 40 + "</p>")}
+
+    def test_sn_nota_o_indeksach_i_wzorzec_sn(self):
+        out = self._uruchom(self.SN)
+        self.assertIn("SAOS spłaszcza indeksy górne", out)
+        self.assertIn("I%20CSK%20364-15.pdf", out)
+        self.assertIn("nie służy do weryfikacji", out)
+        self.assertIn("lista z SAOS", out)
+        self.assertIn("bywa niepełna", out)
+        self.assertIn("wpis SAOS prawdopodobnie uszkodzony", out)
+        self.assertIn("typ: wyrok (wyrok SN)", out)
+
+    def test_sad_powszechny_indeks_gorny_inline_i_bez_noty(self):
+        out = self._uruchom(self.SP)
+        self.assertIn("art. 556¹ § 1 k.c.", out)
+        self.assertNotIn("spłaszcza", out)
+        self.assertIn("Źródło oryginalne: https://apiorzeczenia", out)
+        self.assertIn("typ: wyrok", out)
+
+    def test_fragment_granice_zdan_i_wielokropki(self):  # D10
+        out = self._uruchom(self.SP, ["--fragment", "rękojmi"])
+        tresc = out.split("## Treść uzasadnienia")[1]
+        self.assertRegex(tresc, r"\n…[A-ZĄĆĘŁŃÓŚŹŻ]")  # okno zaczyna się od początku zdania, z „…"
+        self.assertNotIn("\nerki", tresc)
+        self.assertIn("…\n", tresc)
+
+
+class TestT10PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = saos.urllib.request.Request("https://www.saos.org.pl/api/search/judgments")
+        handler = saos._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://www.saos.org.pl/api/judgments/123")
+        self.assertEqual(nowy.full_url, "https://www.saos.org.pl/api/judgments/123")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/judgment")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Lightweight, dependency-free validator for the gibek-skills plugins (Claude Code + OpenAI Codex).
+
+Checks every plugin's manifests, both marketplace catalogs, each skill's SKILL.md frontmatter,
+and that each engine compiles. All declared versions must be identical (lockstep). No pip deps.
+"""
+import json
+import re
+import sys
+import py_compile
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PLUGINS = [  # (plugin, [engines]) — plugin może mieć kilka silników (np. eli.py + edzienniki.py)
+    ("prawo-pl-eli", ["eli.py"]),
+    ("prawo-pl-edzienniki", ["edzienniki.py"]),
+    ("prawo-eu-eurlex", ["eurlex.py"]),
+    ("prawo-pl-saos", ["saos.py"]),
+    ("prawo-pl-cbosa", ["cbosa.py"]),
+    ("prawo-pl-uodo", ["uodo.py"]),
+    ("prawo-pl-rejestr-umow", ["rejestrumow.py"]),
+]
+errors = []
+versions = {}  # source file -> declared version (all must match: lockstep)
+
+
+def load_json(rel):
+    p = ROOT / rel
+    if not p.exists():
+        errors.append(f"{rel}: missing")
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"{rel}: invalid JSON ({e})")
+        return None
+
+
+for plugin, engine_names in PLUGINS:
+    # Plugin manifests (Claude + Codex)
+    for rel in (f"plugins/{plugin}/.claude-plugin/plugin.json", f"plugins/{plugin}/.codex-plugin/plugin.json"):
+        d = load_json(rel)
+        if isinstance(d, dict):
+            for k in ("name", "description", "version"):
+                if k not in d:
+                    errors.append(f"{rel}: missing field '{k}'")
+            if d.get("name") != plugin:
+                errors.append(f"{rel}: name should be '{plugin}'")
+            if "version" in d:
+                versions[rel] = d["version"]
+
+    # Shared SKILL.md frontmatter (open Agent Skills standard)
+    skill_rel = f"plugins/{plugin}/skills/{plugin}/SKILL.md"
+    skill = ROOT / skill_rel
+    if not skill.exists():
+        errors.append(f"{skill_rel}: missing")
+    else:
+        text = skill.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            errors.append(f"{skill_rel}: no YAML frontmatter")
+        else:
+            parts = text.split("---", 2)
+            fm = parts[1] if len(parts) >= 3 else ""
+            for k in ("name:", "description:", "version:"):
+                if k not in fm:
+                    errors.append(f"{skill_rel}: frontmatter missing '{k}'")
+            m = re.search(r"^version:\s*(\S+)\s*$", fm, re.M)
+            if m:
+                versions[skill_rel] = m.group(1).strip("'\"")
+            m = re.search(r"description: >-\n((?:  .*\n)+)", text)
+            if m:
+                desc = " ".join(l.strip() for l in m.group(1).splitlines())
+                if len(desc) > 1024:
+                    errors.append(f"{skill_rel}: description too long ({len(desc)} > 1024 chars)")
+
+    # Engines compile
+    for engine_name in engine_names:
+        engine_rel = f"plugins/{plugin}/skills/{plugin}/scripts/{engine_name}"
+        engine = ROOT / engine_rel
+        if not engine.exists():
+            errors.append(f"{engine_rel}: missing")
+            continue
+        try:
+            py_compile.compile(str(engine), doraise=True)
+        except py_compile.PyCompileError as e:
+            errors.append(f"{engine_name}: syntax error ({e})")
+        m = re.search(r"^__version__\s*=\s*[\"']([^\"']+)[\"']", engine.read_text(encoding="utf-8"), re.M)
+        if not m:
+            errors.append(f"{engine_name}: missing __version__")
+        else:
+            versions[engine_rel] = m.group(1)
+
+# Marketplace catalogs (Claude + Codex) — must list every plugin with a version
+for rel in (".claude-plugin/marketplace.json", ".agents/plugins/marketplace.json"):
+    d = load_json(rel)
+    if isinstance(d, dict):
+        if "name" not in d:
+            errors.append(f"{rel}: missing 'name'")
+        if not isinstance(d.get("plugins"), list) or not d.get("plugins"):
+            errors.append(f"{rel}: 'plugins' must be a non-empty list")
+        listed = {e.get("name"): e for e in d.get("plugins") or [] if isinstance(e, dict)}
+        for plugin, _ in PLUGINS:
+            entry = listed.get(plugin)
+            if not entry:
+                errors.append(f"{rel}: missing plugin entry '{plugin}'")
+            elif "version" not in entry:
+                errors.append(f"{rel}: plugin entry '{plugin}' missing 'version'")
+            else:
+                versions[f"{rel}#{plugin}"] = entry["version"]
+
+# Single version everywhere (manifests, marketplaces, SKILL.md, engines) — lockstep
+if len(set(versions.values())) > 1:
+    listing = ", ".join(f"{src}={v}" for src, v in sorted(versions.items()))
+    errors.append(f"version mismatch: {listing}")
+
+if errors:
+    print("VALIDATION FAILED:")
+    for e in errors:
+        print(f"  - {e}")
+    sys.exit(1)
+print(f"OK: {len(PLUGINS)} plugins — manifests, marketplaces, SKILL.md frontmatter and engines "
+      f"all valid (version {next(iter(versions.values()))}).")


### PR DESCRIPTION
Gałąź techniczna do `/code-review ultra`: pełna zawartość plików z `release/2.0.0` (część 1 z 2, ≤8000 linii) na pustej bazie, żeby ultrareview objął cały kod, a nie tylko diff. **Nie mergować** — do zamknięcia po przeglądzie.