### PR TITLE
REVIEW-ONLY 2/2: przegląd całości kodu (nie mergować)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,71 @@
+{
+  "name": "gibek-skills",
+  "interface": {
+    "displayName": "Gibek Skills"
+  },
+  "plugins": [
+    {
+      "name": "prawo-pl-eli",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-pl-eli"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prawo-pl-edzienniki",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-pl-edzienniki"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prawo-eu-eurlex",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-eu-eurlex"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prawo-pl-saos",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-pl-saos"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prawo-pl-cbosa",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-pl-cbosa"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prawo-pl-uodo",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-pl-uodo"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prawo-pl-rejestr-umow",
+      "version": "2.0.0",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prawo-pl-rejestr-umow"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,72 @@
+{
+  "name": "gibek-skills",
+  "description": "Otwarte skille prawnicze dla Claude Code oraz OpenAI Codex (standard Agent Skills): prawo polskie z oficjalnego API ELI Sejmu, prawo miejscowe z wojewódzkich dzienników urzędowych, prawo UE z CELLAR/EUR-Lex, orzecznictwo z API SAOS, orzecznictwo sądów administracyjnych z CBOSA, decyzje UODO z oficjalnego API i umowy jednostek sektora finansów publicznych z Centralnego Rejestru Umów.",
+  "owner": {
+    "name": "Krzysztof Gibek"
+  },
+  "plugins": [
+    {
+      "name": "prawo-pl-eli",
+      "source": "./plugins/prawo-pl-eli",
+      "description": "Polskie prawo z oficjalnego API ELI Sejmu (Dz.U./M.P.) do każdego pytania z prawa polskiego oraz pracy nad umowami i pismami procesowymi: akty, pojedyncze artykuły, tekst jednolity, nowelizacje, podstawa prawna.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    },
+    {
+      "name": "prawo-pl-edzienniki",
+      "source": "./plugins/prawo-pl-edzienniki",
+      "description": "Prawo miejscowe z API ELI 16 wojewódzkich dzienników urzędowych: uchwały rad gmin/powiatów/sejmików (podatki i opłaty lokalne, plany miejscowe MPZP, statuty), rozporządzenia wojewody. Wyszukiwanie po tytule i roczniku, metadane, pełna treść i urzędowy PDF. Read-only, bez klucza.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    },
+    {
+      "name": "prawo-eu-eurlex",
+      "source": "./plugins/prawo-eu-eurlex",
+      "description": "Prawo UE z oficjalnego repozytorium CELLAR/EUR-Lex (CELEX, bez klucza) do każdego pytania o prawo unijne: rozporządzenia, dyrektywy, wersje skonsolidowane, pojedyncze artykuły po polsku, nowelizacje, podstawa prawna.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    },
+    {
+      "name": "prawo-pl-saos",
+      "source": "./plugins/prawo-pl-saos",
+      "description": "Polskie orzecznictwo z publicznego API SAOS (saos.org.pl): wyroki, postanowienia i uchwały SN, TK, sądów powszechnych i KIO. Wyszukiwanie po frazie, sygnaturze, sądzie, sędzim, powołanym przepisie i dacie; pełne uzasadnienia, powołane przepisy i orzeczenia.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    },
+    {
+      "name": "prawo-pl-cbosa",
+      "source": "./plugins/prawo-pl-cbosa",
+      "description": "Orzecznictwo sądów administracyjnych z CBOSA (orzeczenia.nsa.gov.pl): NSA i 16 WSA, ~2,4 mln orzeczeń od 2004 r. Wyszukiwanie po frazie, sygnaturze, sądzie, symbolu sprawy, sędzim i dacie; pełne sentencje i uzasadnienia, powołane przepisy. CBOSA nie ma API — read-only scraping publicznych stron z throttlingiem.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    },
+    {
+      "name": "prawo-pl-uodo",
+      "source": "./plugins/prawo-pl-uodo",
+      "description": "Decyzje Prezesa UODO z oficjalnego API Portalu Orzeczeń UODO (orzeczenia.uodo.gov.pl): kary za naruszenia RODO, upomnienia, nakazy. Wyszukiwanie pełnotekstowe i po tytule/dacie; pełna treść decyzji po sygnaturze. Read-only, bez klucza.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    },
+    {
+      "name": "prawo-pl-rejestr-umow",
+      "source": "./plugins/prawo-pl-rejestr-umow",
+      "description": "Umowy jednostek sektora finansów publicznych z publicznego API Centralnego Rejestru Umów (rejestrumow.gov.pl, jawny rejestr od 1.07.2026): zamawiający, wykonawca, przedmiot, wartość, aneksy, wyłączenia jawności. Wyszukiwanie po przedmiocie umowy, nazwie/REGON/NIP stron, województwie, dacie i wartości; pełne szczegóły umowy. Read-only, bez klucza.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Krzysztof Gibek"
+      }
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: validate-and-release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate plugin manifests + SKILL.md (Claude + Codex)
+        run: python3 tools/validate.py
+      - name: Unit tests (offline, all engines)
+        run: |
+          for t in tools/test_*.py; do python3 "$t"; done
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build plugin packages (one zip per plugin)
+        run: |
+          for dir in plugins/*/; do
+            name=$(basename "$dir")
+            ( cd "$dir" && zip -r "$GITHUB_WORKSPACE/${name}-${GITHUB_REF_NAME}.zip" . -x '**/.DS_Store' )
+          done
+      - name: Create GitHub Release with the packages
+        uses: softprops/action-gh-release@v3
+        with:
+          files: "*-${{ github.ref_name }}.zip"
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,506 @@
+# gibek-skills: prawo polskie i unijne + orzecznictwo (7 skilli)
+
+[![CI](https://github.com/jamarpl21/prawo-pl-eli/actions/workflows/release.yml/badge.svg)](https://github.com/jamarpl21/prawo-pl-eli/actions/workflows/release.yml)
+[![Release](https://img.shields.io/github/v/release/jamarpl21/prawo-pl-eli)](https://github.com/jamarpl21/prawo-pl-eli/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+**Prawo polskie i unijne oraz orzecznictwo z OFICJALNYCH źródeł — zamiast cytowania z pamięci.**
+*Cross-tool agent skills (Claude Code + OpenAI Codex): Polish primary law (Sejm ELI API), local law
+(voivodeship journals), EU law (CELLAR/EUR-Lex), Polish case-law (SAOS), administrative courts
+case-law (CBOSA), Polish DPA decisions (UODO) and the public contracts register of Polish public
+finance sector entities (Centralny Rejestr Umów).*
+
+Repo zawiera siedem bliźniaczych pluginów/skilli (wspólny marketplace `gibek-skills`, wersjonowane razem):
+
+| Plugin / skill | Źródło | Zakres |
+|---|---|---|
+| **prawo-pl-eli** | [API ELI Sejmu](https://api.sejm.gov.pl/eli) | prawo polskie: Dz.U./M.P., teksty jednolite, kodeksy |
+| **prawo-pl-edzienniki** | API ELI 16 dzienników wojewódzkich (np. [edzienniki.duw.pl](https://edzienniki.duw.pl)) | prawo miejscowe: uchwały gmin/powiatów/sejmików, akty wojewody |
+| **prawo-eu-eurlex** | [CELLAR/EUR-Lex](https://publications.europa.eu/webapi/rdf/sparql) | prawo UE: rozporządzenia, dyrektywy, wersje skonsolidowane (CELEX) |
+| **prawo-pl-saos** | [API SAOS](https://www.saos.org.pl/api) | polskie orzecznictwo: SN, TK, sądy powszechne, KIO |
+| **prawo-pl-cbosa** | [CBOSA](https://orzeczenia.nsa.gov.pl) (brak API — scraping) | orzecznictwo sądów administracyjnych: NSA + 16 WSA |
+| **prawo-pl-uodo** | [API Portalu Orzeczeń UODO](https://orzeczenia.uodo.gov.pl/api-doc/) | decyzje Prezesa UODO (RODO): kary, upomnienia, nakazy |
+| **prawo-pl-rejestr-umow** | [API Centralnego Rejestru Umów](https://rejestrumow.gov.pl) | umowy jednostek sektora finansów publicznych (JSFP) od 1.07.2026 |
+
+## prawo-pl-eli
+
+Cytowanie polskich przepisów „z głowy" jest zawodne: ustawy są nowelizowane, sygnatury się mylą, a model
+potrafi podać brzmienie sprzed kilku zmian. Ten skill sięga do **źródła pierwotnego** — oficjalnego
+[API ELI Sejmu](https://api.sejm.gov.pl/eli) (Dziennik Ustaw i Monitor Polski) — i pozwala:
+
+- wyszukać akt po tytule / typie / roku / haśle przedmiotowym,
+- pobrać metadane (w tym **datę wejścia w życie**), pełny tekst i **TEKST JEDNOLITY**,
+- wyciąć **pojedynczy artykuł** (`tekst --fragment "art. 299"`) — pod cytat w umowie lub piśmie procesowym,
+- sprawdzić **nowelizacje**, podstawę prawną i czy akt **nadal obowiązuje** (narzędzie samo ostrzega
+  przed cytowaniem nieaktualnej wersji),
+- zacytować przepis z poprawną sygnaturą `Dz.U.`/`M.P.` i identyfikatorem ELI.
+
+Pomyślany jako wsparcie pracy nad **umowami i pismami procesowymi** (tworzenie i analiza) — wszędzie tam,
+gdzie trzeba odwołać się do przepisów i procedur prawa polskiego.
+
+## prawo-pl-edzienniki
+
+Ten sam wzorzec dla **prawa miejscowego**: uchwały rad gmin/powiatów/sejmików (podatki i opłaty
+lokalne, plany miejscowe MPZP, statuty, organizacja szkół), rozporządzenia i zarządzenia wojewody.
+Tych aktów nie ma w Dz.U./M.P. — publikuje je 16 **wojewódzkich dzienników urzędowych**, każdy
+z własnym API zgodnym z ELI. Silnik `edzienniki.py` zna tabelę hostów i pozwala:
+
+- listować dzienniki i roczniki: `dzienniki --woj DS`,
+- szukać aktów po tytule (nazwa gminy, przedmiot uchwały): `szukaj --woj DS "plan zagospodarowania" --rok 2026`
+  (API dzienników ignoruje filtry serwerowe — silnik pobiera rocznik i filtruje lokalnie),
+- pobrać metadane i treść: `akt DS 2026 3299`, `tekst DS 2026 3299 --fragment "§ 2"`, `--pdf plan.pdf`.
+
+## prawo-eu-eurlex
+
+Ten sam wzorzec dla **prawa Unii Europejskiej**: silnik `eurlex.py` odpytuje **CELLAR** — wspólne
+repozytorium Urzędu Publikacji UE zasilające EUR-Lex (SPARQL + REST, bez rejestracji i klucza) — i pozwala:
+
+- wyszukać akt po polskim (lub innym) tytule: `szukaj "sztucznej inteligencji" --typ REG`,
+- pobrać metadane z **datami wejścia w życie i stosowania** (`meta 32016R0679` — RODO pokaże obie!),
+- znaleźć **WERSJE SKONSOLIDOWANE** (odpowiednik tekstu jednolitego): `skonsolidowany 32006L0112`,
+- wyciąć **pojedynczy artykuł po polsku** (lub w 23 innych językach):
+  `tekst 02016R0679-20160504 --fragment "art. 28"`, `--pdf` zapisuje urzędowy PDF,
+- sprawdzić **nowelizacje, sprostowania i podstawę traktatową**: `odniesienia 32016R0679`.
+
+Identyfikatorem jest numer **CELEX** (`32016R0679`), akceptowana też forma ELI (`reg/2016/679`).
+Skille odsyłają do siebie nawzajem: dyrektywa UE → transpozycja → polska ustawa (prawo-pl-eli);
+polski przepis wdrażający → akt źródłowy UE (prawo-eu-eurlex).
+
+## prawo-pl-saos
+
+Trzeci skill domyka komplet: **orzecznictwo** (judykatura). Silnik `saos.py` odpytuje publiczne
+[API SAOS](https://www.saos.org.pl/api) (System Analizy Orzeczeń Sądowych) — agregat orzeczeń jawnych:
+**SN, TK, sądy powszechne (SA/SO/SR), KIO** — i pozwala:
+
+- znaleźć orzeczenia po frazie, **sygnaturze**, sądzie, sędzim, **powołanym przepisie** i dacie:
+  `szukaj "odpowiedzialność członka zarządu" --przepis "Kodeks spółek handlowych" --sad SN`,
+- pobrać **pełne orzeczenie** po ID: teza/uzasadnienie, **powołane przepisy** i **powołane orzeczenia**
+  (z ID do dalszego skoku po linii orzeczniczej): `orzeczenie 76341`,
+- odszukać wyrok po numerze sprawy: `sygnatura III CSK 203/09`,
+- wyciąć fragment długiego uzasadnienia wokół frazy: `orzeczenie 76341 --fragment "rękojmia"`.
+
+Podział ról: **treść przepisu → prawo-pl-eli (ELI)**, **jak sądy go stosują → prawo-pl-saos (SAOS)**.
+Most między nimi: ustal akt w ELI, potem `szukaj --przepis "<akt>"` w SAOS. **Uwaga:** SAOS to baza
+**wtórna** (agregat) — sądy administracyjne (NSA/WSA) są w niej praktycznie nieobecne (dla nich:
+**prawo-pl-cbosa** niżej), a do dosłownego cytatu warto zajrzeć do portalu sądu.
+
+## prawo-pl-cbosa
+
+Czwarty skill wypełnia największą lukę: **orzecznictwo sądów administracyjnych** (NSA + 16 WSA) —
+podatki, skargi na decyzje organów, interpretacje, k.p.a., prawo budowlane. Źródłem jest **CBOSA**
+([orzeczenia.nsa.gov.pl](https://orzeczenia.nsa.gov.pl), ~2,4 mln orzeczeń od 2004 r.). CBOSA **nie ma
+oficjalnego API**, więc silnik `cbosa.py` czyta publiczne strony HTML (read-only, z throttlingiem
+≥0,5 s i awaryjną obsługą niekompletnego łańcucha SSL) — i pozwala:
+
+- szukać po frazie, **sygnaturze**, sądzie, **symbolu sprawy**, sędzim i dacie:
+  `szukaj "odpowiedzialność członków zarządu" --sad NSA --od 2024-01-01`,
+- pobrać **pełne orzeczenie** (sentencja + uzasadnienie + powołane przepisy): `orzeczenie 8889489BE0`,
+- skakać między instancjami po **sygnaturach powiązanych** (WSA ↔ NSA tej samej sprawy),
+- wyciąć fragment długiego uzasadnienia: `orzeczenie <doc_id> --fragment "art. 116"`.
+
+## prawo-pl-uodo
+
+Piąty skill: **decyzje Prezesa UODO** (kary za naruszenia RODO, upomnienia, nakazy) z **oficjalnego
+API** Portalu Orzeczeń UODO ([orzeczenia.uodo.gov.pl](https://orzeczenia.uodo.gov.pl), od 2025 r.,
+bez klucza). Silnik `uodo.py` pozwala:
+
+- przeglądać najnowsze decyzje: `najnowsze --limit 10`,
+- szukać pełnotekstowo (regex, bez rozróżniania wielkości liter): `szukaj "biometr"`,
+  po tytule i dacie publikacji: `szukaj --tytul "kara" --od 2026-01-01`,
+- pobrać **pełną treść decyzji** po sygnaturze: `decyzja DKN.5131.9.2025 --fragment "art. 33"`.
+
+Komplet RODO: treść rozporządzenia → **prawo-eu-eurlex**, decyzje organu → **prawo-pl-uodo**,
+sądowa kontrola decyzji (WSA/NSA) → **prawo-pl-cbosa**.
+
+## prawo-pl-rejestr-umow
+
+Szósty skill wychodzi poza przepisy i orzecznictwo — do **praktyki wydatkowej sektora publicznego**:
+**Centralny Rejestr Umów JSFP** ([rejestrumow.gov.pl](https://rejestrumow.gov.pl), jawny rejestr
+z art. 34a ustawy o finansach publicznych, uruchomiony 1.07.2026, publiczne API bez klucza).
+Umowy zawierane przez urzędy, gminy, szpitale, uczelnie czy sądy — z danymi stron (NIP/REGON,
+adresy), przedmiotem, wartością i zmianami. Silnik `rejestrumow.py` pozwala:
+
+- przeglądać najnowsze umowy: `najnowsze --limit 10`,
+- szukać po przedmiocie, stronach i lokalizacji: `szukaj "remont drogi" --woj dolnośląskie --sort priceDesc`,
+  `szukaj --jsfp "urząd gminy" --wartosc-od 100000`, `szukaj --wykonawca-nip <NIP>`,
+- pobrać **pełne szczegóły umowy** (strony z adresami, wartość słownie, aneksy, wyłączenia
+  jawności): `umowa <idUmowy>`.
+
+Rejestr pokazuje **zawarte umowy** (nie przetargi — te są w BZP/TED) i obejmuje wyłącznie umowy
+od 1.07.2026; podstawa prawna (art. 34a–34b u.f.p.) → **prawo-pl-eli**.
+
+Wszystkie skille są w otwartym standardzie **[Agent Skills](https://agentskills.io)** (`SKILL.md`), więc działają w
+**Claude Code** i **OpenAI Codex**. Silniki (`scripts/eli.py`, `scripts/edzienniki.py`, `scripts/eurlex.py`,
+`scripts/saos.py`, `scripts/cbosa.py`, `scripts/uodo.py`, `scripts/rejestrumow.py`) to czysty Python
+(tylko stdlib), wszystko **read-only**.
+
+## Wymagania
+
+- Python 3.8+ (tylko stdlib; brak `pip install`)
+- **zalecane: `pdftotext` (poppler)** — `brew install poppler` / `apt install poppler-utils`. Od 2.0 silniki
+  ELI i e-dzienników czytają treść aktu z **urzędowego PDF**, gdy API nie ma HTML (k.c. Dz.U. 2026 poz. 795,
+  Konstytucja) albo gdy HTML jest tylko pierwszą stroną (wszystkie dzienniki wojewódzkie). Bez pdftotext
+  silnik sięga po tekst zastępczy z głośnym ostrzeżeniem, a `--strict` go odrzuca.
+- dostęp do internetu (`api.sejm.gov.pl`, hosty e-dzienników wojewódzkich, `publications.europa.eu`,
+  `www.saos.org.pl`, `orzeczenia.nsa.gov.pl`, `orzeczenia.uodo.gov.pl`, `rejestrumow.gov.pl`)
+
+## Instalacja
+
+### Claude Code
+
+```
+/plugin marketplace add jamarpl21/prawo-pl-eli
+/plugin install prawo-pl-eli@gibek-skills
+/plugin install prawo-pl-edzienniki@gibek-skills
+/plugin install prawo-eu-eurlex@gibek-skills
+/plugin install prawo-pl-saos@gibek-skills
+/plugin install prawo-pl-cbosa@gibek-skills
+/plugin install prawo-pl-uodo@gibek-skills
+/plugin install prawo-pl-rejestr-umow@gibek-skills
+```
+
+Aktualizacje: `/plugin marketplace update`.
+
+### Claude Desktop (aplikacja)
+
+Bez terminala — przez URL w ustawieniach aplikacji:
+
+1. **Settings → Capabilities** → włącz **Code execution** (wymagane przez skille).
+2. **Settings → Customize → Plugins → + Add plugin** → wklej `jamarpl21/prawo-pl-eli` → **Sync**.
+3. Kliknij **Install** przy wybranych skillach; włącz auto-aktualizacje marketplace'u.
+
+Uwaga: skille odpytują publiczne API — piaskownica zwykłego czatu może nie mieć dostępu
+do tych hostów; pełną funkcjonalność dają **Cowork** i **Claude Code**. Wizualna instrukcja
+krok po kroku (z makietami UI, obejmuje też aplikację ChatGPT Desktop):
+[docs/instalacja-claude-desktop.html](docs/instalacja-claude-desktop.html).
+
+### OpenAI Codex
+
+```
+codex plugin marketplace add jamarpl21/prawo-pl-eli
+codex plugin add prawo-pl-eli@gibek-skills
+codex plugin add prawo-pl-edzienniki@gibek-skills
+codex plugin add prawo-eu-eurlex@gibek-skills
+codex plugin add prawo-pl-saos@gibek-skills
+codex plugin add prawo-pl-cbosa@gibek-skills
+codex plugin add prawo-pl-uodo@gibek-skills
+codex plugin add prawo-pl-rejestr-umow@gibek-skills
+```
+
+Aktualizacje: `codex plugin marketplace upgrade`.
+
+Pluginy zainstalowane przez CLI są widoczne także w aplikacji **ChatGPT Desktop**
+(od 9.07.2026, z wbudowanym Codexem): tryb **Work** lub **Codex** → panel **Plugins** →
+zakładka **Personal**. Skille aktywują się dopiero w nowej sesji.
+
+### Ręcznie / dev (oba narzędzia)
+
+Sklonuj repo i podlinkuj sam katalog skilla (otwarty standard Agent Skills):
+
+```bash
+git clone https://github.com/jamarpl21/prawo-pl-eli
+for s in prawo-pl-eli prawo-pl-edzienniki prawo-eu-eurlex prawo-pl-saos prawo-pl-cbosa prawo-pl-uodo prawo-pl-rejestr-umow; do
+  SKILL="$PWD/prawo-pl-eli/plugins/$s/skills/$s"
+  ln -s "$SKILL" ~/.claude/skills/$s    # Claude Code
+  ln -s "$SKILL" ~/.agents/skills/$s    # OpenAI Codex
+done
+```
+
+### Paczka ZIP (offline / pojedyncza sesja)
+
+Każdy tag `v*` publikuje po jednym zipie na plugin w GitHub Releases
+(`prawo-pl-eli-<wersja>.zip`, `prawo-pl-edzienniki-<wersja>.zip`, `prawo-eu-eurlex-<wersja>.zip`,
+`prawo-pl-saos-<wersja>.zip`, `prawo-pl-cbosa-<wersja>.zip`, `prawo-pl-uodo-<wersja>.zip`,
+`prawo-pl-rejestr-umow-<wersja>.zip`):
+
+```bash
+claude --plugin-dir ./prawo-pl-saos-v2.0.0.zip
+# albo zdalnie, bez pobierania:
+claude --plugin-url https://github.com/jamarpl21/prawo-pl-eli/releases/download/v2.0.0/prawo-pl-saos-v2.0.0.zip
+```
+
+## Użycie jako samodzielne CLI (bez żadnego LLM-a)
+
+```bash
+cd plugins/prawo-pl-eli/skills/prawo-pl-eli && python3 scripts/eli.py <komenda> [...]
+cd plugins/prawo-pl-edzienniki/skills/prawo-pl-edzienniki && python3 scripts/edzienniki.py <komenda> [...]
+cd plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex && python3 scripts/eurlex.py <komenda> [...]
+cd plugins/prawo-pl-saos/skills/prawo-pl-saos && python3 scripts/saos.py <komenda> [...]
+cd plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa && python3 scripts/cbosa.py <komenda> [...]
+cd plugins/prawo-pl-uodo/skills/prawo-pl-uodo && python3 scripts/uodo.py <komenda> [...]
+cd plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow && python3 scripts/rejestrumow.py <komenda> [...]
+```
+
+Dwie flagi globalne, w każdym silniku, działają przed komendą i po niej:
+
+- `--json` — surowa odpowiedź API / sparsowane dane do dalszego przetwarzania. Zero trafień i nierozpoznana
+  odpowiedź kończą się komunikatem z kodem wyjścia ≠ 0 **także z `--json`** — pusty JSON wyglądałby jak
+  „sprawdzone, nic nie ma", a to najgroźniejszy fałszywy negatyw w pracy prawnika.
+- `--strict` — tryb „do pisma procesowego": wynik, którego **aktualności lub kompletności** nie dało się
+  zweryfikować, nie jest drukowany z ostrzeżeniem, tylko odrzucany (kod wyjścia ≠ 0, pusty stdout).
+  Domyślny tryb (research) jest bez zmian — te same sytuacje dają głośne `UWAGA:`. Co blokuje strict
+  (pełna lista per silnik w każdym SKILL.md, sekcja „Co sprawdza --strict"):
+  - **ELI:** awaria kontroli aktualności (`/references`), starszy t.j., gdy istnieje nowszy (także gdy
+    podasz sygnaturę starego t.j.), tekst zastępczy ze starszego t.j. (brak pdftotext), nieudana
+    ekstrakcja PDF, niekompletna lista nowelizacji po t.j.;
+  - **EUR-Lex:** awaria SPARQL, starsza wersja skonsolidowana, treść aktu bazowego, gdy istnieje
+    konsolidacja, `meta` aktu bazowego znowelizowanego (daty stosowania w CELLAR są wtedy nieaktualne);
+  - **SAOS:** zakres dat poza końcem zbioru SN (22.06.2016) / TK (9.12.2015) / KIO (6.09.2018) —
+    granica potwierdzana na żywo; **CBOSA:** treść bez weryfikacji TLS, orzeczenie **nieprawomocne** lub
+    bez potwierdzonej prawomocności; **UODO:** decyzja bez pełnej treści, decyzja **uchylona przez sąd**;
+  - **e-dzienniki:** pominięty lub niekompletny rocznik, tekst z text.html (tylko 1. strona), tekst
+    uszkodzony (U+FFFD, brak §); **rejestr umów:** zbiór większy niż okno API (10 000).
+
+  Wszystkie kontrole wykonują się PRZED emisją wyniku, również dla `--json`. Strict nie zastępuje oceny
+  prawnika: t.j. z późniejszymi nowelizacjami nadal przechodzi (z listą „Nowelizacje po tekście
+  jednolitym"), bo nowszego t.j. po prostu nie ma; zakres uchylenia decyzji UODO czy wyroku WSA trzeba
+  odczytać z sentencji (strict tylko odmawia treści, która może już nie obowiązywać).
+
+### eli.py (prawo polskie)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `szukaj` | znajdź akt po tytule/typie/roku/haśle | `szukaj "Kodeks spółek handlowych" --typ Ustawa --limit 5` |
+| `meta` | metadane aktu: status, **data aktu** („z dnia"), **ogłoszono** (publikacja w Dz.U.), wejście w życie, stan prawny t.j., uwagi o rozłożonym wejściu w życie | `meta DU 2000 1037` |
+| `tj` | znajdź AKTUALNY tekst jednolity (najnowszy oznaczony) | `tj DU 2000 1037` |
+| `odniesienia` | nowelizacje, podstawa prawna, tekst jednolity | `odniesienia DU 2024 18` |
+| `tekst` | treść aktu; `--fragment` wycina pojedynczy artykuł; `--pdf` zapisuje urzędowy PDF | `tekst DU 2024 18 --fragment "art. 299"` |
+| `struktura` | spis jednostek redakcyjnych aktu | `struktura DU 2024 18 --filtr "Art. 299"` |
+
+Komendy `tekst` i `tj` same ostrzegają, gdy cytujesz z nieaktualnej wersji (istnieje nowszy tekst
+jednolity / są nowelizacje po t.j. — lista łączy wpisy t.j. z „Aktami zmieniającymi" aktu bazowego po
+dacie stanu prawnego). Gdy API nie ma HTML aktu (świeży t.j. k.c., Konstytucja), `tekst` czyta urzędowy
+PDF przez `pdftotext` — przypisy z dołu strony trafiają do linii `[przypis N)]`.
+
+Każda komenda przyjmuje `--json` i `--strict` (wyżej). Sygnaturę można podać w wielu formach:
+`DU 2000 1037`, `DU/2024/18`, `"Dz.U. 2024 poz. 18"`, `WDU20240000018`, albo `DU/2000/1037` (ELI).
+
+### edzienniki.py (prawo miejscowe — dzienniki wojewódzkie)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `dzienniki` | lista 16 dzienników; z `--woj` roczniki i liczba aktów | `dzienniki --woj DS` |
+| `szukaj` | akty województwa po frazie z tytułu (filtr lokalny) | `szukaj --woj DS "plan zagospodarowania" --rok 2026` |
+| `akt` | metadane aktu (typ, organ, **data aktu** i **data publikacji** w dzienniku, status, powiązania: sprostowania, uchylenia, rozstrzygnięcia nadzorcze) | `akt DS 2026 3299` |
+| `tekst` | treść aktu **z urzędowego PDF** (pdftotext); `--fragment "§ N"` zwraca cały §; `--pdf` zapisuje PDF | `tekst DS 2026 3299 --fragment "§ 2"` |
+
+Kody województw = sufiks publishera ELI (`DS`=dolnośląskie, `MZ`=mazowieckie, `SL`=śląskie…);
+można też podać nazwę (`--woj lodzkie`). API dzienników ignoruje filtry serwerowe — silnik pobiera
+rocznik i filtruje tytuły lokalnie (bez `?limit=…`, bo ten wariant serwer podaje z przestarzałego cache'u —
+silnik porównuje liczbę pozycji z `totalCount`). `text.html` dzienników zawiera tylko pierwszą stronę aktu,
+dlatego treść pochodzi z PDF. Hosty z niepełnym łańcuchem certyfikatów (MP, LS, LD) obsługiwane przez
+dociągnięcie certyfikatu pośredniego (AIA) z pełną weryfikacją.
+
+### eurlex.py (prawo UE)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `szukaj` | znajdź akt po frazie z tytułu (domyślnie PL) | `szukaj "sztucznej inteligencji" --typ REG` |
+| `meta` | metadane (typ, wejście w życie / stosowanie, **termin transpozycji** dyrektywy, status, ELI); na wersji skonsolidowanej: „stan na" + daty **aktu bazowego**; ostrzeżenie, gdy akt był zmieniany (daty stosowania w CELLAR nie są wtedy aktualizowane) | `meta 32016R0679` |
+| `skonsolidowany` | wersje skonsolidowane (odpowiednik t.j.) | `skonsolidowany 32006L0112` |
+| `odniesienia` | nowelizacje, sprostowania, **uchylenia (w obie strony)**, podstawa traktatowa | `odniesienia 32016R0679` |
+| `tekst` | treść aktu (domyślnie PL); `--fragment` wycina artykuł; `--jezyk`, `--pdf` | `tekst 02016R0679-20160504 --fragment "art. 28"` |
+
+### saos.py (orzecznictwo polskie)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `szukaj` | znajdź orzeczenia po frazie/sądzie/sygnaturze/przepisie/dacie | `szukaj "rękojmia" --sad SN --przepis "Kodeks cywilny" --limit 5` |
+| `orzeczenie` | pełne orzeczenie po ID (teza, powołane przepisy i orzeczenia, treść); `--fragment` | `orzeczenie 76341 --fragment "rękojmia"` |
+| `sygnatura` | szybkie odszukanie po numerze sprawy | `sygnatura III CSK 203/09` |
+
+`--sad`: `SN | TK | powszechne | admin | KIO`. SAOS to baza **wtórna** — `--sad admin` zwykle zwraca 0
+(orzecznictwo administracyjne: skill **prawo-pl-cbosa** niżej). Zbiory **SN, TK i KIO są zamknięte** —
+kończą się dokładnie na 22.06.2016, 9.12.2015 i 6.09.2018 (silnik potwierdza granicę na żywo i ostrzega
+z dokładnością do dnia; w strict `--sad SN/TK/KIO` wymaga `--do` w granicach zbioru). W tekstach SN/TK/KIO
+SAOS spłaszcza indeksy górne (art. 417¹ → „4171") — silnik ostrzega; w sądach powszechnych renderuje
+`art. 556¹`. „Powołane przepisy" to niepełna lista SAOS; `--przepis` dopasowuje luźno (dopisz nazwę ustawy).
+
+### cbosa.py (orzecznictwo sądów administracyjnych — NSA/WSA)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `szukaj` | orzeczenia po frazie/sądzie/sygnaturze/symbolu/sędzim/dacie | `szukaj "odpowiedzialność członków zarządu" --sad NSA --od 2024-01-01` |
+| `orzeczenie` | pełne orzeczenie po doc_id (metadane, sentencja, uzasadnienie, powołane przepisy); `--fragment` | `orzeczenie 8889489BE0 --fragment "art. 116"` |
+| `sygnatura` | szybkie odszukanie po sygnaturze | `sygnatura II FSK 2870/18` |
+
+`--sad`: `NSA` albo `"WSA <miasto>"` (16 miast). CBOSA nie ma API — silnik czyta publiczne strony
+HTML z throttlingiem ≥0,5 s (zmiana układu stron może wymagać aktualizacji). Wielkość strony
+wyników: stałe 10 (`--strona N`). `orzeczenie` podaje **prawomocność** (flaga ze strony CBOSA) i ostrzega,
+gdy orzeczenie jest nieprawomocne (mogło zostać uchylone — zob. orzeczenia powiązane WSA ↔ NSA).
+
+### uodo.py (decyzje Prezesa UODO — RODO)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `najnowsze` | ostatnio **wydane** dokumenty (API sortuje po dacie decyzji) | `najnowsze --limit 10` |
+| `szukaj` | pełnotekstowo (regex) / po tytule / dacie **decyzji** (`--od/--do`) lub **publikacji** (`--pub-od/--pub-do`) | `szukaj "biometr" --od 2026-01-01` |
+| `decyzja` | pełna treść decyzji po sygnaturze albo URN; blok **„Kontrola sądowa"** (uchylenia/utrzymania z sygnaturami WSA/NSA); `--fragment` | `decyzja DKN.5131.9.2025 --fragment "art. 33"` |
+
+API stosuje jeden warunek filtrujący na zapytanie (fraza ALBO tytuł); zaawansowane filtry:
+`--warunek "indeks:operator:wartość"`. Decyzja uchylona przez sąd jest oznaczana nagłówkiem „DECYZJA
+UCHYLONA PRZEZ SĄD" (zakres uchylenia — w sentencji wyroku: skill prawo-pl-cbosa); pole `inforce` API nie
+odzwierciedla uchyleń.
+
+### rejestrumow.py (umowy sektora finansów publicznych)
+
+| Komenda | Opis | Przykład |
+|---|---|---|
+| `najnowsze` | ostatnio opublikowane umowy | `najnowsze --limit 10` |
+| `szukaj` | po przedmiocie / stronach (nazwa, REGON, NIP) / lokalizacji JSFP / dacie / wartości | `szukaj "remont drogi" --woj dolnośląskie --sort priceDesc` |
+| `umowa` | pełne szczegóły umowy po idUmowy (strony z adresami, aneksy, wyłączenia jawności) | `umowa 958e7d59-057b-4eb4-8f55-e664638f393a` |
+| `slownik` | słowniki API (kody rodzajów zmian, stron, wyłączeń) | `slownik rodzaje_zmian_umowy` |
+
+Filtry można łączyć (AND): fraza dotyczy przedmiotu umowy, `--jsfp/--regon/--nip` zamawiającego
+(`--rola wykonawca|dowolna` zmienia stronę), `--wykonawca(-nip/-regon)` drugiej strony, `--od/--do` daty
+zawarcia, `--wartosc-od/-do` kwoty, `--zmiana-rodzaj KOD` / `--zmiana-od/-do` aneksów i zmian; surowe body:
+`--zapytanie '<json>'` (API ignoruje nieznane pola — zła nazwa = cały rejestr). Okno wyszukiwania: 10 000
+wyników (silnik mówi wprost, gdy jest wyczerpane), strona maks. 50.
+
+### Przykładowe przepływy
+
+> „co dokładnie mówi art. 299 § 1 Kodeksu spółek handlowych i czy to aktualne?"
+
+```bash
+python3 scripts/eli.py szukaj "Kodeks spółek handlowych" --typ Ustawa   # → akt bazowy DU/2000/1037
+python3 scripts/eli.py tj DU 2000 1037                                  # → AKTUALNY tekst jednolity DU/2024/18
+python3 scripts/eli.py tekst DU 2024 18 --fragment "art. 299"           # → sam art. 299 + ostrzeżenie
+                                                                        #   o nowelizacjach po t.j.
+```
+
+> „czy klauzula powierzenia jest zgodna z art. 28 RODO?"
+
+```bash
+python3 scripts/eurlex.py skonsolidowany 32016R0679                     # → 02016R0679-20160504 (AKTUALNA)
+python3 scripts/eurlex.py tekst 02016R0679-20160504 --fragment "art. 28"  # → art. 28 po polsku
+```
+
+> „jak SN podchodzi do odpowiedzialności członka zarządu z art. 299 k.s.h.?"
+
+```bash
+python3 scripts/saos.py szukaj "odpowiedzialność członka zarządu" \
+        --przepis "Kodeks spółek handlowych" --sad SN --limit 5         # → lista orzeczeń SN z ID
+python3 scripts/saos.py orzeczenie <id>                                 # → teza + powołane przepisy/orzeczenia
+```
+
+> „jak NSA podchodzi do odpowiedzialności członka zarządu za zaległości podatkowe (art. 116 o.p.)?"
+
+```bash
+python3 scripts/cbosa.py szukaj "odpowiedzialność członka zarządu" \
+        --sad NSA --od 2024-01-01                                       # → lista wyroków NSA z doc_id
+python3 scripts/cbosa.py orzeczenie <doc_id> --fragment "art. 116"      # → uzasadnienie wokół przepisu
+```
+
+> „czy UODO karał za brak zgłoszenia naruszenia i jak to uzasadnia?"
+
+```bash
+python3 scripts/uodo.py szukaj "art. 33"                                # → decyzje z sygnaturami
+python3 scripts/uodo.py decyzja <sygnatura> --fragment "art. 33"        # → argumentacja organu
+```
+
+> „na co gmina wydaje ostatnio najwięcej i kto jest wykonawcą?"
+
+```bash
+python3 scripts/rejestrumow.py szukaj --jsfp "gmina legnickie pole" \
+        --sort priceDesc --limit 5                                      # → największe umowy z idUmowy
+python3 scripts/rejestrumow.py umowa <idUmowy>                          # → wykonawca (NIP/REGON), wartość, aneksy
+```
+
+## Struktura
+
+```
+.claude-plugin/marketplace.json          # marketplace dla Claude Code (siedem pluginów)
+.agents/plugins/marketplace.json         # marketplace dla Codex (Claude czyta .claude-plugin/)
+plugins/<plugin>/                        # prawo-pl-eli | prawo-pl-edzienniki | prawo-eu-eurlex | prawo-pl-saos | prawo-pl-cbosa | prawo-pl-uodo | prawo-pl-rejestr-umow
+├── .claude-plugin/plugin.json           # manifest pluginu — Claude
+├── .codex-plugin/plugin.json            # manifest pluginu — Codex ("skills": "./skills/")
+└── skills/<plugin>/                      # Agent Skills — WSPÓLNE dla obu narzędzi
+    ├── SKILL.md
+    ├── scripts/<silnik>.py               # eli.py | edzienniki.py | eurlex.py | saos.py | cbosa.py | uodo.py | rejestrumow.py
+    └── references/api.md                 # referencja endpointów źródła
+tools/validate.py                        # walidator manifestów wszystkich pluginów (używany w CI)
+tools/test_*.py                          # testy jednostkowe silników, offline (używane w CI)
+.github/workflows/release.yml            # GitHub Actions: walidacja + testy + ZIP-y release na tagu v*
+```
+
+## GitHub Actions (deploy)
+
+- **push / PR** → `tools/validate.py` waliduje manifesty WSZYSTKICH pluginów (Claude + Codex), oba marketplace'y
+  i frontmattery `SKILL.md`; `tools/test_*.py` testują silniki (offline, bez sieci).
+- **tag `v*`** → build po jednym zipie na plugin + GitHub Release z paczkami
+  (instalowalnymi przez `claude --plugin-dir` / `--plugin-url`).
+
+## Wersjonowanie
+
+Wszystkie pluginy są wersjonowane **razem (lockstep)** — jedna wersja (obecnie **2.0.0**) zadeklarowana
+we wszystkich miejscach, identyczna; `tools/validate.py` wymusza to w CI:
+
+- `plugins/<plugin>/.claude-plugin/plugin.json` i `.codex-plugin/plugin.json` (pole `version`) — wszystkie pluginy,
+- wpisy wszystkich pluginów w obu marketplace'ach (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`),
+- frontmattery `SKILL.md` (pole `version`),
+- silniki: `eli.py`, `edzienniki.py`, `eurlex.py`, `saos.py`, `cbosa.py`, `uodo.py`, `rejestrumow.py` (`__version__`; CLI: `--version`).
+
+Wydanie nowej wersji: bump `version` we wszystkich powyższych → `python3 tools/validate.py &&
+for t in tools/test_*.py; do python3 $t; done` → `git tag v1.x.y` → `git push --tags`.
+
+## Audyt merytoryczny (sierpień 2026) i wydanie 2.0
+
+22–23 sierpnia 2026 wersja 1.7.0 wszystkich siedmiu silników przeszła **audyt merytoryczny**: nie jakości
+kodu, lecz tego, czy to, co narzędzia zwracają, jest w 100% prawdą w zestawieniu z **niezależnym źródłem
+urzędowym** (ISAP i urzędowe PDF-y Dz.U., strony i PDF-y dzienników wojewódzkich, EUR-Lex, sn.pl /
+ipo.trybunal.gov.pl / uzp.gov.pl, surowe strony CBOSA, portal UODO i uodo.gov.pl, API rejestru umów
+i Biała lista VAT). 15 agentów w trzech fazach — sondy per silnik, adwersaryjna weryfikacja najcięższych
+ustaleń, krytyk kompletności — wykonało **129 kontroli**: 73 TRUE, 37 PARTIAL, 18 FALSE, 1 UNVERIFIABLE,
+łącznie **56 defektów** (7 potwierdzonych adwersaryjnie, 0 obalonych). Pełny raport z dowodami i krokami
+reprodukcji: [`docs/audyt-merytoryczny-2026-08.md`](docs/audyt-merytoryczny-2026-08.md).
+
+**Co się potwierdziło.** Tam, gdzie silnik ma tekst, brzmienie przepisów zgadza się z urzędowym PDF znak
+po znaku (k.c. art. 415, 353¹, 449¹, 23; k.p.c. art. 17; k.s.h. art. 299; Konstytucja; RODO art. 6 i 17;
+AI Act art. 5; teksty CBOSA, SAOS i UODO); sygnatury, daty orzeczeń, składy, statusy obowiązywania aktów,
+mapowanie pól rejestru umów (NIP-y kontrahentów zgodne z Białą listą) — prawdziwe.
+
+**Co było nieprawdą — i co naprawiło wydanie 2.0:**
+
+| Silnik | Defekt (1.7.0) | Naprawa (2.0.0) |
+|---|---|---|
+| ELI, e-dzienniki | „Ogłoszono" = data uchwalenia aktu, nie publikacji (sygnaliści: 14.06 vs 24.06.2024; DS 3292: 7 tygodni) | `Data aktu` + `Ogłoszono` z pola `promulgation`; `Stan prawny na`; `Uwagi` z rozłożonym wejściem w życie |
+| ELI | przy pustym `text.html` (k.c. Dz.U. 2026/795, Konstytucja) cichy tekst ze STARSZEGO t.j. pod nagłówkiem aktualnego — art. 187 k.c. w brzmieniu z 2024 r.; instrukcja nałożenia zmian wskazywała nieistniejącą sekcję | treść z **urzędowego PDF** aktu przez `pdftotext`; bez pdftotext — jawny tekst zastępczy z listą aktów zmieniających, blokowany w strict |
+| ELI | „Nowelizacje po t.j." zaniżone (k.p.c. 2 z 4–5); `Znaleziono` = rozmiar strony | lista uzupełniana z aktu bazowego; `Znaleziono` = `totalCount` |
+| e-dzienniki | `text.html` = tylko 1. strona PDF; „Nie znaleziono frazy" dla § 2–4 i stawek; listing `?limit=100000` z przestarzałego cache'u (brak najnowszych aktów, unieważniony MPZP jako „obowiązujący"); tekst hosta podlaskiego z dziurami; MP/LS/LD „niedostępne" | tekst z PDF; listing bez magicznego limitu z kontrolą `totalCount`; detekcja uszkodzeń; dociąganie łańcucha TLS (AIA); powiązania (sprostowania, uchylenia, nieważność) z rejestru dziennika |
+| UODO | decyzje **uchylone przez sąd** (Bisnode — kara 943 470 zł, Morele) jako „w obrocie: tak"; `--od/--do` filtrowało po dacie decyzji, opisane jako publikacji | blok „Kontrola sądowa" z sygnaturami WSA/NSA, nagłówek „DECYZJA UCHYLONA", strict blokuje; filtry nazwane zgodnie z prawdą + `--pub-od/--pub-do`; tekst z `body.html` (przypisy, numeracja) |
+| CBOSA | flaga „orzeczenie nieprawomocne" gubiona — uchylony wyrok WSA wyglądał jak obowiązujący | `Prawomocność:` w tekście i JSON, ostrzeżenie, strict blokuje nieprawomocne |
+| SAOS | granice zbiorów roczne (SN kończy się 22.06.2016, KIO 6.09.2018) — „zweryfikowane zero" dla II półrocza 2016; `<sup>` jako łamanie linii; spłaszczone indeksy SN bez ostrzeżenia; martwe linki „Źródło oryginalne" | granice z dokładnością do dnia, potwierdzane na żywo; `art. 556¹`; ostrzeżenie o spłaszczeniu; wzorce adresów sn.pl / ipo.trybunal.gov.pl / uzp |
+| EUR-Lex | `meta` na konsolidacji: data „stan na" jako wejście w życie; daty stosowania AI Act sprzed nowelizacji; brak terminów transpozycji i uchyleń; ostatni artykuł z 58 przypisami | daty aktu bazowego, ostrzeżenie o nowelizacjach, `cdm:directive_date_transposition`, uchylenia w obie strony, granice strukturalne XHTML |
+| rejestr umów | `--nip/--regon` pasowały do dowolnej strony umowy; strona za oknem 10 000 = fałszywe zero; `api.md` z nieistniejącą sekcją filtrów zmian | `--rola`, komunikaty o oknie, prawdziwa sekcja `zmianyUmowy` + `--zmiana-*` |
+| wszystkie | `--strict` dawał fałszywy „pass" tam, gdzie nie było dedykowanej kontroli; obietnica „zero trafień → kod ≠ 0 także z `--json`" fałszywa dla `szukaj` w ELI/EUR-Lex/SAOS | kontrakt strict opisany per silnik i rozszerzony (wyżej); `szukaj` wszędzie kończy zero komunikatem i kodem ≠ 0 |
+
+Testy jednostkowe: 276 → 491. Audyt wskazał też luki do kolejnych testów (przepisy znowelizowane
+w ostatnich 90 dniach, t.j. z brzmieniem z datą przyszłą, indeksy literowe w k.p.c., tabele załączników)
+— zob. sekcję D raportu.
+
+## Ważne zastrzeżenia
+
+- **To nie jest porada prawna.** Narzędzie pomaga dotrzeć do treści i sygnatury aktu / orzeczenia —
+  interpretacja należy do prawnika.
+- **Akt OGŁOSZONY ≠ OBOWIĄZUJĄCY.** Sprawdzaj `wejście w życie`/vacatio legis i odnoś przepis do **daty
+  zdarzenia/sprawy**. Tekst jednolity oddaje stan na `legalStatusDate`; nowsze zmiany trzeba nałożyć ręcznie.
+- **Indeksacja bywa opóźniona** — brak nowelizacji w API ≠ pewność, że jej nie ma. Przy sprawie na
+  konkretną datę zweryfikuj dodatkowo (np. `dziennikustaw.gov.pl`, proces legislacyjny).
+- **Wersja skonsolidowana EUR-Lex ma charakter dokumentacyjny** (nie jest tekstem autentycznym) —
+  w piśmie urzędowym wskaż akt bazowy + akty zmieniające.
+- **SAOS to baza wtórna (agregat orzeczeń jawnych)** — nie zawiera sądów administracyjnych (NSA/WSA →
+  prawo-pl-cbosa), świeżość bywa opóźniona, a do dosłownego cytatu zweryfikuj orzeczenie w portalu właściwego sądu.
+- **CBOSA nie ma API** — skill prawo-pl-cbosa czyta publiczne strony HTML (scraping, read-only, z throttlingiem);
+  zmiana układu stron może chwilowo zepsuć parsowanie. Baza ma charakter informacyjno-edukacyjny (anonimizacja).
+- **Portal orzeczeń UODO jest młody (2025)** — starsze decyzje pojawiają się sukcesywnie; brak decyzji
+  w portalu ≠ jej nieistnienie. Sprawdzaj status (prawomocna/nieprawomocna).
+- **Centralny Rejestr Umów obejmuje tylko umowy zawarte od 1.07.2026** — wcześniejszych i poniżej
+  ustawowego progu tam nie ma; dane wpisują ręcznie kierownicy JSFP (literówki, skróty nazw — szukaj
+  po NIP/REGON), a brak umowy w rejestrze ≠ jej nieistnienie.
+- Projekt nieoficjalny; korzysta z publicznych API/stron Kancelarii Sejmu, urzędów wojewódzkich (e-dzienniki),
+  Urzędu Publikacji UE, SAOS (ICM UW / Fundacja ePaństwo), NSA (CBOSA), UODO i Ministerstwa Finansów
+  (Centralny Rejestr Umów).
+
+## Licencja
+
+MIT — zobacz [`LICENSE`](LICENSE).

--- a/plugins/prawo-eu-eurlex/.claude-plugin/plugin.json
+++ b/plugins/prawo-eu-eurlex/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-eu-eurlex",
+  "description": "Prawo UE z oficjalnego repozytorium CELLAR/EUR-Lex Urzędu Publikacji (SPARQL + REST, bez klucza) do każdego pytania o prawo unijne: rozporządzenia (RODO, AI Act, DORA, DSA), dyrektywy, wersje skonsolidowane, pojedyncze artykuły po polsku, nowelizacje i podstawa prawna. Read-only — źródło pierwotne zamiast cytowania przepisów z pamięci lub portali.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-eu-eurlex/.codex-plugin/plugin.json
+++ b/plugins/prawo-eu-eurlex/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prawo-eu-eurlex",
+  "version": "2.0.0",
+  "description": "Prawo UE z oficjalnego repozytorium CELLAR/EUR-Lex Urzędu Publikacji (SPARQL + REST, bez klucza) do każdego pytania o prawo unijne: rozporządzenia, dyrektywy, wersje skonsolidowane, pojedyncze artykuły po polsku, nowelizacje i podstawa prawna. Read-only.",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": ["prawo", "eu-law", "eur-lex", "cellar", "celex", "legal"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo UE — EUR-Lex/CELLAR",
+    "shortDescription": "Prawo UE z oficjalnego CELLAR/EUR-Lex (CELEX, wersje skonsolidowane).",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/SKILL.md
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: prawo-eu-eurlex
+version: 2.0.0
+description: >-
+  Odpytuje OFICJALNE repozytorium prawa UE — CELLAR/EUR-Lex Urzędu Publikacji (SPARQL + REST,
+  bez klucza): wyszukiwanie aktów, pełny tekst PO POLSKU i w 23 innych językach, WERSJE
+  SKONSOLIDOWANE, pojedyncze artykuły, metadane, nowelizacje, uchylenia, sprostowania, podstawa prawna —
+  po numerze CELEX lub ELI. Używaj przy KAŻDYM pytaniu o prawo UE: rozporządzenia (RODO/GDPR,
+  AI Act, DORA, DSA, DMA, MiCA, eIDAS), dyrektywy (NIS2, konsumenckie, ePrivacy, PSD2),
+  decyzje, traktaty i Karta — TAKŻE gdy przepis nie jest jeszcze znany. Wywołuj PRZED
+  wyszukiwaniem w internecie: treść przepisu UE cytuj WYŁĄCZNIE z EUR-Lex/CELLAR, nigdy
+  z pamięci ani portali; internet tylko do orzecznictwa TSUE i doktryny. Polską implementację
+  dyrektywy sprawdzaj skillem prawo-pl-eli. Wyzwalaj przy: „co mówi RODO/AI Act o…", „art. X
+  rozporządzenia/dyrektywy…", „CELEX", „czy zgodne z prawem UE", „od kiedy stosuje się…".
+  EU law from the official EUR-Lex/CELLAR — always use for EU law questions BEFORE web search.
+---
+
+# Prawo UE z oficjalnego repozytorium CELLAR/EUR-Lex
+
+Skill do pracy z prawem Unii Europejskiej — przy **każdym pytaniu o prawo UE** oraz przy **tworzeniu
+i analizie umów i pism**, gdzie trzeba przywołać przepis unijny, zweryfikować podstawę prawną lub datę
+stosowania. Cytowanie przepisów UE z pamięci albo z portali jest zawodne (nowelizacje, sprostowania,
+różne daty stosowania) — ten skill sięga do **źródła pierwotnego**: CELLAR, wspólnego repozytorium
+Urzędu Publikacji UE, które zasila EUR-Lex (SPARQL + REST, bez rejestracji i klucza).
+
+## Kolejność źródeł (przepis ≠ internet)
+
+1. **Treść przepisu UE — wyłącznie z EUR-Lex/CELLAR.** Nigdy nie cytuj brzmienia z pamięci ani
+   z portali. Jeśli wynik wyszukiwania internetowego podał brzmienie — zweryfikuj przez `eurlex.py`,
+   zanim go użyjesz w odpowiedzi.
+2. **Internet — tylko do orzecznictwa TSUE (curia.europa.eu), doktryny i identyfikacji aktów.**
+   Po identyfikacji wróć do CELLAR po tekst.
+3. **Pytanie bez wskazanego przepisu** („czy to zgodne z prawem UE…", „czy RODO pozwala…") to też
+   zadanie dla tego skilla — najpierw ustal akt (tabela niżej lub `szukaj`), pobierz przepisy
+   (`tekst --fragment`), dopiero potem ewentualnie internet po orzecznictwo.
+4. **Granica PL/UE:** rozporządzenie UE stosuje się wprost; dyrektywa działa przez TRANSPOZYCJĘ —
+   polską ustawę wdrażającą sprawdzaj skillem **prawo-pl-eli** (ELI Sejmu). Przy pytaniach mieszanych
+   (np. RODO + polska ustawa o ochronie danych) używaj OBU skilli.
+5. **Delegując research subagentowi**, wpisz do jego promptu: „treść przepisów UE pobieraj wyłącznie
+   przez `scripts/eurlex.py` (skill prawo-eu-eurlex); internet tylko do orzecznictwa i doktryny".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/eurlex.py` (tylko biblioteka standardowa Pythona — bez instalacji,
+bez klucza API). Skrypt leży **obok tego pliku SKILL.md** — NIE zakładaj, że to `~/.claude/skills/`
+(skill zainstalowany jako plugin leży w katalogu pluginów; w Claude Code:
+`${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+EURLEX="${CLAUDE_PLUGIN_ROOT}/skills/prawo-eu-eurlex/scripts/eurlex.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$EURLEX" ] || EURLEX="<katalog skilla>/scripts/eurlex.py"
+[ -f "$EURLEX" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $EURLEX" >&2; exit 1; }
+python3 "$EURLEX" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/eurlex.py` oznacza `python3 "$EURLEX"`, jeśli nie jesteś
+w katalogu skilla.)
+
+Identyfikator aktu to numer **CELEX** (np. `32016R0679` = sektor 3 legislacja, rok 2016, R =
+rozporządzenie, nr 0679); akceptowane też: `CELEX:32016R0679`, forma ELI `reg/2016/679`,
+wersje skonsolidowane `02016R0679-20160504`, sprostowania `32016R0679R(01)`, traktaty `12012E/TXT`.
+
+### Komendy
+
+- **szukaj** — znajdź akt po frazie z tytułu (domyślnie tytuły polskie):
+  `python3 scripts/eurlex.py szukaj "sztucznej inteligencji" --typ REG --limit 5`
+  (opcje: `--typ REG|DIR|DEC`, `--rok`, `--jezyk pol|eng|…`, `--obowiazujace`, `--limit`)
+  Fraza dopasowuje się DOSŁOWNIE do tytułu, a tytuły są odmienione — podawaj RDZEŃ albo formę
+  z tytułu („danych osobowych"/„osobow", nie „dane osobowe"; RODO ma w tytule „ochrony osób
+  fizycznych w związku z przetwarzaniem danych osobowych"). Zero trafień z mianownika to NIE
+  dowód, że aktu nie ma.
+- **meta** — metadane: pełny tytuł, typ, daty, status, ELI: `python3 scripts/eurlex.py meta 32016R0679`
+  - **Daty pochodzą z metadanych AKTU BAZOWEGO.** CELLAR trzyma wejście w życie i daty rozpoczęcia
+    stosowania w JEDNEJ właściwości i ich nie rozróżnia: jedna data = „Wejście w życie"; kilka dat =
+    „Wejście w życie / stosowanie" (najwcześniejsza to z reguły wejście w życie) — którą datą objęty
+    jest dany przepis, ustal z przepisów końcowych (`tekst --fragment` na ostatnim artykule).
+  - **Dyrektywa:** osobno „Termin transpozycji" (bywa kilka — różne zakresy); polską ustawę
+    wdrażającą sprawdź skillem prawo-pl-eli.
+  - **`meta` na CELEX-ie skonsolidowanym** (`0…-YYYYMMDD`) pokazuje „Stan na (konsolidacja)", listę
+    aktów ujętych w konsolidacji oraz daty i status **aktu bazowego** — data w CELEX-ie konsolidacji
+    NIE jest datą wejścia w życie ani stosowania aktu.
+  - **Akt zmieniany** (lista aktów zmieniających): narzędzie ostrzega, że daty stosowania z aktu
+    bazowego mogą być nieaktualne (nowelizacja mogła przesunąć terminy — tak AI Act po 2026/1744) i
+    każe sprawdzić artykuł o stosowaniu w najnowszej wersji skonsolidowanej. Same sprostowania nie
+    zmieniają dat i nie wywołują ostrzeżenia.
+- **skonsolidowany** — WERSJE SKONSOLIDOWANE aktu (odpowiednik tekstu jednolitego; data w CELEX
+  = stan prawny na): `python3 scripts/eurlex.py skonsolidowany 32006L0112`
+- **tekst** — treść aktu (XHTML → czysty tekst), domyślnie po polsku. **Do pojedynczego artykułu
+  używaj `--fragment`** (pełny akt to setki tysięcy znaków):
+  `python3 scripts/eurlex.py tekst 02016R0679-20160504 --fragment "art. 28"`
+  `python3 scripts/eurlex.py tekst 32024R1689 --fragment "profilowanie"` (pełnotekstowo)
+  `--jezyk eng` — inna wersja językowa; `--pdf ŚCIEŻKA` zapisuje urzędowy PDF.
+  Fragment kończy się na granicy jednostki redakcyjnej (następny artykuł/rozdział/załącznik) oraz
+  na końcu części normatywnej: formuła „Sporządzono w…", podpisy i blok przypisów końcowych
+  (rozpoznawany po strukturze XHTML CELLAR) NIE wchodzą do fragmentu ostatniego artykułu; formuła
+  „Niniejsze rozporządzenie wiąże w całości…" zostaje przy nim. Przypisy czytaj bez `--fragment`
+  albo frazą z przypisu.
+  404 na wersji skonsolidowanej z listy `skonsolidowany` (np. pierwsza, tożsama z aktem bazowym)
+  oznacza, że CELLAR nie serwuje już tej ZASTĄPIONEJ wersji — narzędzie wskazuje najnowszą.
+- **odniesienia** — nowelizacje, sprostowania, **uchylenia w obie strony** („UCHYLONY PRZEZ" /
+  „Uchyla", także dorozumiane), akty zmieniane, podstawa prawna; na akcie uchylonym pierwsza linia
+  mówi wprost „AKT UCHYLONY przez … — NIE OBOWIĄZUJE":
+  `python3 scripts/eurlex.py odniesienia 32016R0679` (→ uchyla 31995L0046)
+- każda komenda przyjmuje `--json` oraz `--strict`; obie flagi działają przed komendą i po niej.
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”; dotyczy też `szukaj`).
+  `--json` dla `meta` zwraca obiekt: `meta` (surowe wiersze tej pracy), `akt_bazowy` (na wersji
+  skonsolidowanej), `zmieniajace`, `wersje_skonsolidowane`, `ostrzezenia`.
+- **Co sprawdza `--strict`, a czego nie.** Każda kontrola wykonuje się PRZED emisją wyniku; awaria
+  kontroli (SPARQL niedostępny) blokuje wynik zamiast udawać „brak". Blokuje: `tekst` aktu bazowego,
+  gdy istnieją wersje skonsolidowane, i starszą wersję skonsolidowaną, gdy jest nowsza (także w
+  `meta`); `meta` AKTU BAZOWEGO, gdy akt był zmieniany (daty stosowania mogą być nieaktualne —
+  użyj `meta`/`tekst` najnowszej konsolidacji). Nie blokuje: `meta` aktu bazowego bez nowelizacji
+  (konsolidacja z samych sprostowań → tylko ostrzeżenie), `meta` najnowszej wersji skonsolidowanej
+  (daty aktu bazowego idą z ostrzeżeniem). `--strict` NIE weryfikuje treści dat z przepisami
+  końcowymi ani nie wykrywa zmian, których CELLAR jeszcze nie zaindeksował.
+
+Narzędzie samo ostrzega: na akcie bazowym podpowiada najnowszą wersję skonsolidowaną; na wersji
+skonsolidowanej przypomina o jej dokumentacyjnym charakterze i o nowszych wersjach. Nie ignoruj
+tych ostrzeżeń.
+
+### Akty bazowe najczęstszych aktów (pomiń `szukaj`)
+
+Numery CELEX są niezmienne — dla poniższych zaczynaj od `skonsolidowany <CELEX>` (a przy braku
+wersji skonsolidowanych czytaj akt bazowy):
+
+| Akt | CELEX |
+|---|---|
+| RODO / GDPR | `32016R0679` |
+| AI Act (akt o sztucznej inteligencji) | `32024R1689` |
+| DORA (operacyjna odporność cyfrowa) | `32022R2554` |
+| NIS2 (dyrektywa o cyberbezpieczeństwie) | `32022L2555` |
+| DSA (akt o usługach cyfrowych) | `32022R2065` |
+| DMA (akt o rynkach cyfrowych) | `32022R1925` |
+| MiCA (rynki kryptoaktywów) | `32023R1114` |
+| eIDAS (identyfikacja elektroniczna) | `32014R0910` |
+| PSD2 (usługi płatnicze) | `32015L2366` |
+| Dyrektywa o prawach konsumentów | `32011L0083` |
+| ePrivacy (łączność elektroniczna) | `32002L0058` |
+| Karta praw podstawowych UE | `12012P/TXT` |
+| TFUE (Traktat o funkcjonowaniu UE) | `12012E/TXT` |
+
+## Zasady (ważne — dlaczego)
+
+1. **Najpierw właściwy akt i wersja, potem cytat.** Typowy przepływ: tabela wyżej (albo `szukaj`) →
+   `skonsolidowany <CELEX>` → `tekst <najnowsza wersja> --fragment "art. N"`. Cytowanie aktu
+   bazowego sprzed nowelizacji to częsty błąd.
+2. **Wejście w życie ≠ rozpoczęcie stosowania ≠ termin transpozycji.** RODO weszło w życie
+   24.05.2016, a stosuje się od 25.05.2018; AI Act stosuje się ETAPAMI (różne daty dla różnych
+   rozdziałów); dyrektywa wiąże państwa od terminu transpozycji. `meta` pokazuje wszystkie daty
+   CELLAR (bez rozróżnienia, która to stosowanie) — przy kilku datach sprawdź przepisy końcowe
+   aktu (`tekst --fragment` na ostatnim artykule) i odnieś do DATY zdarzenia/sprawy. **Po
+   nowelizacji daty z metadanych aktu bazowego mogą być nieaktualne** (AI Act: art. 113 zmieniony
+   przez 2026/1744 — część terminów przesunięta) — wtedy artykuł o stosowaniu czytaj z najnowszej
+   wersji skonsolidowanej, a daty z `meta` traktuj jako pierwotne. Data w CELEX-ie wersji
+   skonsolidowanej to „stan na" konsolidacji, nie data aktu.
+3. **Wersja skonsolidowana ma charakter dokumentacyjny** (nie jest tekstem autentycznym) — świetna
+   do analizy, ale w piśmie urzędowym/sądowym wskaż akt bazowy + akty zmieniające (`odniesienia`).
+   Do DOSŁOWNEGO cytatu pobierz urzędowy PDF (`tekst … --pdf`).
+4. **Wszystkie wersje językowe są równorzędnie autentyczne.** Przy wątpliwości interpretacyjnej
+   porównaj polską z angielską: `tekst <CELEX> --jezyk eng --fragment "art. N"`.
+5. **Zawsze podawaj CELEX i ELI** przy cytacie (np. „art. 28 ust. 3 RODO, CELEX 32016R0679",
+   `meta` zwraca ELI). To pozwala odbiorcy zweryfikować źródło.
+6. Baza może nie mieć najświeższych zmian (indeksacja bywa opóźniona) — przy sprawie na konkretną
+   datę zaznacz w odpowiedzi: „stan wg CELLAR na dzień X — do potwierdzenia".
+
+## Czego ten skill NIE obejmuje
+
+- **orzecznictwa TSUE z uzasadnieniami** (wyroki → curia.europa.eu; CELLAR ma sektor 6, ale tylko
+  metadane i sentencje — nie analizuj wyroków samym tym skillem),
+- **prawa krajowego, w tym polskiej transpozycji dyrektyw** — użyj skilla **prawo-pl-eli**,
+- **projektów w toku procesu legislacyjnego** (COM/SEC, prace PE i Rady — inne źródła),
+- **wyszukiwarki pełnotekstowej EUR-Lex** (SOAP, wymaga rejestracji — ten skill jej nie używa;
+  `szukaj` działa po tytułach, frazy w treści szukaj przez `tekst --fragment`).
+Jeśli zagadnienie wymaga tych źródeł — powiedz to wprost, nie udawaj, że CELLAR je pokryje.
+
+## Przykładowy przepływ
+
+Pytanie: „czy klauzula powierzenia w tej umowie jest zgodna z art. 28 RODO?" (przykład — stan na
+czerwiec 2026):
+1. Tabela: RODO = `32016R0679` → `skonsolidowany 32016R0679` → najnowsza wersja `02016R0679-20160504`.
+2. `tekst 02016R0679-20160504 --fragment "art. 28"` → pełna treść artykułu po polsku
+   (+ automatyczne przypomnienie o dokumentacyjnym charakterze wersji skonsolidowanej).
+3. Porównaj klauzulę z wymogami art. 28 ust. 3 lit. a–h; przy wątpliwości językowej:
+   `tekst … --jezyk eng --fragment "art. 28"`.
+4. W odpowiedzi: cytat, CELEX, ELI i data stanu prawnego; polska ustawa wdrożeniowa (UODO) →
+   skill prawo-pl-eli.

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/references/api.md
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/references/api.md
@@ -1,0 +1,88 @@
+# CELLAR/EUR-Lex — ściąga API (dla zapytań spoza komend eurlex.py)
+
+Wszystko publiczne, bez klucza. Read-only.
+
+## Endpointy
+
+- **SPARQL**: `https://publications.europa.eu/webapi/rdf/sparql`
+  POST/GET z `query=` + `format=application/sparql-results+json` (też XML/CSV).
+- **CELLAR REST (treść)**: URI zasobu ma postać
+  `http://publications.europa.eu/resource/celex/{CELEX}`, ale żądanie sieciowe wysyłaj przez
+  `https://publications.europa.eu/resource/celex/{CELEX}`. `eurlex.py` podnosi schemat do HTTPS
+  tuż przed pobraniem, także dla URL manifestacji zwróconych przez SPARQL **oraz w celach
+  przekierowań** — CELLAR odpowiada 303 z `Location: http://…` nawet na żądanie https, więc
+  samo podniesienie URL wejściowego nie wystarcza (treść przyszłaby czystym HTTP). Używa nagłówków
+  `Accept: application/xhtml+xml` i `Accept-Language: pol|eng|…` (kod 3-literowy, małymi).
+  PDF NIE działa przez negocjację — pobierz URL manifestacji przez SPARQL
+  (`cdm:manifestation_manifests_expression`, `cdm:manifestation_type` zaczynający się od `pdf`)
+  i doklej `/DOC_1`.
+- **Struktura XHTML** (do cięcia fragmentów): artykuł = `div.eli-subdivision#art_N`; akt bazowy —
+  formuła końcowa i podpisy w `div.oj-final` (`p` „Sporządzono w…", `div.oj-signatory`), przypisy
+  po `hr.oj-note` jako `p.oj-note`; wersja skonsolidowana — formuła w `div#fnp_1`, przypisy jako
+  `p.footnote`, znaczniki zmian `p.modref` (▼B/▼M1), załączniki `div#anx_I` (`p.title-annex-1`).
+  `eurlex.py` wstawia przed `oj-signatory`/`oj-note`/`footnote` znak granicy (U+001F), usuwany
+  przed wydrukiem.
+- **ELI URI**: `http://data.europa.eu/eli/reg/2016/679/oj` → przekierowanie na EUR-Lex.
+
+## Ontologia CDM (prefiks `cdm: <http://publications.europa.eu/ontology/cdm#>`)
+
+Najużyteczniejsze właściwości (zweryfikowane):
+
+- `cdm:resource_legal_id_celex` — numer CELEX (literal `xsd:string`); klucz wyszukiwania.
+- `cdm:work_has_resource-type` — typ aktu: URI `…/resource-type/REG|DIR|DEC|…`
+- `cdm:work_date_document` (data aktu), `cdm:resource_legal_date_signature`,
+  `cdm:resource_legal_date_entry-into-force` — bywa KILKA wartości: wejście w życie ORAZ daty
+  rozpoczęcia stosowania (RODO: 2016-05-24, 2018-05-25; AI Act: 5 dat). **CDM nie ma osobnej
+  właściwości „data stosowania"** ani opisu poszczególnych dat (EUR-Lex pokazuje je z komentarzem
+  tylko na stronie notatki) — sprawdzone na 32016R0679/32024R1689 przez
+  `SELECT ?p ?o { ?w ?p ?o FILTER(CONTAINS(STR(?p),"date")||CONTAINS(STR(?p),"applic")) }`.
+  Po nowelizacji CELLAR NIE aktualizuje tych dat w akcie bazowym (32024R1689 dalej ma 2027-08-02,
+  choć 32026R1744 zmienił art. 113). `cdm:resource_legal_date_end-of-validity` (9999-12-31 =
+  bezterminowo). `cdm:resource_legal_date_deadline` — inne terminy z aktu (przeglądy, sprawozdania),
+  nie stosowanie.
+- `cdm:directive_date_transposition` — termin(y) transpozycji dyrektywy (32019L1937: 2021-12-17,
+  2023-12-17; 31995L0046: 1998-10-24). Brak w CDM `resource_legal_date_transposition`.
+- `cdm:resource_legal_in-force` — "1"/"true" = obowiązuje.
+- `cdm:resource_legal_eli` — URI ELI.
+- wersja skonsolidowana (typ `CONS_TEXT`, klasa `cdm:act_consolidated`):
+  `cdm:act_consolidated_date` = „stan na" (to samo co `work_date_document` i
+  `resource_legal_date_entry-into-force` tej pracy — NIE daty aktu!),
+  `cdm:act_consolidated_based_on_resource_legal` → akt bazowy,
+  `cdm:act_consolidated_consolidates_resource_legal` → akty ujęte w konsolidacji (bazowy +
+  zmieniające + sprostowania). Konsolidacja nie ma `resource_legal_in-force` — status czytaj z aktu
+  bazowego.
+- tytuły per język: `?exp cdm:expression_belongs_to_work ?w . ?exp cdm:expression_uses_language
+  <…/authority/language/POL> . ?exp cdm:expression_title ?title`
+- relacje (kierunek ma znaczenie): `cdm:resource_legal_amends_resource_legal` (X zmienia W —
+  nowelizacje szukaj ODWROTNIE: `?x …amends… ?w`), `cdm:resource_legal_corrects_resource_legal`
+  (sprostowania), `cdm:resource_legal_based_on_resource_legal` (podstawa traktatowa),
+  `cdm:resource_legal_repeals_resource_legal` (X uchyla W; 32016R0679 → 31995L0046; „uchylony
+  przez" = odwrotnie `?x …repeals… ?w`), `cdm:resource_legal_implicitly_repeals_resource_legal`
+  (uchylenie dorozumiane; 32016R0679 → 32003R1882), `cdm:resource_legal_proposes_to_amend_resource_legal`
+  (projekty COM w toku — sektor 5; eurlex.py ich nie listuje).
+
+## Numery CELEX
+
+`[sektor][rok][litera typu][numer]`, np. `32016R0679`:
+- sektory: 1 = traktaty (`12012E/TXT` TFUE, `12012P/TXT` Karta), 2 = umowy międzynarodowe,
+  3 = legislacja (R = rozporządzenie, L = dyrektywa, D = decyzja), 5 = prace przygotowawcze
+  (COM…), 6 = orzecznictwo TSUE (CJ = wyroki), 0 = **wersje skonsolidowane**.
+- wersja skonsolidowana: `0` + rok/litera/numer aktu bazowego + `-YYYYMMDD` (stan na dzień),
+  np. `02016R0679-20160504`. Lista: SPARQL `FILTER(STRSTARTS(STR(?celex), "02016R0679-"))`.
+  CELLAR/EUR-Lex listują wszystkie wersje, ale treści wersji ZASTĄPIONYCH bywają wycofane
+  (REST 404, np. `02024R1689-20240712`, `02019L1937-20191126` — zwykle pierwsza, tożsama z aktem
+  bazowym); nowsze wersje pośrednie zwykle są serwowane.
+- sprostowanie: sufiks `R(nn)`, np. `32016R0679R(02)`.
+
+## Języki (authority codes)
+
+`POL ENG DEU FRA SPA ITA CES SLK NLD POR …` — w `Accept-Language` małymi (`pol`),
+w SPARQL pełny URI `…/authority/language/POL`.
+
+## Limity i wydajność
+
+- SPARQL: zapytania z `CONTAINS` po tytułach trwają 1–3 s; zawężaj przez `--typ`/`--rok`.
+  Endpoint potrafi zwrócić 5xx pod obciążeniem — ponów po chwili.
+- Wyszukiwarka pełnotekstowa EUR-Lex to osobny webservice SOAP (wymaga rejestracji EU Login,
+  limit 10 000 wyników od 2026) — eurlex.py jej nie używa.
+- Masowe pobrania: bulk download / Data Dump Urzędu Publikacji (nie rób crawl po REST).

--- a/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
+++ b/plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do OFICJALNEGO repozytorium prawa UE: CELLAR/EUR-Lex Urzędu Publikacji UE.
+SPARQL (wyszukiwanie, metadane, relacje) + REST (teksty aktów). Tylko biblioteka standardowa
+Pythona — brak zależności pip. Operacje WYŁĄCZNIE read-only. Bez rejestracji i klucza API.
+
+Komendy:
+  szukaj "<fraza>" [--typ REG|DIR|DEC] [--rok R] [--jezyk pol] [--obowiazujace] [--limit N]
+  meta <CELEX>                   metadane aktu (tytuł, typ, daty wejścia w życie / stosowania,
+                                 termin transpozycji dyrektywy, czy obowiązuje, ELI); na wersji
+                                 skonsolidowanej: data „stan na" + daty AKTU BAZOWEGO
+  tekst <CELEX> [--jezyk pol] [--fragment "art. 6"] [--pdf ŚCIEŻKA]
+                                 tekst aktu z CELLAR (XHTML → czysty tekst); --fragment wycina
+                                 tylko jednostki z frazą; --pdf zapisuje urzędowy PDF
+  skonsolidowany <CELEX>         wersje skonsolidowane aktu (odpowiednik tekstu jednolitego)
+  odniesienia <CELEX>            nowelizacje, sprostowania, uchylenia (w obie strony), podstawa prawna
+Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności)
+
+CELEX np.: 32016R0679 (RODO), 02016R0679-20160504 (wersja skonsolidowana), reg/2016/679 (ELI).
+"""
+import sys, json, re, time, argparse, textwrap, urllib.request, urllib.parse, urllib.error
+from html.parser import HTMLParser
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+SPARQL = "https://publications.europa.eu/webapi/rdf/sparql"
+CELLAR = "http://publications.europa.eu/resource/celex/"
+CDM = "http://publications.europa.eu/ontology/cdm#"
+LANG_AUTH = "http://publications.europa.eu/resource/authority/language/"
+TYPE_AUTH = "http://publications.europa.eu/resource/authority/resource-type/"
+XSD_STR = "http://www.w3.org/2001/XMLSchema#string"
+CONTENT_HOSTS = ("publications.europa.eu", "data.europa.eu")
+
+JEZYKI = {"pl": "POL", "pol": "POL", "en": "ENG", "eng": "ENG", "de": "DEU", "deu": "DEU",
+          "fr": "FRA", "fra": "FRA", "es": "SPA", "spa": "SPA", "it": "ITA", "ita": "ITA",
+          "cs": "CES", "ces": "CES", "sk": "SLK", "slk": "SLK", "nl": "NLD", "nld": "NLD",
+          "pt": "POR", "por": "POR", "uk": "UKR", "ukr": "UKR"}
+
+
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _nie_zweryfikowano(co, blad):
+    sys.exit(f"BŁĄD: nie udało się zweryfikować {co} ({blad}). "
+             "Spróbuj ponownie za chwilę.")
+
+
+def _lang(j):
+    code = JEZYKI.get((j or "pol").lower())
+    if code:
+        return code
+    if re.match(r"^[A-Za-z]{3}$", j or ""):
+        return j.upper()
+    sys.exit(f"Nieznany język: {j!r}. Użyj np. pol, eng, deu, fra (kod 3-literowy).")
+
+
+def _wymus_https(url):
+    """Podnosi http:// do https:// dla adresów, z których realnie pobieramy treść.
+
+    CELLAR identyfikuje zasoby URI w formie ``http://`` i tak też zwraca adresy
+    manifestacji w wynikach SPARQL — to poprawne jako *nazwa* zasobu, ale jako
+    *transport* oznacza pobieranie tekstu aktu prawnego kanałem bez szyfrowania
+    i bez uwierzytelnienia serwera. Treść trafia stąd do cytatów prawnych, więc
+    podmiana w tranzycie jest realnym ryzykiem, nie teoretycznym.
+
+    Podnosimy schemat wyłącznie tuż przed żądaniem; stałe URI przestrzeni nazw
+    (CDM, LANG_AUTH, TYPE_AUTH, XSD_STR) zostają nietknięte, bo zmiana ich
+    postaci zerwałaby dopasowanie w zapytaniach SPARQL.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        # Zmieniamy wyłącznie schemat. Oryginalna pisownia hosta, user-info, port,
+        # ścieżka, parametry, query i fragment pozostają bajt w bajt bez zmian.
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi przekierowania HTTP dla dozwolonych hostów treści, inne odrzuca.
+
+    CELLAR odpowiada 303 z Location w formie http:// nawet na żądanie https. Bez
+    kontroli celu przekierowania treść aktu mogłaby popłynąć czystym HTTP."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
+
+
+def _http(url, data=None, headers=None, timeout=60):
+    """GET/POST z jednym ponowieniem na błąd przejściowy. Zwraca (bytes, content-type)."""
+    url = _wymus_https(url)
+    req = urllib.request.Request(url, data=data, headers={
+        "User-Agent": f"eurlex-skill/{__version__}", **(headers or {})})
+    for attempt in (1, 2):
+        try:
+            with _opener.open(req, timeout=timeout) as r:
+                return r.read(), r.headers.get("Content-Type", "")
+        except urllib.error.HTTPError as e:
+            if e.code >= 500 and attempt == 1:
+                time.sleep(2); continue
+            if e.code == 300:
+                sys.exit(f"BŁĄD: CELLAR zwrócił 300 (wiele wariantów) dla {url} — "
+                         "spróbuj --pdf albo inny --jezyk.")
+            if e.code == 404:
+                sys.exit(f"BŁĄD: nie znaleziono zasobu (404): {url}\n"
+                         "Sprawdź numer CELEX (szukaj \"<fraza>\") i czy istnieje wersja w tym języku.")
+            sys.exit(f"BŁĄD HTTP {e.code}: {url}")
+        except Exception as e:
+            if attempt == 1:
+                time.sleep(2); continue
+            sys.exit(f"BŁĄD sieci: {url} ({e})")
+
+
+def _sparql(query, soft=False):
+    """Zapytanie SPARQL zwracające listę bindingów.
+
+    Pusta lista oznacza VERIFIED_ABSENT. Przy soft=True błąd ma osobny stan
+    UNKNOWN (VerificationUnknown), nigdy None/pustą listę.
+    """
+    data = urllib.parse.urlencode({"query": query, "format": "application/sparql-results+json"}).encode()
+    try:
+        raw, _ = _http(SPARQL, data=data, headers={"Accept": "application/sparql-results+json"})
+        return json.loads(raw.decode("utf-8", "replace"))["results"]["bindings"]
+    except SystemExit as e:
+        if soft:
+            raise VerificationUnknown(str(e)) from e
+        raise
+    except Exception as e:
+        if soft:
+            raise VerificationUnknown(f"nieoczekiwana odpowiedź SPARQL: {e}") from e
+        sys.exit(f"BŁĄD: nieoczekiwana odpowiedź SPARQL ({e}) — spróbuj ponownie za chwilę.")
+
+
+def _v(b, key):
+    return b.get(key, {}).get("value", "")
+
+
+# Znak granicy STRUKTURALNEJ (ASCII unit separator): _Stripper wstawia go w osobnej linii przed
+# blokiem podpisów i przed każdym przypisem końcowym, bo w tekście bez znaczników nie da się
+# odróżnić przypisu „(1) Dz.U. …" od punktu „(1) …" aktu zmieniającego (EN). Klasy XHTML CELLAR:
+# akt bazowy — div.oj-signatory (podpisy), hr/p.oj-note (przypisy); wersja skonsolidowana —
+# p.footnote. Znak jest usuwany przed wydrukiem (_bez_granic), nigdy nie trafia do cytatu.
+GRANICA = "\x1f"
+_KLASY_GRANIC = frozenset(("oj-signatory", "oj-note", "footnote"))
+
+
+class _Stripper(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.out, self.skip = [], 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style"):
+            self.skip += 1
+        if tag in ("p", "div", "hr"):
+            klasy = (dict(attrs).get("class") or "").split()
+            if _KLASY_GRANIC.intersection(klasy):
+                self.out.append("\n" + GRANICA + "\n")
+        if tag in ("p", "br", "div", "tr", "li", "h1", "h2", "h3", "h4", "table"):
+            self.out.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style") and self.skip:
+            self.skip -= 1
+
+    def handle_data(self, data):
+        if not self.skip:
+            self.out.append(data)
+
+
+def html_to_text(html):
+    """XHTML → czysty tekst; znaki GRANICA zostają (granice podpisów/przypisów dla --fragment)."""
+    p = _Stripper()
+    p.feed(html)
+    # EUR-Lex używa twardych spacji (NBSP) — normalizuj, żeby frazy były wyszukiwalne
+    t = "".join(p.out).replace("\xa0", " ")
+    t = re.sub(r"[ \t]+", " ", t)
+    t = re.sub(r"\n[ \t]+", "\n", t)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return t.strip()
+
+
+def _bez_granic(t):
+    """Usuwa znaki granicy strukturalnej przed wydrukiem."""
+    return t.replace(GRANICA + "\n", "").replace(GRANICA, "")
+
+
+# Granice jednostek redakcyjnych w aktach UE (nagłówki na początku linii; PL/EN/DE/FR) oraz
+# granice KOŃCA części normatywnej: formuła „Sporządzono w …", podpisy „W imieniu Parlamentu/
+# Rady/Komisji", blok przypisów (znak GRANICA z XHTML; zapasowo linia „(1) Dz.U./OJ/ABl."),
+# załączniki. Bez nich fragment OSTATNIEGO artykułu ciągnął za sobą podpisy i wszystkie
+# przypisy aktu (RODO art. 99: 21 przypisów; AI Act art. 113: 58).
+# Nagłówek artykułu to CAŁA linia („Artykuł 113"); linia zaczynająca się odesłaniem („Article 6(1)
+# and the corresponding obligations… shall apply from 2 August 2027") nagłówkiem NIE jest — bez
+# kotwicy końca linii ucinała fragment art. 113 AI Act (EN) w połowie lit. c).
+_GRANICE = (r"(?m)^((?:Artykuł|Article|Artikel)\s+\d+[a-z]*\s*$|ROZDZIAŁ\s|CHAPTER\s|KAPITEL\s|"
+            r"SEKCJA\s|Sekcja\s|SECTION\s|TYTUŁ\s|TITLE\s|ZAŁĄCZNIK|ANNEX|ANHANG|PREAMBUŁA|"
+            + GRANICA + r"|Sporządzono w\b|Done at\b|Geschehen zu\b|Fait à\b|"
+            r"W imieniu (?:Parlamentu|Rady|Komisji)|For the (?:European Parliament|Council|Commission)|"
+            r"Im Namen (?:des|der)\b|Par le (?:Parlement|Conseil)|\(1\)\s+(?:Dz\.U\.|OJ\s|ABl\.|JO\s))")
+
+
+def _fragmenty(txt, fraza, maks=8):
+    """Spany (start, end) fragmentów z frazą, docięte do granic jednostek redakcyjnych.
+
+    Fraza "art. 6" / "artykuł 6" / "article 6" trafia w NAGŁÓWEK artykułu (w aktach UE:
+    "Artykuł 6" w osobnej linii), nie w odesłania; inna fraza działa pełnotekstowo.
+    """
+    bounds = [m.start() for m in re.finditer(_GRANICE, txt)]
+    m = re.match(r"(?i)^art(?:\.|ykuł|icle|ikel)?\s*(\d+[a-z]*)\.?$", fraza.strip())
+    if m:
+        n = m.group(1)
+        hits = [h.start() for h in re.finditer(
+            rf"(?m)^(?:Artykuł|Article|Artikel)\s+{n}\s*$", txt)]
+    else:
+        low, f = txt.lower(), fraza.lower()
+        hits, p = [], low.find(f)
+        while p != -1:
+            hits.append(p)
+            p = low.find(f, p + len(f))
+    spans = []
+    for pos in hits:
+        if len(spans) >= maks:
+            break
+        start = max((b for b in bounds if b <= pos), default=max(0, pos - 400))
+        end = min((b for b in bounds if b > pos), default=len(txt))
+        if spans and start < spans[-1][1]:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], end))
+        else:
+            spans.append((start, end))
+    return spans
+
+
+def celex_norm(parts):
+    """Normalizuje identyfikator do numeru CELEX, akceptując różne formy."""
+    s = " ".join(parts).strip()
+    s = re.sub(r"(?i)^celex:?\s*", "", s).strip()
+    # forma ELI: [http://data.europa.eu/eli/]reg|dir|dec/2016/679[/oj]
+    m = re.search(r"(?i)\b(reg|dir|dec)[a-z_]*/(\d{4})/(\d+)", s)
+    if m and not re.match(r"^\d", s):
+        lit = {"reg": "R", "dir": "L", "dec": "D"}[m.group(1).lower()[:3]]
+        return f"3{m.group(2)}{lit}{int(m.group(3)):04d}"
+    c = s.replace(" ", "").upper()
+    # sektor (1 cyfra) + rok (4 cyfry) + litera typu + numer | /TXT (traktaty, Karta)
+    if re.match(r"^[0-9]\d{4}[A-Z]{1,2}(?:\d+(?:\(\d{2}\))?(?:R\(\d{2}\))?(?:-\d{8})?|/TXT)$", c):
+        return c
+    sys.exit(f"Nie rozpoznano CELEX: {s!r}. Przykłady: 32016R0679, CELEX:32024R1689, "
+             "02016R0679-20160504 (skonsolidowany), reg/2016/679 (ELI).")
+
+
+def _konsolidacje(celex):
+    """Lista CELEX-ów wersji skonsolidowanych albo VERIFIED_ABSENT jako [].
+
+    VerificationUnknown jest przekazywany do wywołującego, bez zamiany na [].
+    """
+    base = celex.split("-")[0]
+    base = base if base.startswith("0") else "0" + base[1:]
+    rows = _sparql(f"""PREFIX cdm: <{CDM}>
+SELECT DISTINCT ?celex WHERE {{
+  ?w cdm:resource_legal_id_celex ?celex .
+  FILTER(STRSTARTS(STR(?celex), "{base}-"))
+}} ORDER BY DESC(?celex) LIMIT 100""", soft=True)
+    return [c for c in (_v(b, "celex") for b in rows) if re.search(r"-\d{8}$", c)]
+
+
+def _ostrzezenia_konsolidacja(celex, strict=False, tresc=True, kons=None):
+    """Ostrzeżenia o wersjach skonsolidowanych dla aktu/wersji (lista linii).
+
+    To informacja POBOCZNA przy tekście/metadanych — awaria SPARQL nie może odebrać
+    użytkownikowi treści głównej, więc UNKNOWN staje się tu głośnym ostrzeżeniem
+    (pełną weryfikację wymusza komenda skonsolidowany, gdzie to treść główna).
+
+    strict: awaria kontroli → VerificationUnknown (wywołujący blokuje wynik).
+    tresc:  wynik komendy to TREŚĆ aktu — w strict wykryta nowsza wersja skonsolidowana
+            blokuje starszą treść. Metadane (daty, obowiązywanie, tytuł) aktu bazowego nie
+            są „nieaktualne" przez to, że istnieje konsolidacja — tam tylko ostrzegamy.
+    kons:   gotowa lista z _konsolidacje (wywołujący już ją pobrał); None = pobierz tutaj."""
+    if kons is None:
+        try:
+            kons = _konsolidacje(celex)
+        except VerificationUnknown as e:
+            if strict:
+                raise
+            return [f"UWAGA: nie udało się zweryfikować, czy akt {celex} ma wersje skonsolidowane "
+                    f"({e}) — sprawdź komendą: skonsolidowany {celex}, zanim zacytujesz."]
+    out = []
+    blokuj = strict and tresc
+    if celex.startswith("0"):
+        out.append("UWAGA: wersja skonsolidowana ma charakter DOKUMENTACYJNY (nie jest autentyczna) — "
+                   "do urzędowego cytatu wskaż akt bazowy + zmiany.")
+        if kons and kons[0] > celex:
+            if blokuj:
+                sys.exit(f"BŁĄD: istnieje nowsza wersja skonsolidowana: {kons[0]}. "
+                         "Tryb strict blokuje starszą wersję (jej treść i stan na dzień).")
+            out.append(f"UWAGA: istnieje NOWSZA wersja skonsolidowana: {kons[0]} — używaj jej.")
+    elif kons:
+        if blokuj:
+            sys.exit(f"BŁĄD: akt ma wersje skonsolidowane — aktualny stan prawny to {kons[0]}. "
+                     f"Tryb strict blokuje treść aktu bazowego; do analizy: tekst {kons[0]} "
+                     "(wersja skonsolidowana jest dokumentacyjna — do urzędowego cytatu wskaż akt "
+                     "bazowy + zmiany; bez --strict tekst aktu bazowego jest dostępny).")
+        out.append(f"UWAGA: akt ma wersje skonsolidowane — do analizy aktualnego stanu użyj najnowszej: "
+                   f"{kons[0]} (pełna lista: skonsolidowany {celex}).")
+    return out
+
+
+def cmd_szukaj(a):
+    if not a.fraza:
+        sys.exit('Podaj frazę tytułu, np. szukaj "sztucznej inteligencji" --typ REG')
+    lang = _lang(a.jezyk)
+    fraza = a.fraza.lower().replace('"', "").replace("\\", "")
+    pat, filt = [], [f'FILTER(CONTAINS(LCASE(STR(?title)), "{fraza}"))']
+    if a.typ:
+        pat.append(f"?w cdm:work_has_resource-type <{TYPE_AUTH}{a.typ.upper()}> .")
+    if a.rok:
+        filt.append(f'FILTER(STRSTARTS(STR(?date), "{a.rok}"))')
+    if a.obowiazujace:
+        pat.append("?w cdm:resource_legal_in-force ?inf2 .")
+        filt.append('FILTER(STR(?inf2) IN ("1", "true"))')
+    q = f"""PREFIX cdm: <{CDM}>
+SELECT DISTINCT ?celex ?date ?title ?inf WHERE {{
+  ?w cdm:resource_legal_id_celex ?celex .
+  ?w cdm:work_date_document ?date .
+  {' '.join(pat)}
+  OPTIONAL {{ ?w cdm:resource_legal_in-force ?inf }}
+  ?exp cdm:expression_belongs_to_work ?w .
+  ?exp cdm:expression_uses_language <{LANG_AUTH}{lang}> .
+  ?exp cdm:expression_title ?title .
+  {' '.join(filt)}
+}} ORDER BY DESC(?date) LIMIT {a.limit}"""
+    rows = _sparql(q)
+    if not rows:
+        # zero trafień = komunikat + kod wyjścia ≠ 0 TAKŻE z --json: puste „[]" wyglądałoby jak
+        # „sprawdzone, nic nie ma", a szukanie po tytule z odmienioną frazą niczego nie dowodzi
+        sys.exit(f"Brak wyników dla {a.fraza!r} (język {lang}). Szukanie idzie po TYTULE i dopasowuje "
+                 "DOSŁOWNIE, a tytuły są odmienione ('ochrony danych osobowych', nie 'dane osobowe') — "
+                 "podaj RDZEŃ albo formę z tytułu ('osobow', 'danych osobowych'). Dalej nic? Spróbuj "
+                 "--jezyk eng albo bez --typ/--rok. To NIE dowód, że aktu nie ma.")
+    if a.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2)); return
+    print(f"Wyniki (pokazuję {len(rows)}, najnowsze pierwsze):\n")
+    for b in rows:
+        inf = _v(b, "inf")
+        status = "obowiązuje" if inf in ("1", "true") else ("nie obowiązuje" if inf in ("0", "false") else "—")
+        print(f"  {_v(b, 'celex')}  ({_v(b, 'date')})  [{status}]")
+        print(f"    {_v(b, 'title')[:160]}")
+        print()
+
+
+_META_POLA = ("type", "date", "inf", "eli", "eiv", "eov", "trans", "kons_data", "baza", "sklad", "title")
+
+
+def _meta_wiersze(celex, lang):
+    """Metadane pracy (work) o danym CELEX — surowe wiersze SPARQL.
+
+    Daty: cdm:resource_legal_date_entry-into-force trzyma ZARÓWNO wejście w życie, jak i daty
+    rozpoczęcia stosowania (CELLAR ich nie rozróżnia — osobnej właściwości „data stosowania"
+    w CDM nie ma); cdm:directive_date_transposition — termin(y) transpozycji dyrektywy.
+    Wersja skonsolidowana (sektor 0): cdm:act_consolidated_date = „stan na",
+    cdm:act_consolidated_based_on_resource_legal = akt bazowy,
+    cdm:act_consolidated_consolidates_resource_legal = akty ujęte w konsolidacji."""
+    return _sparql(f"""PREFIX cdm: <{CDM}>
+SELECT ?type ?date ?inf ?eli ?eiv ?eov ?trans ?kons_data ?baza ?sklad ?title WHERE {{
+  ?w cdm:resource_legal_id_celex "{celex}"^^<{XSD_STR}> .
+  OPTIONAL {{ ?w cdm:work_has_resource-type ?type }}
+  OPTIONAL {{ ?w cdm:work_date_document ?date }}
+  OPTIONAL {{ ?w cdm:resource_legal_in-force ?inf }}
+  OPTIONAL {{ ?w cdm:resource_legal_eli ?eli }}
+  OPTIONAL {{ ?w cdm:resource_legal_date_entry-into-force ?eiv }}
+  OPTIONAL {{ ?w cdm:resource_legal_date_end-of-validity ?eov }}
+  OPTIONAL {{ ?w cdm:directive_date_transposition ?trans }}
+  OPTIONAL {{ ?w cdm:act_consolidated_date ?kons_data }}
+  OPTIONAL {{ ?w cdm:act_consolidated_based_on_resource_legal ?b . ?b cdm:resource_legal_id_celex ?baza }}
+  OPTIONAL {{ ?w cdm:act_consolidated_consolidates_resource_legal ?s . ?s cdm:resource_legal_id_celex ?sklad }}
+  OPTIONAL {{ ?exp cdm:expression_belongs_to_work ?w .
+              ?exp cdm:expression_uses_language <{LANG_AUTH}{lang}> .
+              ?exp cdm:expression_title ?title }}
+}}""")
+
+
+def _zbierz(rows, pola=_META_POLA):
+    return {k: sorted({_v(b, k) for b in rows if _v(b, k)}) for k in pola}
+
+
+def _zmieniajace(celex):
+    """CELEX-y aktów ZMIENIAJĄCYCH dany akt (?x cdm:resource_legal_amends_resource_legal ?w).
+
+    [] = VERIFIED_ABSENT (sprostowania to osobna relacja — nie zmieniają dat stosowania);
+    awaria → VerificationUnknown (nigdy pusta lista)."""
+    rows = _sparql(f"""PREFIX cdm: <{CDM}>
+SELECT DISTINCT ?c2 WHERE {{
+  ?w cdm:resource_legal_id_celex "{celex}"^^<{XSD_STR}> .
+  ?x cdm:resource_legal_amends_resource_legal ?w . ?x cdm:resource_legal_id_celex ?c2 .
+}} ORDER BY ?c2 LIMIT 200""", soft=True)
+    return [_v(b, "c2") for b in rows if _v(b, "c2")]
+
+
+def _status(zb):
+    inf = zb["inf"][0] if zb["inf"] else ""
+    return "OBOWIĄZUJE" if inf in ("1", "true") else ("NIE OBOWIĄZUJE" if inf in ("0", "false") else "—")
+
+
+def _drukuj_daty(zb, wc="  "):
+    """Daty aktu (bazowego) z uczciwymi etykietami: jedna data = wejście w życie; kilka dat =
+    wejście w życie + daty stosowania, których CELLAR nie rozróżnia; dyrektywa = termin transpozycji."""
+    typy = {t.rsplit("/", 1)[-1] for t in zb["type"]}
+    if zb["date"]:
+        print(f"{wc}Data aktu: {zb['date'][0]}")
+    eiv = zb["eiv"]
+    if len(eiv) == 1:
+        print(f"{wc}Wejście w życie: {eiv[0]}")
+    elif eiv:
+        print(f"{wc}Wejście w życie / stosowanie: {', '.join(eiv)}")
+        print(f"{wc}  (kilka dat — CELLAR nie opisuje, która to wejście w życie, a która rozpoczęcie "
+              "stosowania; najwcześniejsza to z reguły wejście w życie — sprawdź przepisy końcowe aktu!)")
+    if zb["trans"]:
+        print(f"{wc}Termin transpozycji: {', '.join(zb['trans'])}"
+              + ("   (kilka terminów — różne zakresy; sprawdź przepis o transpozycji)"
+                 if len(zb["trans"]) > 1 else ""))
+        print(f"{wc}  (dyrektywa działa przez transpozycję — polską ustawę wdrażającą sprawdź "
+              "skillem prawo-pl-eli)")
+    elif "DIR" in typy:
+        print(f"{wc}Termin transpozycji: brak w CELLAR — sprawdź przepis o transpozycji w tekście dyrektywy")
+    if zb["eov"] and zb["eov"][0] != "9999-12-31":
+        print(f"{wc}Koniec obowiązywania: {zb['eov'][0]}")
+    print(f"{wc}Status:  {_status(zb)}")
+
+
+def _ostrzezenie_zmiany(akt, zmiany, najnowsza):
+    """Akt był zmieniany → daty stosowania z metadanych aktu bazowego mogą być nieaktualne."""
+    cel = (f"w najnowszej wersji skonsolidowanej {najnowsza} (tekst {najnowsza} --fragment \"art. N\")"
+           if najnowsza else f"w aktach zmieniających (odniesienia {akt})")
+    return (f"UWAGA: akt {akt} był zmieniany ({', '.join(zmiany)}) — daty wejścia w życie / stosowania "
+            f"pochodzą z metadanych AKTU BAZOWEGO i mogą być nieaktualne; sprawdź art. o stosowaniu {cel}.")
+
+
+def cmd_meta(a):
+    celex = celex_norm(a.celex)
+    lang = _lang(a.jezyk)
+    strict = getattr(a, "strict", False)
+    rows = _meta_wiersze(celex, lang)
+    if not rows:
+        sys.exit(f"Nie znaleziono aktu o CELEX {celex} w CELLAR.")
+    zb = _zbierz(rows)
+    # wersja skonsolidowana: jej daty to „stan na" konsolidacji, NIE daty aktu — daty czytamy z aktu bazowego
+    kons_wersja = bool(zb["kons_data"]) or bool(re.match(r"^0.*-\d{8}$", celex))
+    baza = zb["baza"][0] if zb["baza"] else (None if not kons_wersja else "3" + celex[1:].split("-")[0])
+    zb_baza = _zbierz(_meta_wiersze(baza, lang)) if kons_wersja else None
+    akt = baza if kons_wersja else celex
+    # --- weryfikacja PRZED emisją: wersje skonsolidowane + akty zmieniające -----------------
+    kons = None
+    try:
+        kons = _konsolidacje(celex)
+    except VerificationUnknown:
+        if strict:
+            raise
+    try:
+        zmiany, zmiany_uwaga = _zmieniajace(akt), None
+    except VerificationUnknown as e:
+        if strict:
+            raise
+        zmiany, zmiany_uwaga = [], (f"UWAGA: nie udało się zweryfikować, czy akt {akt} był zmieniany "
+                                    f"({e}) — sprawdź: odniesienia {akt}, zanim powołasz się na daty.")
+    najnowsza = kons[0] if kons else None
+    if strict and zmiany and not kons_wersja:
+        # Daty aktu bazowego po nowelizacji mogą być nieaktualne (AI Act art. 113 po 32026R1744),
+        # a CELLAR nie aktualizuje ich w metadanych aktu bazowego — strict nie może ich przepuścić.
+        # Same sprostowania nie blokują (nie zmieniają dat). Na wersji skonsolidowanej daty aktu
+        # bazowego idą z ostrzeżeniem — konsolidacja to właśnie miejsce, gdzie czyta się art. o stosowaniu.
+        sys.exit(f"BŁĄD: akt {celex} był zmieniany ({', '.join(zmiany)}) — daty wejścia w życie / "
+                 "stosowania z metadanych aktu bazowego mogą być nieaktualne. Tryb strict blokuje metadane "
+                 "aktu bazowego; do analizy: "
+                 + (f"meta {najnowsza} oraz art. o stosowaniu: tekst {najnowsza} --fragment \"art. N\""
+                    if najnowsza else f"odniesienia {celex} (akty zmieniające)")
+                 + " (bez --strict metadane aktu bazowego są dostępne z ostrzeżeniem).")
+    # konsolidacje: akt bazowy — tylko ostrzeżenie (tresc=False); wersja skonsolidowana w strict —
+    # nowsza wersja blokuje (stan „na dzień" starszej wersji jest z definicji zastąpiony)
+    ostrz = _ostrzezenia_konsolidacja(celex, strict, tresc=kons_wersja, kons=kons)
+    if zmiany:
+        ostrz.append(_ostrzezenie_zmiany(akt, zmiany, najnowsza))
+    if zmiany_uwaga:
+        ostrz.append(zmiany_uwaga)
+    if a.json:
+        # "meta" = surowe wiersze SPARQL tej pracy (na wersji skonsolidowanej: eiv/date = „stan na");
+        # "akt_bazowy" = zebrane metadane aktu bazowego; "zmieniajace" = CELEX-y nowelizacji;
+        # "ostrzezenia" = te same linie, które widzi człowiek
+        out = {"celex": celex, "wersja_skonsolidowana": kons_wersja, "meta": rows,
+               "zmieniajace": zmiany, "wersje_skonsolidowane": kons, "ostrzezenia": ostrz}
+        if kons_wersja:
+            out["akt_bazowy"] = {"celex": baza, "meta": zb_baza}
+        print(json.dumps(out, ensure_ascii=False, indent=2)); return
+    # --- emisja -------------------------------------------------------------------------------
+    print(f"Akt: CELEX {celex}")
+    if zb["title"]:
+        print(textwrap.fill(zb["title"][0], width=100, initial_indent="  Tytuł:   ",
+                            subsequent_indent="           "))
+    if zb["type"]:
+        print(f"  Typ:     {', '.join(t.rsplit('/', 1)[-1] for t in zb['type'])}"
+              + ("  (wersja skonsolidowana — dokumentacyjna)" if kons_wersja else ""))
+    if kons_wersja:
+        print(f"  Stan na (konsolidacja): {zb['kons_data'][0] if zb['kons_data'] else celex.rsplit('-', 1)[-1]}")
+        if zb["sklad"]:
+            print(f"  Uwzględnia: {', '.join(zb['sklad'])}")
+        if zb["eli"]:
+            print(f"  ELI:     {zb['eli'][0]}")
+        print(f"  Akt bazowy: CELEX {baza}" + ("" if zb_baza["type"] or zb_baza["date"] else "  (brak w CELLAR)"))
+        _drukuj_daty(zb_baza, wc="    ")
+        if zb_baza["eli"]:
+            print(f"    ELI:     {zb_baza['eli'][0]}")
+    else:
+        _drukuj_daty(zb)
+        if zb["eli"]:
+            print(f"  ELI:     {zb['eli'][0]}")
+    print(f"  Tekst:   python3 {sys.argv[0]} tekst {celex} --jezyk pol --fragment \"art. N\"")
+    for w in ostrz:
+        print(w)
+
+
+def cmd_skonsolidowany(a):
+    celex = celex_norm(a.celex)
+    try:
+        kons = _konsolidacje(celex)
+    except VerificationUnknown as e:
+        _nie_zweryfikowano(f"wersji skonsolidowanych dla {celex}", e)
+    if a.json:
+        print(json.dumps(kons, ensure_ascii=False, indent=2)); return
+    if not kons:
+        print(f"Brak wersji skonsolidowanych dla {celex} — akt nie był zmieniany "
+              f"(cytuj z aktu bazowego: tekst {celex}); sprawdź sprostowania: odniesienia {celex}.")
+        return
+    print(f"WERSJE SKONSOLIDOWANE dla {celex} (najnowsza pierwsza; data w CELEX = stan na):")
+    for i, c in enumerate(kons):
+        print(f"  - {c}{'  ← AKTUALNA' if i == 0 else ''}")
+    print("\nUWAGA: wersja skonsolidowana ma charakter dokumentacyjny — do urzędowego cytatu "
+          "wskaż akt bazowy + zmiany.")
+    print(f"Dalej: python3 {sys.argv[0]} tekst {kons[0]} --jezyk pol --fragment \"art. N\"")
+
+
+def _pdf_url(celex, lang):
+    """URL manifestacji PDF danej wersji językowej (negocjacja Accept: application/pdf nie działa w CELLAR)."""
+    rows = _sparql(f"""PREFIX cdm: <{CDM}>
+SELECT ?man ?mtype WHERE {{
+  ?w cdm:resource_legal_id_celex "{celex}"^^<{XSD_STR}> .
+  ?exp cdm:expression_belongs_to_work ?w .
+  ?exp cdm:expression_uses_language <{LANG_AUTH}{lang}> .
+  ?man cdm:manifestation_manifests_expression ?exp .
+  ?man cdm:manifestation_type ?mtype .
+  FILTER(STRSTARTS(STR(?mtype), "pdf"))
+}} LIMIT 5""", soft=True)
+    pdfy = sorted(rows, key=lambda b: _v(b, "mtype"))  # pdfa1a/pdfa2a przed zwykłym pdf
+    return (_v(pdfy[0], "man") + "/DOC_1") if pdfy else None
+
+
+def cmd_tekst(a):
+    celex = celex_norm(a.celex)
+    lang = _lang(a.jezyk)
+    lang3 = lang.lower()
+    url = CELLAR + urllib.parse.quote(celex, safe="/")
+    if a.pdf:
+        strict = getattr(a, "strict", False)
+        ostrz = _ostrzezenia_konsolidacja(celex, True) if strict else None
+        try:
+            pdf_url = _pdf_url(celex, lang)
+        except VerificationUnknown as e:
+            _nie_zweryfikowano(f"manifestacji PDF dla {celex} w języku {lang3}", e)
+        if not pdf_url:
+            sys.exit(f"Brak manifestacji PDF dla {celex} w języku {lang3} — spróbuj inny --jezyk.")
+        data, _ = _http(pdf_url)
+        with open(a.pdf, "wb") as f:
+            f.write(data)
+        print(f"Zapisano PDF ({len(data)} B): {a.pdf}\n(źródło: {pdf_url}, język {lang3})")
+        for w in (ostrz if ostrz is not None else _ostrzezenia_konsolidacja(celex)):
+            print(w)
+        return
+    try:
+        raw, _ = _http(url, headers={"Accept": "application/xhtml+xml", "Accept-Language": lang3})
+    except SystemExit as e:
+        if "(404)" in str(e) and re.match(r"^0.*-\d{8}$", celex):
+            _wyjasnij_404_konsolidacji(celex, lang3)
+        raise
+    txt = html_to_text(raw.decode("utf-8", "replace"))
+    if not _bez_granic(txt).strip():
+        sys.exit(f"Pusty tekst XHTML dla {celex} (język {lang3}) — spróbuj --pdf albo inny --jezyk.")
+    ostrz = _ostrzezenia_konsolidacja(celex, getattr(a, "strict", False))
+    print(f"# CELEX {celex} ({lang3}) — tekst z CELLAR (XHTML→tekst; do dosłownego cytatu zweryfikuj z PDF)\n")
+    for w in ostrz:
+        print(w)
+    if ostrz:
+        print()
+    if a.fragment:
+        spans = _fragmenty(txt, a.fragment)
+        if not spans:
+            sys.exit(f"Nie znaleziono frazy {a.fragment!r} w tekście aktu ({len(txt)} znaków). "
+                     "Spróbuj inną frazą, w innym języku, albo bez --fragment.")
+        for i, (s, e) in enumerate(spans):
+            if i:
+                print("\n[...]\n")
+            print(_bez_granic(txt[s:e]).strip())
+        print(f"\n(fragmenty: {len(spans)} — pominięto resztę aktu (w tym podpisy i przypisy końcowe); "
+              "pełny tekst: bez --fragment)")
+        return
+    txt = _bez_granic(txt)
+    if len(txt) > 60000:
+        print(f"(UWAGA: pełny tekst ma {len(txt)} znaków — do pojedynczego przepisu użyj --fragment \"art. N\")\n")
+    print(txt)
+
+
+def _wyjasnij_404_konsolidacji(celex, lang3):
+    """404 na wersji skonsolidowanej: numer bywa poprawny (figuruje na liście wersji), ale CELLAR
+    nie serwuje treści wersji zastąpionych — zwłaszcza pierwszej, tożsamej z aktem bazowym
+    (np. 02024R1689-20240712). Nie każ wtedy „sprawdzać numeru CELEX"."""
+    baza = "3" + celex[1:].split("-")[0]
+    try:
+        kons = _konsolidacje(celex)
+    except VerificationUnknown as e:
+        sys.exit(f"BŁĄD: CELLAR nie udostępnia tekstu wersji skonsolidowanej {celex} (404), a listy wersji "
+                 f"nie udało się zweryfikować ({e}) — sprawdź: skonsolidowany {baza}.")
+    if celex in kons and kons[0] != celex:
+        sys.exit(f"BŁĄD: CELLAR nie udostępnia już tekstu wersji skonsolidowanej {celex} (404). Numer jest "
+                 "poprawny i figuruje na liście wersji, ale Urząd Publikacji nie serwuje treści tej "
+                 f"ZASTĄPIONEJ wersji (ani w EUR-Lex). Najnowsza wersja: {kons[0]} → "
+                 f"tekst {kons[0]} --fragment \"art. N\"; pełna lista: skonsolidowany {baza}; "
+                 f"stan pierwotny: tekst {baza}.")
+    if kons and kons[0] == celex:
+        sys.exit(f"BŁĄD: CELLAR nie udostępnia tekstu najnowszej wersji skonsolidowanej {celex} w języku "
+                 f"{lang3} (404) — spróbuj --jezyk eng albo --pdf; akt bazowy: tekst {baza}.")
+    sys.exit(f"BŁĄD: CELLAR nie zna wersji skonsolidowanej {celex} (404) — dostępne wersje: "
+             f"skonsolidowany {baza}" + (f" (najnowsza: {kons[0]})" if kons else " (brak)") + ".")
+
+
+# kolejność sekcji w odniesieniach: najpierw to, co decyduje o mocy obowiązującej aktu
+_KIERUNKI = ("UCHYLONY PRZEZ (akt uchylający ten akt)",
+             "Uchylony w sposób dorozumiany przez",
+             "Nowelizacje (akty zmieniające ten akt)",
+             "Sprostowania",
+             "Uchyla (akty uchylone przez ten akt)",
+             "Uchyla w sposób dorozumiany (przepisy tracące moc przez ten akt)",
+             "Zmienia (akty zmieniane przez ten akt)",
+             "Podstawa prawna (traktatowa)")
+
+
+def cmd_odniesienia(a):
+    celex = celex_norm(a.celex)
+    rows = _sparql(f"""PREFIX cdm: <{CDM}>
+SELECT DISTINCT ?kier ?c2 ?inf ?eov WHERE {{
+  ?w cdm:resource_legal_id_celex "{celex}"^^<{XSD_STR}> .
+  OPTIONAL {{ ?w cdm:resource_legal_in-force ?inf }}
+  OPTIONAL {{ ?w cdm:resource_legal_date_end-of-validity ?eov }}
+  {{ ?x cdm:resource_legal_repeals_resource_legal ?w . ?x cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[0]}" AS ?kier) }}
+  UNION
+  {{ ?x cdm:resource_legal_implicitly_repeals_resource_legal ?w . ?x cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[1]}" AS ?kier) }}
+  UNION
+  {{ ?x cdm:resource_legal_amends_resource_legal ?w . ?x cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[2]}" AS ?kier) }}
+  UNION
+  {{ ?x cdm:resource_legal_corrects_resource_legal ?w . ?x cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[3]}" AS ?kier) }}
+  UNION
+  {{ ?w cdm:resource_legal_repeals_resource_legal ?o . ?o cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[4]}" AS ?kier) }}
+  UNION
+  {{ ?w cdm:resource_legal_implicitly_repeals_resource_legal ?o . ?o cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[5]}" AS ?kier) }}
+  UNION
+  {{ ?w cdm:resource_legal_amends_resource_legal ?o . ?o cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[6]}" AS ?kier) }}
+  UNION
+  {{ ?w cdm:resource_legal_based_on_resource_legal ?o . ?o cdm:resource_legal_id_celex ?c2 .
+     BIND("{_KIERUNKI[7]}" AS ?kier) }}
+}} ORDER BY ?kier DESC(?c2) LIMIT 400""")
+    if a.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2)); return
+    print(f"Odniesienia dla: CELEX {celex}\n")
+    if not rows:
+        print("Brak odnotowanych relacji w CELLAR (albo zły CELEX — sprawdź: meta).")
+        return
+    grupy = {}
+    for b in rows:
+        grupy.setdefault(_v(b, "kier"), []).append(_v(b, "c2"))
+    zb = _zbierz(rows, ("inf", "eov"))
+    uchylony = grupy.get(_KIERUNKI[0], [])
+    eov = zb["eov"][0] if zb["eov"] and zb["eov"][0] != "9999-12-31" else ""
+    if uchylony:
+        print(f"AKT UCHYLONY przez {', '.join(uchylony)}"
+              + (f" (koniec obowiązywania: {eov})" if eov else "")
+              + f" — {_status(zb) if zb['inf'] else 'NIE OBOWIĄZUJE'}; aktualny stan prawny czytaj z aktu uchylającego.\n")
+    elif _status(zb) == "NIE OBOWIĄZUJE":
+        print("AKT NIE OBOWIĄZUJE" + (f" (koniec obowiązywania: {eov})" if eov else "")
+              + " — w CELLAR brak relacji „uchylony przez\"; sprawdź: meta.\n")
+    for kier in sorted(grupy, key=lambda k: _KIERUNKI.index(k) if k in _KIERUNKI else 99):
+        lst = grupy[kier]
+        print(f"## {kier}  ({len(lst)})")
+        for c in lst:
+            print(f"  - {c}")
+        print()
+    if _KIERUNKI[2] in grupy and not uchylony:
+        print(f"Akt był zmieniany → aktualny stan czytaj z wersji skonsolidowanej: skonsolidowany {celex}")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="CELLAR/EUR-Lex (read-only, bez klucza). Źródło pierwotne prawa UE.")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("szukaj"); s.add_argument("fraza", nargs="?")
+    s.add_argument("--typ", help="typ aktu: REG (rozporządzenie), DIR (dyrektywa), DEC (decyzja)")
+    s.add_argument("--rok"); s.add_argument("--jezyk", default="pol")
+    s.add_argument("--obowiazujace", action="store_true")
+    s.add_argument("--limit", type=int, default=10); s.set_defaults(func=cmd_szukaj)
+
+    for name, fn in (("odniesienia", cmd_odniesienia), ("skonsolidowany", cmd_skonsolidowany)):
+        p = sub.add_parser(name); p.add_argument("celex", nargs="+"); p.set_defaults(func=fn)
+
+    m = sub.add_parser("meta"); m.add_argument("celex", nargs="+")
+    m.add_argument("--jezyk", default="pol"); m.set_defaults(func=cmd_meta)
+
+    t = sub.add_parser("tekst"); t.add_argument("celex", nargs="+")
+    t.add_argument("--jezyk", default="pol"); t.add_argument("--pdf")
+    t.add_argument("--fragment", help='wytnij tylko jednostki z frazą, np. "art. 6" albo "profilowanie"')
+    t.set_defaults(func=cmd_tekst)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności")
+
+    a = ap.parse_args()
+    try:
+        a.func(a)
+    except VerificationUnknown as e:
+        _nie_zweryfikowano("danych w EUR-Lex", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/prawo-pl-cbosa/.claude-plugin/plugin.json
+++ b/plugins/prawo-pl-cbosa/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-pl-cbosa",
+  "description": "Orzecznictwo polskich sądów administracyjnych z CBOSA (orzeczenia.nsa.gov.pl): wyroki, postanowienia i uchwały NSA oraz 16 WSA (~2,4 mln orzeczeń od 2004 r.). Wyszukiwanie po frazie, sygnaturze, sądzie, symbolu sprawy, sędzim i dacie; pełne sentencje i uzasadnienia, powołane przepisy, sygnatury powiązane. CBOSA nie ma API — skill czyta publiczne strony HTML (read-only, z throttlingiem). SN/TK/sądy powszechne/KIO: prawo-pl-saos.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-pl-cbosa/.codex-plugin/plugin.json
+++ b/plugins/prawo-pl-cbosa/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prawo-pl-cbosa",
+  "version": "2.0.0",
+  "description": "Orzecznictwo polskich sądów administracyjnych z CBOSA (orzeczenia.nsa.gov.pl): NSA + 16 WSA. Wyszukiwanie po frazie, sygnaturze, sądzie, symbolu sprawy, sędzim i dacie; pełne sentencje i uzasadnienia, powołane przepisy. Read-only (CBOSA nie ma API — publiczne strony HTML z throttlingiem).",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": ["prawo", "polish-law", "orzecznictwo", "case-law", "cbosa", "nsa", "wsa", "sady-administracyjne", "legal"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo PL — orzecznictwo administracyjne (CBOSA)",
+    "shortDescription": "Orzecznictwo NSA i WSA z bazy CBOSA (orzeczenia.nsa.gov.pl).",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: prawo-pl-cbosa
+version: 2.0.0
+description: >-
+  Przeszukuje CBOSA — Centralną Bazę Orzeczeń Sądów Administracyjnych (orzeczenia.nsa.gov.pl):
+  wyroki, postanowienia i uchwały NSA oraz 16 WSA (~2,4 mln orzeczeń od 2004 r.). Używaj przy
+  KAŻDYM pytaniu o orzecznictwo sądów administracyjnych: skargi na decyzje organów, interpretacje
+  podatkowe, „jak NSA/WSA interpretuje…", „wyrok NSA sygn. …", linia orzecznicza w sprawach
+  administracyjnych i podatkowych (k.p.a., Ordynacja podatkowa, p.p.s.a., RODO/UODO, prawo
+  budowlane, samorządowe, cudzoziemcy). CBOSA NIE MA oficjalnego API — skill czyta publiczne
+  strony HTML (read-only, z throttlingiem). Orzecznictwo SN/TK/sądów powszechnych/KIO → skill
+  prawo-pl-saos; treść przepisów → prawo-pl-eli; decyzje UODO → prawo-pl-uodo. Polish
+  administrative courts (NSA/WSA) case-law from the public CBOSA database.
+---
+
+# Orzecznictwo sądów administracyjnych (NSA/WSA) z CBOSA
+
+Skill do **orzecznictwa sądów administracyjnych**: Naczelnego Sądu Administracyjnego (NSA)
+i 16 wojewódzkich sądów administracyjnych (WSA). Sięga do **CBOSA** — Centralnej Bazy Orzeczeń
+Sądów Administracyjnych (`https://orzeczenia.nsa.gov.pl`, ~2,4 mln orzeczeń od 2004 r., wybrane
+starsze). Używaj go zawsze, gdy pytanie dotyczy **skarg na decyzje administracyjne, interpretacji
+podatkowych, postępowania przed organami** — czyli tam, gdzie właściwe są sądy administracyjne.
+
+**CBOSA nie ma oficjalnego API** — silnik czyta publiczne strony HTML wyszukiwarki (read-only,
+bez logowania, z throttlingiem ≥0,5 s). To najbardziej kompletne i urzędowe źródło orzecznictwa
+administracyjnego; SAOS (skill prawo-pl-saos) sądów administracyjnych praktycznie nie ma.
+
+## Podział ról (który skill do czego)
+
+1. **NSA/WSA (administracja, podatki) → ten skill.** Skargi na decyzje, interpretacje
+   indywidualne, kary administracyjne, RODO (skargi na decyzje UODO), budowlane, samorząd.
+2. **SN/TK/sądy powszechne/KIO → prawo-pl-saos.** Sprawy cywilne, karne, gospodarcze.
+3. **Treść przepisu → prawo-pl-eli** (ELI Sejmu). Orzeczenie mogło zapaść na starszym stanie
+   prawnym — brzmienie i aktualność przepisu potwierdź w ELI.
+4. **Decyzje Prezesa UODO → prawo-pl-uodo**; wyroki WSA/NSA ze skarg na te decyzje → ten skill.
+5. **Delegując research subagentowi**, wpisz: „orzecznictwo sądów administracyjnych pobieraj
+   przez `scripts/cbosa.py` (skill prawo-pl-cbosa)".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/cbosa.py` (tylko biblioteka standardowa Pythona — bez instalacji).
+Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/cbosa.py`) — NIE zakładaj, że to
+`~/.claude/skills/prawo-pl-cbosa` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+CBOSA="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-cbosa/scripts/cbosa.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$CBOSA" ] || CBOSA="<katalog skilla>/scripts/cbosa.py"
+[ -f "$CBOSA" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $CBOSA" >&2; exit 1; }
+python3 "$CBOSA" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/cbosa.py` oznacza `python3 "$CBOSA"`, jeśli nie jesteś w katalogu skilla.)
+
+### Komendy
+
+- **szukaj** — znajdź orzeczenia po kryteriach:
+  `python3 scripts/cbosa.py szukaj "odpowiedzialność członków zarządu" --sad NSA --od 2024-01-01`
+  Opcje: `--sad NSA | "WSA Warszawa" | "WSA Kraków" …` (16 miast; można też podać pełną nazwę),
+  `--sygnatura "II FSK 2870/18"`, `--rodzaj wyrok|postanowienie|uchwala`, `--symbol 6119`
+  (symbol sprawy, np. 611x podatki), `--sedzia "Nowak"`, `--od/--do RRRR-MM-DD` (można też sam rok
+  `2024` albo `2024-01` — silnik uzupełni do początku/końca okresu),
+  `--strona N` (od 1; stała wielkość strony: 10 wyników).
+- **orzeczenie** — pełne orzeczenie po `doc_id` (z listy `szukaj`):
+  `python3 scripts/cbosa.py orzeczenie 8889489BE0`
+  Pokazuje metadane (sąd, sędziowie, symbol, hasła, skarżony organ, **powołane przepisy**,
+  sygnatury powiązane z doc_id do skoku), **prawomocność** (linia `Prawomocność:` zaraz po dacie;
+  w JSON `prawomocne: true/false/null` + `prawomocnosc` = tekst oznaczenia CBOSA), sentencję
+  i uzasadnienie. Do długich uzasadnień: `--fragment "interpretacja"` (wycina okna wokół frazy;
+  brzegi okien dopasowane do granic zdań/wyrazów, `…` na brzegu oznacza ucięcie, `[...]` między oknami).
+- **sygnatura** — szybkie odszukanie po sygnaturze:
+  `python3 scripts/cbosa.py sygnatura II FSK 2870/18`
+- każda komenda przyjmuje `--json` oraz `--strict`; obie flagi działają przed komendą i po niej.
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”).
+
+### Prawomocność i tryb `--strict`
+
+CBOSA oznacza każde orzeczenie na stronie `/doc/<id>` kursywą **„orzeczenie prawomocne” /
+„orzeczenie nieprawomocne”** (w wierszu „Data orzeczenia”); przy części orzeczeń (np. postanowienia
+wpadkowe, świeże orzeczenia) pole jest **puste** — CBOSA nic nie twierdzi. Silnik czyta to oznaczenie
+i w `orzeczenie` zawsze je pokazuje:
+
+- `Prawomocność: prawomocne` — bez uwag.
+- `Prawomocność: NIEPRAWOMOCNE` + głośne **UWAGA** na początku wyniku: orzeczenie mogło zostać
+  **uchylone lub zmienione w wyższej instancji** (typowo: wyrok WSA uchylony przez NSA). Zanim je
+  zacytujesz, skocz do orzeczenia powiązanego (`Sygn. powiązane` / `↳ powiązane`, WSA ↔ NSA) i sprawdź
+  jego „Treść wyniku”. Przykład: `I SA/Bk 226/18` (doc 109C7D1883) jest nieprawomocny — NSA w
+  `II FSK 2870/18` (doc 8889489BE0) „uchylił zaskarżony wyrok”.
+- `Prawomocność: nieznana` + UWAGA — CBOSA nie podaje (puste pole) albo oznaczenia nie znaleziono
+  (zmiana układu strony). Nie traktuj tego jak „prawomocne”.
+
+**Lista wyników `szukaj`/`sygnatura` NIE ma tego oznaczenia** (strona wyników CBOSA go nie niesie) —
+flaga jest dostępna wyłącznie przez `orzeczenie <doc_id>`.
+
+`--strict` blokuje wynik (komunikat + kod ≠ 0, nic na stdout także z `--json`), gdy: (1) transport TLS
+nie został zweryfikowany, (2) strona orzeczenia nie została rozpoznana / wyszukiwarka nie odpowiedziała
+poprawną stroną, (3) orzeczenie jest oznaczone jako **nieprawomocne**, (4) prawomocności na stronie
+brak (puste pole / oznaczenie nieznalezione). Bez `--strict` dostaniesz w tych dwóch ostatnich
+przypadkach pełny tekst z ostrzeżeniem. `--strict` **nie sprawdza**: czy wyrok NSA jest ostateczny
+w sensie wznowienia/skargi nadzwyczajnej, czy przepisy powołane w orzeczeniu nadal obowiązują (→ ELI),
+ani prawomocności wyników `szukaj` (brak danych na liście).
+
+Typowy przepływ: `szukaj` (zawęź `--sad`/`--od`/`--symbol`) → wybierz doc_id → `orzeczenie <doc_id>`
+(spójrz na `Prawomocność:`) → w razie potrzeby skacz po sygnaturach powiązanych (WSA ↔ NSA w tej samej
+sprawie).
+
+## Zasady (ważne — dlaczego)
+
+1. **To scraping, nie API.** CBOSA nie udostępnia API ani zrzutów danych; silnik parsuje publiczny
+   HTML. Zmiana układu stron może zepsuć parsowanie — gdy wynik wygląda na obcięty/pusty, zajrzyj
+   pod podany link „Źródło" i zgłoś problem. Nie zrównoleglaj zapytań (wbudowany throttling ≥0,5 s;
+   serwer bywa przeciążony i ucina połączenia — silnik sam ponawia).
+2. **Rozróżniaj trzy komunikaty — tylko jeden znaczy „awaria".**
+   „Brak wyników (zweryfikowane zero)" = CBOSA wyszukało i nic nie ma → **zmień zapytanie**
+   (krótsza fraza, bez `--sad`, szerszy zakres dat), nie ponawiaj tego samego.
+   „CBOSA odrzuciło zapytanie: …" = błąd parametrów (np. formatu daty) → popraw i ponów.
+   „BŁĄD: … strona bez listy wyników" albo „BŁĄD sieci" = serwer → ponów za chwilę.
+3. **Baza ma charakter informacyjno-edukacyjny** (nie jest urzędowym publikatorem, orzeczenia są
+   zanonimizowane). Zawsze podawaj **sygnaturę + sąd + datę** (np. „wyrok NSA z 10.02.2021,
+   II FSK 2870/18"); do dosłownego cytatu w piśmie podaj też link do strony orzeczenia.
+4. **Dwuinstancyjność:** sprawy WSA i NSA łącz przez pole „Sygn. powiązane" (skarga kasacyjna od
+   wyroku WSA → wyrok NSA). Sygnatury: NSA np. `II FSK 2870/18`, WSA np. `I SA/Bk 226/18`.
+   Wyrok WSA oznaczony `NIEPRAWOMOCNE` może już nie obowiązywać — najpierw sprawdź wyrok NSA.
+5. **Nie myl orzeczenia z przepisem.** Brzmienie i aktualność powołanych przepisów potwierdź w ELI
+   (skill prawo-pl-eli) — orzeczenie mogło zapaść na starszym stanie prawnym.
+6. **Okno serwisowe:** CBOSA ma codzienną krótką przerwę ok. 21:00 — błędy o tej porze są normalne.
+7. **Błąd certyfikatu TLS nie obniża zabezpieczeń automatycznie.** Domyślnie daje `UNKNOWN`.
+   Jeżeli operator świadomie akceptuje ryzyko, może dla jednego uruchomienia ustawić
+   `CBOSA_INSECURE_TLS=1`. Wynik JSON ma wtedy `transport_tls_verified: false`, a wynik tekstowy
+   ostrzeżenie przy treści. Takiej treści nie cytuj bez sprawdzenia w innym źródle.
+8. Szczegóły kontraktu HTML (pola formularza, struktura stron): `references/api.md`.
+
+## Czego ten skill NIE obejmuje
+
+- **treści przepisów** (ustawy/kodeksy → skill **prawo-pl-eli**),
+- **orzecznictwa SN, TK, sądów powszechnych i KIO** (→ skill **prawo-pl-saos**),
+- **prawa UE i orzecznictwa TSUE** (→ skill **prawo-eu-eurlex**),
+- **decyzji Prezesa UODO** (→ skill **prawo-pl-uodo**; tu są tylko WYROKI ze skarg na nie),
+- pism stron, akt sprawy (dostępne tylko dla stron postępowania w portalach sądów).
+Jeśli zagadnienie wymaga tych źródeł — powiedz to wprost, nie udawaj, że CBOSA je pokryje.
+
+## Przykładowy przepływ
+
+Pytanie: „jak NSA podchodzi do odpowiedzialności członka zarządu za zaległości podatkowe spółki
+(art. 116 Ordynacji podatkowej)?"
+1. (opcjonalnie) ELI: `tekst <t.j. Ordynacji> --fragment "art. 116"` → brzmienie przepisu
+   (skill prawo-pl-eli).
+2. `szukaj "odpowiedzialność członka zarządu" --sad NSA --od 2024-01-01 --symbol 6116`
+   → lista wyroków NSA z sygnaturami i doc_id.
+3. `orzeczenie <doc_id> --fragment "art. 116"` → wycinki uzasadnienia wokół przepisu
+   + powołane przepisy + sygnatury powiązane (wyrok WSA I instancji).
+4. W odpowiedzi: zacytuj tezę, podaj sygnaturę + sąd + datę + link, zaznacz „baza CBOSA
+   (informacyjna) — do dosłownego cytatu zweryfikuj na stronie orzeczenia".

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/references/api.md
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/references/api.md
@@ -1,0 +1,109 @@
+# CBOSA — kontrakt HTML (brak oficjalnego API)
+
+Baza: `https://orzeczenia.nsa.gov.pl` — Centralna Baza Orzeczeń Sądów Administracyjnych (NSA + 16 WSA,
+~2,4 mln orzeczeń od 2004 r.). **NSA nie udostępnia API ani zrzutów danych** (mimo petycji KIDP z powołaniem
+na ustawę o otwartych danych) — poniżej udokumentowany kontrakt de facto: publiczne strony HTML, które czyta
+`cbosa.py`. Baza ma charakter informacyjno-edukacyjny; orzeczenia są zanonimizowane. Codzienne okno
+serwisowe ok. 21:00. Wszystkie pola i regexy zweryfikowane na żywych stronach (2026-07).
+
+## Wyszukiwanie: `POST /cbo/search`
+
+`Content-Type: application/x-www-form-urlencoded` (UTF-8). Pola formularza (z `/cbo/query`):
+
+| Pole | Wartości / format |
+|---|---|
+| `wszystkieSlowa` | fraza pełnotekstowa |
+| `wystepowanie` | `gdziekolwiek` \| `w sentencji` \| `w tezach` \| `w uzasadnieniu` |
+| `odmiana` | `on` (uwzględnij odmianę wyrazów) |
+| `sygnatura` | np. `II FSK 2870/18` |
+| `sad` | `dowolny` \| **PEŁNA nazwa**: `Naczelny Sąd Administracyjny`, `Wojewódzki Sąd Administracyjny w Warszawie`, … (`we Wrocławiu`, `w Gorzowie Wlkp.`); też historyczne `NSA oz. w …` |
+| `rodzaj` | `dowolny` \| `Wyrok` \| `Postanowienie` \| `Uchwała` |
+| `symbole` | symbol sprawy, np. `6119` |
+| `odDaty`, `doDaty` | `RRRR-MM-DD` — **wyłącznie ten format**; inny (np. `2024`, `31-12-2024`) zwraca formularz z komunikatem „Niepoprawny format daty, podaj RRRR-MM-DD!" i BEZ listy wyników |
+| `sedziowie` | nazwisko |
+| `funkcja` | `dowolna` \| `przewodniczący` \| `sprawozdawca` \| `autor uzasadnienia` |
+| `submit` | `Szukaj` |
+
+**PUŁAPKA 1:** pole `sad` przyjmuje pełny TEKST opcji — wartość spoza listy (np. `0`) po cichu zwraca
+0 wyników zamiast błędu. `cbosa.py` mapuje aliasy (`NSA`, `WSA <miasto>`) na pełne nazwy.
+
+**PUŁAPKA 2 (zakres dat otwarty od góry):** wypełnione `odDaty` przy PUSTYM `doDaty` po cichu zwraca
+**0 wyników** — puste `doDaty` działa jak górna granica sprzed początku zakresu (zweryfikowane:
+`odDaty=2024-01-01, doDaty=""` → 0; `doDaty=2099-12-31` → 421 trafień na tej samej frazie).
+Odwrotnie jest poprawnie: samo `doDaty` (z pustym `odDaty`) filtruje „do dnia". `cbosa.py` przy samym
+`--od` dostawia `doDaty=2099-12-31` (stała `DO_OTWARTE`).
+
+## Paginacja
+
+POST zwraca stronę 1 + ciasteczka sesji (`Set-Cookie`). Kolejne strony: `GET /cbo/find?p=N`
+**z odesłaniem ciasteczek** (stan wyszukiwania trzymany w sesji). Stała wielkość strony: 10 wyników.
+
+## Strona wyników — struktura HTML
+
+- liczba trafień: `Znaleziono <N> orzeczeń, Str. X z Y`
+- pozycja główna: `<td class="info-list-value " style="font-size: 12pt…"> <a href="/doc/{DOC_ID}">II FSK 2870/18 - Wyrok NSA z 2021-02-10</a>`
+  (`DOC_ID` = 10 znaków hex); po niej komórka `font-size: 10pt` ze snippetem (treść wyniku, symbole,
+  skarżony organ, powołane przepisy)
+- orzeczenia powiązane (ta sama sprawa w innej instancji): `<span class="powiazane"><a href="/doc/…">…</a></span>`
+- **komunikaty formularza:** `<div class="warning">…</div>` na stronie BEZ licznika „Znaleziono N".
+  Znane treści: `Nie znaleziono orzeczeń spełniających podany warunek!` (**zweryfikowane zero** —
+  zapytanie wykonane, brak trafień) oraz `Niepoprawny format daty, podaj RRRR-MM-DD!` (**błąd
+  zapytania** — CBOSA w ogóle nie szukało). Strona bez licznika i bez `warning` = przeciążenie
+  serwera/strona błędu; tylko wtedy warto ponawiać.
+
+## Strona orzeczenia: `GET /doc/{DOC_ID}`
+
+- `<TITLE>II FSK 2870/18 - Wyrok NSA z 2021-02-10</TITLE>` (sygnatura = część przed ` - `)
+- metadane — pary komórek: `<td class="info-list-label">Etykieta</td><td class="info-list-value">wartość</td>`.
+  Etykiety: `Data orzeczenia`, `Data wpływu`, `Sąd`, `Sędziowie` (z funkcją `/przewodniczący sprawozdawca/`),
+  `Symbol z opisem`, `Hasła tematyczne`, `Sygn. powiązane` (linki `/doc/…`), `Skarżony organ`,
+  `Treść wyniku`, `Powołane przepisy` (Dz.U. + artykuły + tytuł aktu)
+- **prawomocność** — JEDYNA komórka z zagnieżdżoną tabelą: wartość `Data orzeczenia` to
+  `<table …><tr><td>2018-06-06</td><td style="… font-style: italic;">orzeczenie nieprawomocne</td></tr></table>`
+  (albo `orzeczenie prawomocne`; bywa **puste** `&nbsp;` — zweryfikowane 2026-08 na postanowieniu
+  o wstrzymaniu wykonania `VI SA/Wa 707/26`, doc 1A8B8B8130). Ogólny regex metadanych czyta z niej tylko
+  datę; oznaczenie parsuje osobno `_prawomocnosc()` → JSON `prawomocne: true|false|null` i `prawomocnosc`
+  (`"orzeczenie prawomocne"` / `"orzeczenie nieprawomocne"` / `""` = pole puste / `null` = pola nie znaleziono).
+  Zweryfikowane na żywo: 109C7D1883 (WSA, nieprawomocne — uchylony przez NSA w II FSK 2870/18),
+  8889489BE0 i DC7DA8E6E8 (prawomocne), F438A0BAA7 (uchwała NSA, prawomocne).
+  **Strona wyników wyszukiwarki oznaczenia nie ma** (jedyne „prawomocn” w `raw_search` to treść snippetów).
+- sekcje treści: `<div class="lista-label">Sentencja</div><span class="info-list-value-uzasadnienie">…</span>`
+  — analogicznie `Tezy` (jeśli są) i `Uzasadnienie` (bywa nieopublikowane)
+
+## Tryb `--strict` — co sprawdza, czego nie
+
+| Kontrola | Efekt w `--strict` | Bez `--strict` |
+|---|---|---|
+| TLS niezweryfikowany (`CBOSA_INSECURE_TLS=1`) | blokada (`VerificationUnknown`) | wynik + adnotacja, JSON `transport_tls_verified:false` |
+| strona `/doc/{id}` nierozpoznana / wyszukiwarka bez licznika i listy | blokada (UNKNOWN, „spróbuj ponownie") | to samo — zawsze |
+| `orzeczenie`: oznaczenie **nieprawomocne** | blokada: „orzeczenie nieprawomocne — tryb strict nie zwraca treści, której aktualność nie jest potwierdzona; bez --strict dostaniesz tekst z ostrzeżeniem” + sygnatury powiązane | pełny tekst, `Prawomocność: NIEPRAWOMOCNE`, UWAGA na początku, JSON `prawomocne:false` + `uwaga` |
+| `orzeczenie`: pole prawomocności puste / nieznalezione | blokada (aktualność niepotwierdzona) | pełny tekst, `Prawomocność: nieznana`, UWAGA, JSON `prawomocne:null` |
+| `orzeczenie`: oznaczenie prawomocne | przechodzi | `Prawomocność: prawomocne`, JSON `prawomocne:true` |
+| `szukaj` / `sygnatura`: prawomocność pozycji | **nie sprawdza** — lista CBOSA nie niesie flagi | j.w.; sprawdź przez `orzeczenie <doc_id>` |
+
+Wszystkie kontrole wykonują się PRZED emisją wyniku (także `--json`): przy blokadzie stdout jest pusty,
+komunikat idzie na stderr, kod wyjścia ≠ 0. Strict NIE ocenia: ostateczności wyroku NSA (wznowienie, skarga
+nadzwyczajna), aktualności powołanych przepisów (→ ELI), ani tego, czy NSA zmienił linię w innej sprawie.
+
+## Mapowanie komend `cbosa.py` → pola
+
+`szukaj FRAZA`→`wszystkieSlowa`, `--sad`→`sad` (alias→pełna nazwa), `--sygnatura`→`sygnatura`,
+`--rodzaj`→`rodzaj`, `--symbol`→`symbole`, `--sedzia`→`sedziowie`, `--od/--do`→`odDaty/doDaty`
+(skróty `RRRR` i `RRRR-MM` silnik uzupełnia do początku okresu dla `--od`, do końca dla `--do`),
+`--strona N`→`GET /cbo/find?p=N` (po POST). `sygnatura <S>` = `szukaj` z samym polem `sygnatura`.
+
+## Wskazówki
+
+- **Throttling ≥0,5 s** między żądaniami (wbudowany). Serwer bywa przeciążony i ucina połączenia bez
+  odpowiedzi — silnik ponawia z rosnącym odstępem; nie zrównoleglaj zapytań.
+- **SSL:** gdy system nie potrafi zweryfikować łańcucha certyfikatów CBOSA, domyślnym wynikiem jest
+  `UNKNOWN`, bez automatycznego obniżenia zabezpieczeń. Jednorazowy, świadomy opt-in
+  `CBOSA_INSECURE_TLS=1 python3 scripts/cbosa.py ...` pozwala ponowić żądanie bez weryfikacji TLS.
+  Taki wynik ma w JSON pole `transport_tls_verified: false`, a w formacie tekstowym wyraźną
+  adnotację przy treści. Nie cytuj jej bez sprawdzenia w innym źródle.
+- **Symbole spraw** (pole `symbole`): 4-cyfrowe oznaczenia repertoriów, np. `611x` podatki
+  (6112 PIT, 6110 VAT), `6014` prawo budowlane, `6320` pomoc społeczna, `6480` informacja publiczna.
+  Pełny wykaz: zarządzenie Prezesa NSA (dostępne na stronach NSA).
+- **Powiązane instancje:** wyrok NSA linkuje wyrok WSA tej samej sprawy (i odwrotnie) — pole
+  `Sygn. powiązane` z doc_id; tak buduje się pełną historię sprawy.
+- Alternatywa dla SN/TK/sądów powszechnych/KIO: API SAOS (skill prawo-pl-saos) — tam CBOSA nie sięga.

--- a/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
+++ b/plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do CBOSA — Centralnej Bazy Orzeczeń Sądów Administracyjnych (https://orzeczenia.nsa.gov.pl).
+Tylko biblioteka standardowa Pythona (urllib/re/json) — brak zależności pip.
+Operacje WYŁĄCZNIE read-only (publiczne strony, bez logowania).
+
+CBOSA to urzędowa baza orzecznictwa SĄDÓW ADMINISTRACYJNYCH: NSA i 16 WSA (~2,4 mln orzeczeń
+od 2004 r., wybrane starsze). CBOSA NIE MA oficjalnego API — ten silnik czyta publiczne strony
+HTML wyszukiwarki (/cbo/search) i orzeczeń (/doc/{id}) z throttlingiem >=0,5 s między żądaniami.
+Zmiana układu stron CBOSA może wymagać aktualizacji silnika. Orzecznictwo SN/TK/sądów
+powszechnych/KIO bierz z SAOS (skill prawo-pl-saos); treść przepisów z ELI (prawo-pl-eli).
+
+Komendy:
+  szukaj ["<fraza>"] [--sad NSA|"WSA Warszawa"] [--sygnatura S] [--rodzaj wyrok|postanowienie|uchwala]
+         [--symbol 6119] [--sedzia N] [--od RRRR-MM-DD] [--do RRRR-MM-DD] [--strona N]
+  orzeczenie <doc_id> [--fragment "<fraza>"]   pełne orzeczenie: metadane, sentencja, uzasadnienie
+  sygnatura <sygnatura...>                      znajdź orzeczenie po sygnaturze
+Globalnie: --json  (zrzut sparsowanych danych jako JSON zamiast podsumowania; działa przed
+                    komendą i po niej)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować aktualności lub kompletności:
+                      TLS niezweryfikowany, nierozpoznana strona, orzeczenie NIEPRAWOMOCNE albo
+                      bez oznaczenia prawomocności na stronie CBOSA)
+
+Prawomocność: strona /doc/{id} niesie w wierszu „Data orzeczenia" kursywę „orzeczenie prawomocne"
+/ „orzeczenie nieprawomocne". Silnik ją parsuje (pole JSON `prawomocne`: true/false/null) — lista
+wyników wyszukiwarki tego oznaczenia NIE ma, więc flaga jest dostępna tylko przez `orzeczenie`.
+"""
+import sys, os, json, re, time, argparse, ssl, calendar, html as html_mod
+import urllib.request, urllib.parse, urllib.error, http.cookiejar
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+BASE = "https://orzeczenia.nsa.gov.pl"
+CONTENT_HOSTS = ("orzeczenia.nsa.gov.pl",)
+
+
+class VerificationUnknown(RuntimeError):
+    """Zapytanie nie pozwoliło ustalić, czy dane istnieją."""
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści CBOSA, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+# Miasta WSA (klucz bez diakrytyków) → końcówka pełnej nazwy z formularza CBOSA.
+# Wartości pola 'sad' to PEŁNE nazwy sądów — wartość spoza listy CBOSA po cichu zwraca 0 wyników.
+_WSA = {
+    "bialystok": "w Białymstoku", "bydgoszcz": "w Bydgoszczy", "gdansk": "w Gdańsku",
+    "gliwice": "w Gliwicach", "gorzow": "w Gorzowie Wlkp.", "kielce": "w Kielcach",
+    "krakow": "w Krakowie", "lublin": "w Lublinie", "lodz": "w Łodzi",
+    "olsztyn": "w Olsztynie", "opole": "w Opolu", "poznan": "w Poznaniu",
+    "rzeszow": "w Rzeszowie", "szczecin": "w Szczecinie", "warszawa": "w Warszawie",
+    "wroclaw": "we Wrocławiu",
+}
+_RODZAJE = {"WYROK": "Wyrok", "POSTANOWIENIE": "Postanowienie",
+            "UCHWAŁA": "Uchwała", "UCHWALA": "Uchwała"}
+
+
+def _ascii(s):
+    return s.lower().translate(str.maketrans("ąćęłńóśźż", "acelnoszz"))
+
+
+def _sad(s):
+    """Alias sądu → pełna nazwa z formularza CBOSA (NSA, 'WSA Warszawa', pełna nazwa)."""
+    if not s:
+        return "dowolny"
+    raw = s.strip()
+    if raw.lower() == "dowolny":
+        return "dowolny"
+    if raw.upper() == "NSA":
+        return "Naczelny Sąd Administracyjny"
+    low = _ascii(raw)
+    if low.startswith(("naczelny", "wojewodzki", "nsa oz", "nsa w warszawie")):
+        return raw  # pełna nazwa z formularza CBOSA (także historyczne ośrodki zamiejscowe NSA)
+    miasto = re.sub(r"^(wsa|wojewodzki sad administracyjny)?\s*(we?\s+)?", "", low).strip().rstrip(".")
+    for klucz, koncowka in _WSA.items():
+        if miasto == klucz or miasto.startswith(klucz):
+            return "Wojewódzki Sąd Administracyjny " + koncowka
+    sys.exit(f"Nieznany sąd: {s!r}. Użyj: NSA albo WSA <miasto> (np. \"WSA Warszawa\"), "
+             f"albo pełnej nazwy z formularza CBOSA. Miasta WSA: {', '.join(sorted(_WSA))}.")
+
+
+def _rodzaj(s):
+    if not s:
+        return "dowolny"
+    r = _RODZAJE.get(s.strip().upper())
+    if not r:
+        sys.exit(f"Nieznany rodzaj orzeczenia: {s!r}. Użyj: wyrok, postanowienie, uchwala.")
+    return r
+
+
+def _data(s, koniec=False):
+    """--od/--do → RRRR-MM-DD. Formularz CBOSA przyjmuje WYŁĄCZNIE ten format (inny zwraca
+    stronę błędu bez wyników, nie do odróżnienia od przeciążenia). Skróty RRRR i RRRR-MM
+    uzupełniamy do początku okresu (--od) albo jego końca (--do)."""
+    if not s:
+        return ""
+    t = s.strip().replace(".", "-").replace("/", "-")
+    m = re.fullmatch(r"(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?", t)
+    if not m:
+        sys.exit(f"Nieprawidłowa data: {s!r}. Format RRRR-MM-DD (np. 2024-01-31); "
+                 "można też podać sam rok (2024) albo rok z miesiącem (2024-01).")
+    rok, mies, dzien = m.group(1), m.group(2), m.group(3)
+    mm = int(mies) if mies else (12 if koniec else 1)
+    if not 1 <= mm <= 12:
+        sys.exit(f"Nieprawidłowa data: {s!r} — miesiąc poza zakresem. Format RRRR-MM-DD.")
+    ostatni = calendar.monthrange(int(rok), mm)[1]
+    dd = int(dzien) if dzien else (ostatni if koniec else 1)
+    if not 1 <= dd <= ostatni:
+        sys.exit(f"Nieprawidłowa data: {s!r} — nie ma takiego dnia. Format RRRR-MM-DD.")
+    return f"{rok}-{mm:02d}-{dd:02d}"
+
+
+# ── HTTP: throttling, ciasteczka sesji (paginacja), jawny opt-in TLS ────────────────────
+_jar = http.cookiejar.CookieJar()
+_ostatnie = [0.0]
+_transport_tls_verified = True
+
+
+def _dane_z_transportem(dane):
+    """Dodaje do wyniku JSON stan uwierzytelnienia transportu w tym przebiegu."""
+    return {**dane, "transport_tls_verified": _transport_tls_verified}
+
+
+def _uwaga_o_transporcie():
+    if _transport_tls_verified:
+        return ""
+    return ("UWAGA: transport TLS nie został zweryfikowany (CBOSA_INSECURE_TLS=1). "
+            "Treść nie jest uwierzytelniona i przed cytowaniem wymaga sprawdzenia "
+            "w innym źródle.")
+
+
+def _drukuj_uwage_o_transporcie():
+    uwaga = _uwaga_o_transporcie()
+    if uwaga:
+        print(uwaga + "\n")
+
+
+def _z_uwaga_o_transporcie(komunikat):
+    uwaga = _uwaga_o_transporcie()
+    return f"{uwaga}\n{komunikat}" if uwaga else komunikat
+
+
+def _sprawdz_transport_strict(a):
+    if getattr(a, "strict", False) and not _transport_tls_verified:
+        raise VerificationUnknown(
+            "tryb strict odrzuca wynik pobrany bez weryfikacji certyfikatu TLS")
+
+
+def _sprawdz_prawomocnosc_strict(a, d):
+    """--strict a prawomocność: CBOSA sama oznacza orzeczenie jako (nie)prawomocne. Orzeczenie
+    NIEPRAWOMOCNE mogło zostać uchylone w wyższej instancji — strict nie zwraca takiej treści.
+    Brak oznaczenia (None) = aktualność niepotwierdzona — strict też blokuje (jawnie, nie
+    jako „awaria": to nie jest błąd przejściowy, więc nie przez VerificationUnknown)."""
+    if not getattr(a, "strict", False):
+        return
+    if d.get("prawomocne") is False:
+        sys.exit(_z_uwaga_o_transporcie(
+            f"BŁĄD (strict): {d.get('sygnatura') or d['doc_id']} — orzeczenie nieprawomocne — tryb "
+            "strict nie zwraca treści, której aktualność nie jest potwierdzona; bez --strict "
+            "dostaniesz tekst z ostrzeżeniem. Sprawdź orzeczenie powiązane (WSA ↔ NSA): "
+            + (", ".join(f"{p['opis']} [{p['doc_id']}]" for p in d.get("powiazane", []))
+               or "brak sygnatur powiązanych na stronie CBOSA") + f". Źródło: {d['url']}"))
+    if d.get("prawomocne") is None:
+        sys.exit(_z_uwaga_o_transporcie(
+            f"BŁĄD (strict): {d.get('sygnatura') or d['doc_id']} — {_opis_braku_oznaczenia(d)} "
+            "— tryb strict nie potwierdza aktualności takiej treści; bez --strict dostaniesz tekst "
+            f"z adnotacją. Sprawdź w przeglądarce: {d['url']}"))
+
+
+def _opis_braku_oznaczenia(d):
+    if d.get("prawomocnosc") == "":
+        return ("CBOSA nie podaje prawomocności tego orzeczenia (pole przy dacie orzeczenia jest "
+                "puste — tak bywa przy postanowieniach wpadkowych i świeżych orzeczeniach)")
+    return ("na stronie CBOSA nie znaleziono oznaczenia „orzeczenie prawomocne / nieprawomocne” "
+            "(zmiana układu strony?)")
+
+
+def _fetch(path, data=None):
+    """GET/POST strony CBOSA (HTML). Throttling >=0,5 s; ponowienia z rosnącym odstępem.
+    Zwraca pobrany HTML jako FOUND; UNKNOWN przekazuje przez VerificationUnknown.
+    VERIFIED_ABSENT ustala dopiero parser _wyniki z poprawnej strony CBOSA.
+
+    CBOSA miewa kilkunastosekundowe okna, w których ucina połączenia bez odpowiedzi — stąd
+    łącznie ~26 s ponawiania (za krótkie okno ponowień = fałszywy raport „skill nie działa").
+    CBOSA może serwować łańcuch certyfikatów, którego część systemów nie potrafi zweryfikować.
+    Domyślnie taki błąd daje UNKNOWN. Dopiero CBOSA_INSECURE_TLS=1 pozwala ponowić żądanie bez
+    weryfikacji; wynik jawnie niesie wtedy stan nieuwierzytelnionego transportu."""
+    global _transport_tls_verified
+    url = BASE + path
+    body = urllib.parse.urlencode(data).encode("utf-8") if data is not None else None
+    headers = {
+        "User-Agent": f"Mozilla/5.0 (compatible; prawo-pl-cbosa/{__version__}; "
+                      f"+https://github.com/jamarpl21/prawo-pl-eli)",
+        "Accept-Language": "pl-PL,pl;q=0.9",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    # Kontekst jest lokalny dla jednego pobrania. Jawny opt-in nie zatruwa kolejnych
+    # wywołań _fetch w tym samym procesie ustawieniem CERT_NONE.
+    ssl_ctx = ssl.create_default_context()
+    insecure_tls = False
+    # odstęp przed kolejną próbą; None = ostatnia zwykła próba (dalej już błąd)
+    for odstep in (2, 4, 8, 12, None):
+        # Wewnętrzna pętla gwarantuje jedną realną, natychmiastową próbę po zmianie
+        # kontekstu, nawet jeśli błąd certyfikatu wystąpił w ostatnim obiegu pętli zewnętrznej.
+        while True:
+            czekaj = 0.5 - (time.time() - _ostatnie[0])
+            if czekaj > 0:
+                time.sleep(czekaj)
+            _ostatnie[0] = time.time()
+            opener = urllib.request.build_opener(
+                _PrzekierowaniaHttps(),
+                urllib.request.HTTPSHandler(context=ssl_ctx),
+                urllib.request.HTTPCookieProcessor(_jar))
+            req = urllib.request.Request(url, data=body, headers=headers)
+            if insecure_tls:
+                _transport_tls_verified = False
+            try:
+                with opener.open(req, timeout=40) as r:
+                    return r.read().decode("utf-8", "replace")
+            except urllib.error.HTTPError as e:
+                if e.code >= 500 and odstep is not None:
+                    time.sleep(odstep)
+                    break
+                if e.code in (404, 410) and path.startswith("/doc/"):
+                    # CBOSA odpowiada 410 (Gone) dla nieistniejącego doc_id — zweryfikowany brak,
+                    # a nie awaria; "spróbuj ponownie" odsyłałoby użytkownika w nieskończoną pętlę
+                    sys.exit(_z_uwaga_o_transporcie(
+                        f"Nie znaleziono orzeczenia o id {path[len('/doc/'):]!r} w CBOSA "
+                        f"(HTTP {e.code} — zweryfikowany brak). doc_id bierz z komendy "
+                        "szukaj albo sygnatura."))
+                dopisek = "; CBOSA ma codzienne krótkie okno serwisowe ok. 21:00" if e.code >= 500 else ""
+                raise VerificationUnknown(f"HTTP {e.code}: {url}{dopisek}") from e
+            except urllib.error.URLError as e:
+                if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
+                    # Domyślnie odmawiamy; obniżenie wymaga jawnej decyzji operatora.
+                    if os.environ.get("CBOSA_INSECURE_TLS") != "1":
+                        raise VerificationUnknown(
+                            f"błąd weryfikacji certyfikatu TLS: {url} ({e.reason}). "
+                            "Treść z niezweryfikowanego połączenia nie nadaje się do cytowania. "
+                            "Jeśli świadomie akceptujesz to ryzyko (np. znany problem po stronie "
+                            "serwera), ustaw CBOSA_INSECURE_TLS=1 dla tego wywołania."
+                        ) from e
+                    if not insecure_tls:
+                        print("UWAGA: CBOSA_INSECURE_TLS=1 — weryfikacja certyfikatu WYŁĄCZONA dla "
+                              f"{url}. Treść pobrana tym połączeniem NIE jest uwierzytelniona i nie "
+                              "powinna być cytowana bez sprawdzenia w innym źródle.", file=sys.stderr)
+                        ssl_ctx = ssl.create_default_context()
+                        ssl_ctx.check_hostname, ssl_ctx.verify_mode = False, ssl.CERT_NONE
+                        insecure_tls = True
+                        continue
+                if odstep is not None:
+                    time.sleep(odstep)
+                    break
+                raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
+            except Exception as e:  # noqa: BLE001
+                if odstep is not None:
+                    time.sleep(odstep)
+                    break
+                raise VerificationUnknown(f"błąd sieci: {url} ({e}); serwer CBOSA ucina połączenia") from e
+    raise VerificationUnknown(f"nie udało się pobrać {url} po kilku próbach")
+
+
+# ── Parsowanie HTML (regexy zweryfikowane na żywych stronach CBOSA) ─────────────────────
+def _flat(h):
+    return re.sub(r"[\r\n\t]", " ", h)
+
+
+def _text(fragment):
+    """Fragment HTML → czysty tekst (akapity <P>/<BR> → nowe linie, encje, NBSP)."""
+    t = re.sub(r"(?i)<(?:p|br|div|tr|li)\b[^>]*>", "\n", fragment)
+    t = re.sub(r"<[^>]+>", " ", t)
+    t = html_mod.unescape(t).replace("\xa0", " ")
+    t = re.sub(r"[ \t]+", " ", t)
+    t = re.sub(r" *\n *", "\n", t)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return t.strip()
+
+
+# Granica zdania: akapit albo .!?;: + odstęp + wielka litera/cudzysłów/nawias. Kropka po skrócie
+# („art.", „ust.", „2018 r.", „Dz.U.") ani po pojedynczej literze nie kończy zdania.
+_GRANICA = re.compile(r"\n+|[.!?;:]\s+(?=[A-ZĄĆĘŁŃÓŚŹŻ„\"(])")
+_SKROTY = {"art", "ust", "pkt", "lit", "poz", "nr", "np", "tj", "tzw", "tzn", "ww", "zw", "sygn",
+           "str", "por", "zob", "wg", "itd", "itp", "ok", "ds", "m.in", "dz.u", "dz", "proc",
+           "zd", "red", "wyd"}
+
+
+def _granice_zdan(txt, a, b):
+    """Pozycje (koniec granicy) początków zdań/akapitów w txt[a:b]."""
+    out = []
+    for m in _GRANICA.finditer(txt, a, b):
+        if m.group(0)[0] in ".!?":
+            przed = re.search(r"(\S+)$", txt[a:m.start()])
+            tok = przed.group(1).lower().strip("„\"()[]") if przed else ""
+            if (tok in _SKROTY or len(tok) <= 1) and "\n" not in m.group(0):
+                continue
+        out.append(m.end())
+    return out
+
+
+def _dopasuj_brzegi(txt, start, end, min_start, max_end, luz=150):
+    """Przesuwa brzegi okna do granicy zdania (w zapasie `luz` znaków), a gdy jej nie ma — do
+    granicy wyrazu. Okno nigdy nie kurczy się poza [min_start, max_end] (pozycje frazy), więc
+    fraza zostaje w środku. Bez żadnej granicy (ciągły ciąg znaków) brzeg zostaje jak był."""
+    if start > 0:
+        limit = min(start + luz, min_start)
+        zdania = _granice_zdan(txt, start, limit)
+        if zdania:
+            start = zdania[0]
+        else:
+            m = re.compile(r"\s+").search(txt, start, limit)
+            if m:
+                start = m.end()
+    if end < len(txt):
+        limit = max(end - luz, max_end)
+        zdania = _granice_zdan(txt, limit, end)
+        if zdania:
+            end = zdania[-1]
+        else:
+            spacje = [m.start() for m in re.finditer(r"\s", txt[limit:end])]
+            if spacje:
+                end = limit + spacje[-1]
+    return start, end
+
+
+def _fragmenty(txt, fraza, maks=6, okno=600):
+    """Okna tekstu wokół wystąpień frazy (bez rozróżniania wielkości liter) — jak w saos.py.
+    Brzegi okien dopasowane do granic zdań/wyrazów (_dopasuj_brzegi), żeby wycinek nie zaczynał
+    się ani nie kończył w środku słowa (audyt: „kupno i sprz", „aluty tradycyjne")."""
+    low, f = txt.lower(), fraza.lower().strip()
+    if not f:
+        return []
+    spans, p = [], low.find(f)  # (start, end, pierwsza_fraza, koniec_ostatniej_frazy)
+    while p != -1 and len(spans) < maks:
+        start = max(0, p - okno // 3)
+        end = min(len(txt), p + len(f) + okno)
+        if spans and start <= spans[-1][1]:
+            s0, e0, p0, _ = spans[-1]
+            spans[-1] = (s0, max(e0, end), p0, p + len(f))
+        else:
+            spans.append((start, end, p, p + len(f)))
+        p = low.find(f, p + len(f))
+    return [_dopasuj_brzegi(txt, s, e, p0, p1) for s, e, p0, p1 in spans]
+
+
+def _prawomocnosc(flat):
+    """Oznaczenie prawomocności ze strony /doc/{id} → (bool|None, tekst etykiety|None).
+    CBOSA wstawia je w komórce „Data orzeczenia" jako zagnieżdżoną tabelę:
+      <td>2018-06-06</td><td style="… font-style: italic;">orzeczenie nieprawomocne</td>
+    — ogólny parser metadanych (_orzeczenie) czyta tylko datę, stąd osobny odczyt tej komórki.
+    Wynik (bool|None, etykieta): etykieta = tekst oznaczenia; "" = komórka kursywy jest, ale PUSTA
+    (&nbsp; — CBOSA nie podaje prawomocności, zweryfikowane na żywo np. dla postanowienia
+    o wstrzymaniu wykonania z 2026-08); None = komórki nie znaleziono (zmiana układu strony?).
+    Nie zgadujemy: brak oznaczenia to „nie wiadomo", nie „prawomocne"."""
+    m = re.search(r'Data orzeczenia</td>.*?<td[^>]*class="info-list-value"[^>]*>(.*?)</tr>\s*</table>',
+                  flat, re.S)
+    komorka = m.group(1) if m else ""
+    if not komorka:  # awaryjnie: etykieta gdziekolwiek na stronie (poza treścią uzasadnienia)
+        tresc = flat.find('class="info-list-value-uzasadnienie"')
+        komorka = flat[:tresc] if tresc != -1 else flat
+    m = re.search(r"orzeczenie\s+(nie)?prawomocne", komorka, re.I)
+    if m:
+        return (m.group(1) is None), re.sub(r"\s+", " ", m.group(0)).lower()
+    kursywa = re.search(r'<td[^>]*font-style:\s*italic[^>]*>(.*?)</td>', komorka, re.S)
+    if kursywa and not _text(kursywa.group(1)).strip():
+        return None, ""  # pole prawomocności istnieje, ale CBOSA zostawiła je puste
+    return None, None
+
+
+def _wyniki(strona_html):
+    """Lista wyników wyszukiwarki → (liczba trafień, [pozycje], komunikat CBOSA). Pozycja:
+    doc_id, opis, snippet, powiazane (True = link z sekcji „orzeczenia powiązane", nie
+    samodzielne trafienie).
+
+    Komunikaty formularza CBOSA siedzą w <div class="warning"> i NIE są błędem serwera:
+    „Nie znaleziono orzeczeń…" to ZWERYFIKOWANE zero (total=0 — inaczej każde puste
+    wyszukiwanie wyglądałoby jak awaria), „Niepoprawny format daty…" to błąd zapytania."""
+    flat = _flat(strona_html)
+    komunikat = ""
+    m = re.search(r'<div class="warning">(.*?)</div>', flat, re.S)
+    if m:
+        komunikat = re.sub(r"\s+", " ", _text(m.group(1))).strip()
+    total = None
+    m = re.search(r"Znaleziono\s+([\d\s\xa0]+)\s+orzecze", flat)
+    if m:
+        total = int(re.sub(r"[\s\xa0]", "", m.group(1)))
+    elif _ascii(komunikat).startswith("nie znaleziono orzecze"):
+        total = 0
+    pozycje = []
+    for m in re.finditer(r'<a href="/doc/([A-F0-9]{6,})"[^>]*>(.*?)</a>', flat, re.I):
+        opis = re.sub(r"\s+", " ", html_mod.unescape(re.sub(r"<[^>]+>", " ", m.group(2)))).strip()
+        if not opis:  # ikonki „wszystkie orzeczenia powiązane" itp.
+            continue
+        przed = flat[:m.start()]
+        powiazane = przed.rfind('class="powiazane"') > przed.rfind("font-size: 12pt")
+        snippet = ""
+        if not powiazane:
+            za = flat[m.end():m.end() + 4000]
+            nast = re.search(r'<a href="/doc/', za)
+            za = za[:nast.start()] if nast else za
+            sm = re.search(r'<td class="info-list-value[^"]*"[^>]*font-size: 10pt[^>]*>(.*?)</td>', za, re.S)
+            if sm:
+                snippet = re.sub(r"\s+", " ", _text(sm.group(1))).strip()
+        pozycje.append({"doc_id": m.group(1), "opis": opis, "snippet": snippet, "powiazane": powiazane})
+    if total is None and not pozycje and not komunikat:
+        raise VerificationUnknown("CBOSA zwróciło stronę bez licznika i listy wyników")
+    return total, pozycje, komunikat
+
+
+def _orzeczenie(strona_html, doc_id):
+    """Strona /doc/{id} → dict: tytuł, sygnatura, metadane (tabela), sentencja/tezy/uzasadnienie."""
+    flat = _flat(strona_html)
+    d = {"doc_id": doc_id, "url": f"{BASE}/doc/{doc_id}"}
+    m = re.search(r"<TITLE>([^<]+)</TITLE>", flat, re.I)
+    if m:
+        d["tytul"] = html_mod.unescape(m.group(1)).strip()
+        if " - " in d["tytul"]:
+            d["sygnatura"] = d["tytul"].split(" - ")[0].strip()
+    meta, powiazane = {}, []
+    for m in re.finditer(r'class="info-list-label"[^>]*>(.*?)</td>\s*<td[^>]*class="info-list-value"[^>]*>(.*?)</td>',
+                         flat, re.S):
+        lab = re.sub(r"\s+", " ", _text(m.group(1))).strip()
+        if not lab:
+            continue
+        meta[lab] = _text(m.group(2))
+        if "powiązane" in lab.lower():
+            powiazane = [{"doc_id": pm.group(1), "opis": re.sub(r"\s+", " ", _text(pm.group(2))).strip()}
+                         for pm in re.finditer(r'<a href="/doc/([A-F0-9]{6,})"[^>]*>(.*?)</a>', m.group(2), re.I)]
+    d["metadane"] = meta
+    if powiazane:
+        d["powiazane"] = powiazane
+    if meta:
+        # oznaczenie CBOSA „orzeczenie prawomocne / nieprawomocne" (komórka „Data orzeczenia")
+        d["prawomocne"], d["prawomocnosc"] = _prawomocnosc(flat)
+    for sekcja in ("Tezy", "Sentencja", "Uzasadnienie"):
+        m = re.search(r'<div class="lista-label">\s*' + sekcja +
+                      r'\s*</div>\s*<span class="info-list-value-uzasadnienie">(.*?)</span>', flat, re.S)
+        if m:
+            d[sekcja.lower()] = _text(m.group(1))
+    return d
+
+
+def _etykieta_prawomocnosci(d):
+    if d.get("prawomocne") is True:
+        return "prawomocne (oznaczenie CBOSA „orzeczenie prawomocne”)"
+    if d.get("prawomocne") is False:
+        return "NIEPRAWOMOCNE (oznaczenie CBOSA „orzeczenie nieprawomocne”) — zob. UWAGA wyżej"
+    if d.get("prawomocnosc") == "":
+        return "nieznana — CBOSA nie podaje (puste pole prawomocności) — zob. UWAGA wyżej"
+    return "nieznana — brak oznaczenia „orzeczenie prawomocne / nieprawomocne” na stronie — zob. UWAGA wyżej"
+
+
+def _uwaga_o_prawomocnosci(d):
+    """Głośne ostrzeżenie do wyniku tekstowego i JSON, gdy CBOSA oznacza orzeczenie jako
+    NIEPRAWOMOCNE (mogło zostać uchylone/zmienione w NSA) albo oznaczenia brak."""
+    if d.get("prawomocne") is True:
+        return ""
+    kto = d.get("sygnatura") or d["doc_id"]
+    if d.get("prawomocne") is False:
+        pow_ = d.get("powiazane") or []
+        if pow_:
+            dokad = ("sprawdź orzeczenie powiązane (WSA ↔ NSA, pole „Sygn. powiązane”) i jego "
+                     "„Treść wyniku”: " + "; ".join(f"{p['opis']} → orzeczenie {p['doc_id']}"
+                                                    for p in pow_))
+        else:
+            dokad = ("CBOSA nie podaje sygnatur powiązanych — sprawdź w CBOSA, czy zapadł wyrok "
+                     "NSA ze skargi kasacyjnej w tej sprawie (szukaj --sygnatura / sygnatura)")
+        return (f"UWAGA: {kto} jest oznaczone w CBOSA jako ORZECZENIE NIEPRAWOMOCNE — mogło zostać "
+                f"uchylone lub zmienione w wyższej instancji i nie musi już obowiązywać. Przed "
+                f"cytowaniem {dokad}. Tryb --strict takiej treści nie zwraca.")
+    return (f"UWAGA: {kto} — {_opis_braku_oznaczenia(d)} — prawomocność NIEPOTWIERDZONA; "
+            f"sprawdź w przeglądarce: {d['url']}. Tryb --strict takiej treści nie zwraca.")
+
+
+# ── Komendy ──────────────────────────────────────────────────────────────────────────────
+DO_OTWARTE = "2099-12-31"  # patrz _formularz: CBOSA nie umie zakresu dat otwartego od góry
+
+
+def _formularz(a):
+    od = _data(getattr(a, "od", None))
+    do = _data(getattr(a, "do", None), koniec=True)
+    # PUŁAPKA CBOSA: samo `odDaty` (bez `doDaty`) daje ZERO wyników — puste `doDaty` jest czytane
+    # jako górna granica sprzed początku zakresu. Odwrotnie (samo `doDaty`) działa poprawnie.
+    if od and not do:
+        do = DO_OTWARTE
+    return {
+        "wszystkieSlowa": getattr(a, "fraza", None) or "",
+        "wystepowanie": "gdziekolwiek",
+        "odmiana": "on",
+        "sygnatura": getattr(a, "sygnatura", None) or "",
+        "sad": _sad(getattr(a, "sad", None)),
+        "rodzaj": _rodzaj(getattr(a, "rodzaj", None)),
+        "symbole": getattr(a, "symbol", None) or "",
+        "odDaty": od,
+        "doDaty": do,
+        "sedziowie": getattr(a, "sedzia", None) or "",
+        "funkcja": "",
+        "submit": "Szukaj",
+    }
+
+
+def _szukaj(form, strona=1):
+    """POST wyszukiwania (strona 1, zakłada sesję) + ew. GET kolejnej strony (/cbo/find?p=N)."""
+    h = _fetch("/cbo/search", data=form)
+    if strona > 1:
+        h = _fetch(f"/cbo/find?p={strona}")
+    return _wyniki(h)
+
+
+def _drukuj_liste(total, pozycje, strona):
+    glowne = [p for p in pozycje if not p["powiazane"]]
+    print(f"Znaleziono: {total if total is not None else '?'}  "
+          f"(strona {strona}, po 10 na stronę)\n")
+    for p in pozycje:
+        if p["powiazane"]:
+            print(f"      ↳ powiązane: [{p['doc_id']}]  {p['opis']}")
+            continue
+        print(f"  [{p['doc_id']}]  {p['opis']}")
+        if p["snippet"]:
+            print(f"    …{p['snippet'][:220].strip()}…")
+    if glowne:
+        print(f"\nPełna treść: orzeczenie <doc_id>  (np. orzeczenie {glowne[0]['doc_id']})")
+    if total and total > strona * 10:
+        print(f"Kolejna strona: --strona {strona + 1}")
+
+
+def cmd_szukaj(a):
+    kryteria = any([a.fraza, a.sygnatura, a.sad, a.rodzaj, a.symbol, a.sedzia, a.od, a.do])
+    if not kryteria:
+        sys.exit("Podaj kryterium: frazę albo --sad / --sygnatura / --rodzaj / --symbol / --sedzia / zakres dat.")
+    strona = max(1, a.strona)
+    total, pozycje, komunikat = _szukaj(_formularz(a), strona)
+    _sprawdz_transport_strict(a)
+    if total is None and not pozycje:
+        if komunikat:  # formularz odrzucił zapytanie (np. zła data) — to błąd wejścia, nie serwera
+            sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}\nPopraw parametry i ponów "
+                     "(daty w formacie RRRR-MM-DD).")
+    if total == 0 or not pozycje:
+        sys.exit(_z_uwaga_o_transporcie(
+            "Brak wyników (zweryfikowane zero). Uwaga: wyszukiwarka CBOSA wymaga dokładnych "
+            "wartości — spróbuj prostszej frazy, bez --sad, albo sprawdź sygnaturę/symbol."))
+    if a.json:
+        print(json.dumps(_dane_z_transportem(
+                         {"total": total, "strona": strona, "komunikat": komunikat,
+                          "wyniki": pozycje}),
+                         ensure_ascii=False, indent=2)); return
+    _drukuj_uwage_o_transporcie()
+    _drukuj_liste(total, pozycje, strona)
+
+
+def cmd_orzeczenie(a):
+    doc_id = a.doc_id.strip().upper()
+    if not re.fullmatch(r"[A-F0-9]{6,}", doc_id):
+        sys.exit(f"Nieprawidłowy doc_id: {a.doc_id!r} (identyfikator ze strony wyników, np. 8889489BE0).")
+    d = _orzeczenie(_fetch(f"/doc/{doc_id}"), doc_id)
+    _sprawdz_transport_strict(a)
+    if not d.get("tytul") and not d.get("metadane"):
+        # strona pobrana, ale nierozpoznana (przebudowa HTML? strona błędu z HTTP 200?) —
+        # UNKNOWN z podpowiedzią; także --json nie może emitować pozornie poprawnego wyniku
+        raise VerificationUnknown(f"nie udało się rozpoznać strony orzeczenia {doc_id} — "
+                                  f"sprawdź w przeglądarce: {d['url']}")
+    d.setdefault("prawomocne", None)
+    d.setdefault("prawomocnosc", None)
+    uwaga = _uwaga_o_prawomocnosci(d)
+    if uwaga:
+        d["uwaga"] = uwaga
+    _sprawdz_prawomocnosc_strict(a, d)  # cała weryfikacja PRZED emisją wyniku (także --json)
+    if a.json:
+        print(json.dumps(_dane_z_transportem(d), ensure_ascii=False, indent=2)); return
+    _drukuj_uwage_o_transporcie()
+    if uwaga:
+        print(uwaga + "\n")
+    print(f"# {d.get('tytul', doc_id)}   [{doc_id}]")
+    for k in ("Data orzeczenia", "Sąd", "Sędziowie", "Symbol z opisem", "Hasła tematyczne",
+              "Skarżony organ", "Treść wyniku", "Powołane przepisy", "Sygn. powiązane"):
+        v = d["metadane"].get(k)
+        if v:
+            v1 = re.sub(r"\s*\n\s*", " | ", v.strip())
+            print(f"  {k}: {v1[:500]}")
+        if k == "Data orzeczenia":
+            print(f"  Prawomocność: {_etykieta_prawomocnosci(d)}")
+    print(f"  Źródło: {d['url']}")
+    for p in d.get("powiazane", []):
+        print(f"  ↳ powiązane: [{p['doc_id']}]  {p['opis']}")
+    if d.get("tezy"):
+        print(f"\n## Tezy\n{d['tezy']}")
+    if d.get("sentencja"):
+        print(f"\n## Sentencja\n{d['sentencja']}")
+    txt = d.get("uzasadnienie") or ""
+    print(f"\n## Uzasadnienie ({len(txt)} znaków)")
+    if not txt:
+        print("(brak opublikowanego uzasadnienia — zob. stronę źródłową wyżej)")
+        return
+    if a.fragment:
+        spans = _fragmenty(txt, a.fragment)
+        if not spans:
+            sys.exit(f"Nie znaleziono frazy {a.fragment!r} w uzasadnieniu ({len(txt)} znaków). Spróbuj inną frazą.")
+        for i, (s, e) in enumerate(spans):
+            if i:
+                print("\n[...]\n")
+            # „…" na brzegu = w tym miejscu okno ucina tekst (brzeg dopasowany do granicy
+            # zdania/wyrazu, więc wycinek nie zaczyna się ani nie kończy w środku słowa)
+            print(("…" if s > 0 else "") + txt[s:e].strip() + (" …" if e < len(txt) else ""))
+        print(f"\n(okna: {len(spans)} — „…” oznacza ucięcie; pominięto resztę; pełna treść: bez --fragment)")
+        return
+    if len(txt) > 40000:
+        print(f"(UWAGA: długie uzasadnienie {len(txt)} znaków — do wycinka użyj --fragment \"<fraza>\")\n")
+    print(txt)
+
+
+def cmd_sygnatura(a):
+    sig = " ".join(a.sygnatura).strip()
+    form = {"wszystkieSlowa": "", "wystepowanie": "gdziekolwiek", "odmiana": "on",
+            "sygnatura": sig, "sad": "dowolny", "rodzaj": "dowolny", "symbole": "",
+            "odDaty": "", "doDaty": "", "sedziowie": "", "funkcja": "", "submit": "Szukaj"}
+    total, pozycje, komunikat = _szukaj(form)
+    _sprawdz_transport_strict(a)
+    if total is None and not pozycje:
+        if komunikat:
+            sys.exit(f"CBOSA odrzuciło zapytanie: {komunikat}")
+    glowne = [p for p in pozycje if not p["powiazane"]]
+    if not glowne:
+        sys.exit(_z_uwaga_o_transporcie(
+            f"Nie znaleziono orzeczenia o sygnaturze {sig!r} w CBOSA.\n"
+            "Sygnatury sądów administracyjnych mają formę np. \"II FSK 2870/18\" (NSA) "
+            "albo \"I SA/Bk 226/18\" (WSA). SN/TK/sądy powszechne/KIO → skill prawo-pl-saos."))
+    if a.json:
+        print(json.dumps(_dane_z_transportem(
+                         {"total": total, "komunikat": komunikat, "wyniki": pozycje}),
+                         ensure_ascii=False, indent=2)); return
+    _drukuj_uwage_o_transporcie()
+    print(f"Sygnatura {sig!r}: dopasowań {total}\n")
+    for p in pozycje:
+        prefiks = "  ↳ powiązane: " if p["powiazane"] else "  "
+        print(f"{prefiks}[{p['doc_id']}]  {p['opis']}")
+    print(f"\nPełna treść: orzeczenie {glowne[0]['doc_id']}")
+
+
+def main():
+    global _transport_tls_verified
+    _transport_tls_verified = True
+    ap = argparse.ArgumentParser(
+        description="CBOSA (read-only, scraping — brak oficjalnego API). "
+                    "Orzecznictwo sądów administracyjnych: NSA + 16 WSA.")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut sparsowanych danych jako JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności "
+                         "(TLS, rozpoznana strona, prawomocność orzeczenia)")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("szukaj")
+    s.add_argument("fraza", nargs="?", default=None)
+    s.add_argument("--sad", help='NSA | "WSA <miasto>" (np. "WSA Warszawa") | pełna nazwa z CBOSA')
+    s.add_argument("--sygnatura", help='sygnatura sprawy, np. "II FSK 2870/18"')
+    s.add_argument("--rodzaj", help="wyrok | postanowienie | uchwala")
+    s.add_argument("--symbol", help="symbol sprawy, np. 6119 (podatki), 6320 (pomoc społeczna)")
+    s.add_argument("--sedzia", help="nazwisko sędziego")
+    s.add_argument("--od", help="data orzeczenia od (RRRR-MM-DD)")
+    s.add_argument("--do", help="data orzeczenia do (RRRR-MM-DD)")
+    s.add_argument("--strona", type=int, default=1, help="numer strony wyników (od 1, po 10 wyników)")
+    s.set_defaults(func=cmd_szukaj)
+
+    o = sub.add_parser("orzeczenie")
+    o.add_argument("doc_id", help="identyfikator ze strony wyników, np. 8889489BE0")
+    o.add_argument("--fragment", help='wytnij okna wokół frazy w uzasadnieniu (np. "interpretacja")')
+    o.set_defaults(func=cmd_orzeczenie)
+
+    sy = sub.add_parser("sygnatura")
+    sy.add_argument("sygnatura", nargs="+")
+    sy.set_defaults(func=cmd_sygnatura)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut sparsowanych danych jako JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować aktualności lub kompletności "
+                         "(TLS, rozpoznana strona, prawomocność orzeczenia)")
+
+    a = ap.parse_args()
+    try:
+        a.func(a)
+    except VerificationUnknown as e:
+        sys.exit(f"BŁĄD: nie udało się zweryfikować danych w CBOSA ({e}). "
+                 "Spróbuj ponownie za chwilę.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/prawo-pl-rejestr-umow/.claude-plugin/plugin.json
+++ b/plugins/prawo-pl-rejestr-umow/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-pl-rejestr-umow",
+  "description": "Umowy jednostek sektora finansów publicznych z publicznego API Centralnego Rejestru Umów (rejestrumow.gov.pl, jawny rejestr od 1.07.2026): zamawiający (JSFP), wykonawca, przedmiot, wartość, okres, aneksy, wyłączenia jawności. Wyszukiwanie po przedmiocie umowy, nazwie/REGON/NIP stron, województwie, dacie i wartości; pełne szczegóły umowy po idUmowy. Read-only, bez klucza. Podstawa prawna (art. 34a–34b u.f.p.): prawo-pl-eli; orzecznictwo o jawności umów: prawo-pl-cbosa/prawo-pl-saos.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-pl-rejestr-umow/.codex-plugin/plugin.json
+++ b/plugins/prawo-pl-rejestr-umow/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prawo-pl-rejestr-umow",
+  "version": "2.0.0",
+  "description": "Umowy jednostek sektora finansów publicznych z publicznego API Centralnego Rejestru Umów (rejestrumow.gov.pl, od 1.07.2026): zamawiający, wykonawca, przedmiot, wartość, aneksy, wyłączenia jawności. Wyszukiwanie po przedmiocie, stronach (nazwa/REGON/NIP), województwie, dacie i wartości. Read-only, bez klucza.",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": ["prawo", "polish-law", "rejestr-umow", "umowy", "jsfp", "finanse-publiczne", "transparency", "public-spending", "legal"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo PL — Centralny Rejestr Umów (JSFP)",
+    "shortDescription": "Umowy jednostek sektora finansów publicznych z publicznego API rejestru.",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/SKILL.md
+++ b/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: prawo-pl-rejestr-umow
+version: 2.0.0
+description: >-
+  Odpytuje publiczne API Centralnego Rejestru Umów JSFP (rejestrumow.gov.pl) — jawny
+  rejestr umów zawieranych od 1.07.2026 przez jednostki sektora finansów publicznych:
+  urzędy, gminy, szpitale, uczelnie, sądy. Używaj przy pytaniach „jakie umowy zawarł
+  urząd/gmina/szpital X", „z kim i na ile ma umowę…", „kto dostał zlecenie od…", „ile
+  jednostka płaci za…", przy due diligence kontrahenta z sektora publicznego, analizie
+  wydatków publicznych i kontroli obywatelskiej. Wyszukiwanie po przedmiocie umowy,
+  nazwie/REGON/NIP zamawiającego i wykonawcy, województwie, dacie i wartości; pełne
+  szczegóły umowy (strony z adresami, aneksy, wyłączenia jawności). Read-only, bez
+  klucza. Podstawa prawna (art. 34a–34b ustawy o finansach publicznych) → prawo-pl-eli;
+  ogłoszenia o zamówieniach publicznych (BZP/TED) poza zakresem. Public contracts
+  register of Polish public finance sector entities (JSFP) from its official API.
+---
+
+# Umowy jednostek sektora finansów publicznych z Centralnego Rejestru Umów
+
+Skill do **jawnego rejestru umów sektora publicznego**. Sięga do publicznego API
+**Centralnego Rejestru Umów JSFP** (`https://rejestrumow.gov.pl`, uruchomionego
+1.07.2026 na podstawie art. 34a ustawy o finansach publicznych): umowy zawierane przez
+jednostki sektora finansów publicznych — urzędy, gminy, powiaty, szpitale, uczelnie,
+sądy, instytucje kultury — z pełnymi danymi stron (nazwa, NIP/REGON, adres), przedmiotem,
+wartością, okresem obowiązywania i zmianami (aneksy, rozwiązania, wyłączenia jawności).
+Używaj go, gdy pytanie dotyczy tego, **z kim i na co jednostka publiczna zawarła umowę**.
+
+## Podział ról (który skill do czego)
+
+1. **Umowy JSFP (kto, z kim, na co, za ile) → ten skill.** Zamawiający i wykonawcy,
+   kwoty, aneksy, wyłączenia jawności.
+2. **Treść przepisów → prawo-pl-eli** (ustawa o finansach publicznych — art. 34a–34b,
+   Prawo zamówień publicznych, u.d.i.p.).
+3. **Orzecznictwo** o jawności umów / dostępie do informacji publicznej →
+   **prawo-pl-cbosa** (sądy administracyjne), **prawo-pl-saos** (SN, sądy powszechne).
+4. **Delegując research subagentowi**, wpisz: „umowy JSFP pobieraj przez
+   `scripts/rejestrumow.py` (skill prawo-pl-rejestr-umow); treść przepisów przez
+   `scripts/eli.py` (prawo-pl-eli)".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/rejestrumow.py` (tylko biblioteka standardowa Pythona — bez
+instalacji). Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/rejestrumow.py`)
+— NIE zakładaj, że to `~/.claude/skills/prawo-pl-rejestr-umow` (skill zainstalowany jako plugin
+leży w katalogu pluginów; w Claude Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-rejestr-umow`).
+Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+REJ="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$REJ" ] || REJ="<katalog skilla>/scripts/rejestrumow.py"
+[ -f "$REJ" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $REJ" >&2; exit 1; }
+python3 "$REJ" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/rejestrumow.py` oznacza `python3 "$REJ"`, jeśli nie
+jesteś w katalogu skilla.)
+
+### Komendy
+
+- **najnowsze** — ostatnio opublikowane umowy:
+  `python3 scripts/rejestrumow.py najnowsze --limit 10`
+- **szukaj** — wyszukiwarka umów (filtry można łączyć dowolnie):
+  `python3 scripts/rejestrumow.py szukaj "remont drogi" --woj dolnośląskie --sort priceDesc`
+  `python3 scripts/rejestrumow.py szukaj --jsfp "urząd gminy" --od 2026-07-01 --wartosc-od 100000`
+  `python3 scripts/rejestrumow.py szukaj --wykonawca "NAZWA SPÓŁKI"` (albo `--wykonawca-nip`)
+  `python3 scripts/rejestrumow.py szukaj --regon 000001301 --rola dowolna` (podmiot po dowolnej stronie)
+  `python3 scripts/rejestrumow.py szukaj --zmiana-rodzaj TSU02 --zmiana-od 2026-08-01` (umowy z aneksem)
+  Fraza szuka w **przedmiocie umowy**. **Rola podmiotu jest rozłączna** (zweryfikowane:
+  Uniwersytet Wrocławski = 455 umów jako zamawiający + 17 jako wykonawca = 472 „dowolnie"):
+  `--jsfp/--regon/--nip` = TYLKO zamawiający (JSFP), `--wykonawca/--wykonawca-nip/
+  --wykonawca-regon` = TYLKO druga strona (także gdy jest nią inna JSFP), `--rola dowolna`
+  = podmiot z `--jsfp/--regon/--nip` po którejkolwiek stronie (`--rola wykonawca` = to samo
+  co `--wykonawca*`). Pytanie „ile umów ZAWARŁA jednostka X" → domyślna rola; „wszystkie
+  umowy, w których X występuje" → `--rola dowolna`. NIP/REGON podawaj cyframi (kreski silnik
+  usuwa; API porównuje dosłownie). `--woj/--powiat/--gmina/--miejscowosc` = adres
+  zamawiającego. Zmiany umów: `--zmiana-rodzaj KOD` (kod słownika: `TSU02` aneks, `TSU05`
+  rozwiązanie, `TSU06` wypowiedzenie, `TSU07` odstąpienie, `TSU10` wygaśnięcie, `inne`;
+  nazwa zamiast kodu → błąd), `--zmiana-od/--zmiana-do` (data zmiany). Daty `RRRR-MM-DD`
+  (`--od/--do` = zawarcie, `--pub-od/--pub-do` = publikacja), `--status Aktywna|Nieaktywna`
+  (dokładnie tak), `--sort` (m.in. `priceDesc`, `publicationDateDesc`, `executionDateAsc`),
+  `--limit N` (maks. 50 — większy jest obcinany z komunikatem), `--strona N` (od 0; silnik
+  pisze „Kolejna strona" tylko gdy istnieje, „Ostatnia strona", „poza zakresem" albo „poza
+  oknem API"). Zaawansowane: `--zapytanie '<json>'` — surowe body ze wszystkimi sekcjami
+  filtrów (`references/api.md`); **API ignoruje nieznane pola po cichu** — zła nazwa pola =
+  cały rejestr (364 tys. umów) udający wynik; porównuj total z `najnowsze`.
+- **umowa** — pełne szczegóły po idUmowy (UUID z wyników szukania):
+  `python3 scripts/rejestrumow.py umowa 958e7d59-057b-4eb4-8f55-e664638f393a`
+  Pokazuje numer, status, okres, wartość (liczbą; obok ewentualny „opis wartości" — dowolny
+  tekst jednostki, NIE gwarantowana kwota słownie), strony z NIP/REGON i pełnym adresem
+  (ulica, kod, miejscowość, gmina/dzielnica, powiat, województwo), finansowanie ze środków
+  UE/zagranicznych, aneksy i zmiany, wyłączenia jawności (zakres, podstawa, wyłączający).
+- **slownik** — słowniki API: `python3 scripts/rejestrumow.py slownik rodzaje_zmian_umowy`
+  (`kraje`, `strony_umowy`, `rodzaje_zmian_umowy`, `podstawy_wylaczenia_jawnosci`,
+  `zakres_wylaczenia_jawnosci`).
+- każda komenda przyjmuje `--json` oraz `--strict` (blokuje wynik bez zweryfikowanej kompletności); obie flagi działają przed komendą i po niej.
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”).
+
+Typowy przepływ: `szukaj <filtry>` → wybierz idUmowy → `umowa <idUmowy>` → strony,
+kwoty, aneksy do odpowiedzi.
+
+## Zasady (ważne — dlaczego)
+
+1. **Rejestr obejmuje TYLKO umowy zawarte od 1.07.2026** (start obowiązku z art. 34a
+   u.f.p.). Brak umowy w rejestrze ≠ jej nieistnienie: wcześniejsze umowy, umowy poniżej
+   ustawowego progu wartości i wyłączone ustawowo nie trafiają do rejestru — zaznacz to
+   w odpowiedzi. Aktualny próg i wyłączenia weryfikuj w art. 34a u.f.p. (prawo-pl-eli).
+2. **Dane wpisują kierownicy JSFP ręcznie** — nazwy bywają skracane, z literówkami,
+   a daty przekłamane (system blokuje daty wsteczne, co jednostki obchodzą aneksami —
+   bywa to opisane w komentarzu zmiany). Szukając podmiotu, preferuj **REGON/NIP** nad
+   nazwę; przy nazwie próbuj krótkich rdzeni.
+3. **Zawsze podawaj idUmowy + JSFP + datę zawarcia** przy cytowaniu (np. „umowa
+   NI.2720.53.2026 Dolnośląskiej Służby Dróg i Kolei z 7.07.2026, idUmowy 958e7d59-…") —
+   UUID jest stabilnym identyfikatorem, a link `https://rejestrumow.gov.pl/umowa/<idUmowy>`
+   działa w przeglądarce.
+4. **Okno wyszukiwania to 10 000 wyników** (200 stron po 50) — przy większej liczbie
+   trafień (nagłówek „Pasujących umów" pokazuje realną) ogon zbioru jest NIEOSIĄGALNY
+   żadną stroną: silnik ostrzega, na ostatniej osiągalnej stronie pisze „okno wyczerpane",
+   a `--strona` spoza okna kończy komunikatem „poza oknem API" (exit ≠ 0, także z `--json`).
+   Zawężaj zakresami dat/województwem/wartością; `--strict` blokuje zbiór > 10 000 jako
+   niekompletny. „Brak wyników" znaczy zweryfikowane zero trafień — strona spoza mniejszego
+   zbioru to „poza zakresem (stron: M)", nie zero.
+5. **Wartość może być niejawna albo opisowa** — sprawdzaj w szczegółach pola wyłączenia
+   jawności (podstawę prawną wyłączenia wskazuje jednostka) i „opis wartości" (wolny tekst;
+   bywa kwotą słownie, bywa powtórzeniem przedmiotu, często pusty).
+6. Pełna lista endpointów, sekcji filtrów i pułapek: `references/api.md`.
+
+## Czego ten skill NIE obejmuje
+
+- **ogłoszeń o zamówieniach publicznych** (przetargi, SWZ, oferty → BZP `ezamowienia.gov.pl`
+  / TED — internet); rejestr pokazuje ZAWARTE umowy, nie postępowania,
+- **umów sprzed 1.07.2026** oraz umów podmiotów spoza sektora finansów publicznych
+  (spółki komunalne/Skarbu Państwa nie są JSFP),
+- **treści przepisów** (→ **prawo-pl-eli**) ani **orzecznictwa** o jawności umów
+  (→ **prawo-pl-cbosa**, **prawo-pl-saos**),
+- **treści samych umów** (PDF-ów) — rejestr zawiera metadane, nie skany; o treść
+  wystąp do jednostki w trybie u.d.i.p.
+Jeśli zagadnienie wymaga tych źródeł — powiedz to wprost, nie udawaj, że rejestr je pokryje.
+
+## Przykładowy przepływ
+
+Pytanie: „na co gmina X wydaje ostatnio najwięcej i kto jest wykonawcą?"
+1. `szukaj --jsfp "gmina X" --sort priceDesc --limit 10` → największe umowy ZAWARTE przez
+   gminę jako zamawiającego (jeśli pusto: znajdź REGON gminy i `szukaj --regon <REGON>`;
+   umowy, w których gmina jest wykonawcą dla innej JSFP, pokaże dopiero `--rola dowolna`).
+2. `umowa <idUmowy>` → wykonawca (NIP/REGON, adres), opis wartości, aneksy.
+3. (opcjonalnie) inne umowy tego wykonawcy w całym sektorze:
+   `szukaj --wykonawca-nip <NIP>`; umowy gminy zmienione aneksem: `szukaj --regon <REGON>
+   --zmiana-rodzaj TSU02`.
+4. (opcjonalnie) podstawa prawna jawności: skill prawo-pl-eli
+   (`tekst <u.f.p.> --fragment "art. 34a"`).
+5. W odpowiedzi: JSFP + wykonawca + wartość + data zawarcia + idUmowy; dopisz, że rejestr
+   obejmuje umowy od 1.07.2026 i dane wpisują jednostki.

--- a/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/references/api.md
+++ b/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/references/api.md
@@ -1,0 +1,147 @@
+# API Centralnego Rejestru Umów JSFP — referencja endpointów
+
+Baza: `https://rejestrumow.gov.pl/api-dp/v1`  ·  Frontend: `https://rejestrumow.gov.pl`
+(Angular SPA; endpointy wyciągnięte z bundli JS aplikacji — **brak publicznego
+Swaggera**: `api-dp/v3/api-docs` i `api-dp/swagger-ui` zwracają 401).
+Wszystko **read-only**, bez klucza i bez ciasteczek (serwis stoi za CDN Imperva/Incapsula,
+ale zwykłe żądania z dowolnym User-Agentem przechodzą). Rejestr jest jawny (art. 34a
+ust. 11 u.f.p.); informacje udostępniane są do ponownego wykorzystywania bezpłatnie
+(art. 34b ust. 7 u.f.p.); dane wprowadzają i administrują nimi kierownicy JSFP.
+
+## Endpointy (zweryfikowane na żywo, 2026-07; sekcje filtrów i okno ponownie 2026-08-23)
+
+| Ścieżka | Metoda | Zwraca |
+|---|---|---|
+| `/agreements/search?offset=&limit=&sortKey=` | POST (JSON) | lista umów wg filtrów z body (`{}` = wszystkie) |
+| `/agreement/{idUmowy}` | GET | pełne szczegóły umowy (UUID) |
+| `/dictionary?name={nazwa}` | GET | słownik kodów (uwaga: wariant ścieżkowy `/dictionary/{nazwa}` → 401) |
+
+Odpowiedź wyszukiwania: `content[] totalElements totalMatchingElements offset limit`.
+**`totalElements` jest obcięte do 10 000** (okno wyszukiwania à la Elasticsearch);
+realną liczbę trafień pokazuje `totalMatchingElements` — ale **tylko przy `offset < 10 000`**:
+przy `offset ≥ 10 000` API zwraca pustą listę i ZANIŻA także `totalMatchingElements` do 10 000
+(woj. podlaskie: offset 9950 → 50 wierszy i total 11 076; offset 10 000 → `[]` i total 10 000).
+Pusta lista ma więc trzy znaczenia: prawdziwe zero (`totalMatchingElements` = 0), strona poza
+zbiorem (offset ≥ total) albo strona poza oknem (offset ≥ 10 000 przy total > 10 000) — silnik
+odróżnia je w komunikacie („Brak wyników" / „poza zakresem" / „poza oknem API"). Pełny przegląd
+zbiorów > 10 000 rób wycinkami po `dataPublikacjiOd/Do` lub `dataZawarciaOd/Do` (tryb `--strict`
+blokuje zbiór > 10 000 jako niekompletny). `offset` jest zaokrąglany w dół do wielokrotności
+`limit` (offset 455, limit 50 → strona od 450) — silnik wysyła zawsze `strona × limit`.
+
+## Body wyszukiwania (sekcje → pola)
+
+Sekcje odpowiadają formularzowi UI; wszystkie pola opcjonalne, łączone spójnikiem I (AND).
+**Nieznane sekcje i pola są ignorowane PO CICHU** — literówka w nazwie pola lub sekcji = brak
+filtra, bez błędu: body `{"zmianyUmowie":{"zmianyUmowy":{"rodzajZmiany":"TSU02"}}}` zwraca
+364 470 umów (= cały rejestr, jak `{}`), a poprawne `{"zmianyUmowy":{"rodzajZmiany":"TSU02"}}`
+→ 1 056. **Zanim uznasz wynik za odfiltrowany, porównaj total z totalem `{}` (komenda
+`najnowsze`).** Daty w filtrach: `RRRR-MM-DD` (odpowiedzi zwracają `DD.MM.RRRR`).
+
+**Trzy sekcje stron umowy** (zweryfikowane 2026-08-23 na Uniwersytecie Wrocławskim,
+REGON 000001301 / NIP 8960005408; te same liczby dla `nazwa`, `regon` i `nip`):
+
+| Sekcja | Kogo filtruje | Trafień |
+|---|---|---|
+| `jsfp.nazwa/regon/nip` | **tylko zamawiający** (JSFP) | 455 |
+| `inneStronyUmowy.nazwa/regon/nip` | **tylko druga strona** (wykonawca — także gdy jest nią inna JSFP) | 17 |
+| `menuGlowne.nazwa/regon/nip` | **dowolna strona** (pole „szukaj" z UI) | 472 = 455 + 17 |
+
+`nip`/`regon` porównywane są dosłownie (`896-000-54-08` → 0 trafień) — podawaj same cyfry;
+`nazwa` działa pełnotekstowo, bez rozróżniania wielkości liter.
+
+| Sekcja | Pola |
+|---|---|
+| `menuGlowne` | `nazwa regon nip` (DOWOLNA strona umowy), `przedmiotUmowy`, `statusUmowy`, `wartoscOd wartoscDo`, `dataZawarciaOd/Do`, `dataPublikacjiOd/Do` (NIE ma tu `dataZmianyOd/Do` — to sekcja `zmianyUmowy`) |
+| `jsfp` (zamawiający) | `nazwa regon nip wojewodztwo powiat gmina miejscowosc ulica numerNieruchomosci numerLokalu kodPocztowy` |
+| `inneStronyUmowy` (wykonawca) | `czyKonsorcjum rodzaj` (kod `SU01/SU02/SU03`, nie nazwa) `kraj regon nazwa nip imie nazwisko ulica numerNieruchomosci numerLokalu wojewodztwo powiat gmina miejscowosc kodPocztowy` |
+| `daneUmowy` | `numerUmowy brakNumeruUmowy umowaNaCzasNieoznaczony finansowanaZeSrodkow opisWartosciPrzedmiotu okresLiczbaOd/Do okresJednostka dataZakonczeniaUmowyOd/Do czyWylaczenieJawnosci zakresWylaczenia` (`SC02/SC03/SC04`) `podstawa organLubOsobaWylaczajaca` |
+| `zmianyUmowy` (sekcja NAJWYŻSZEGO poziomu, bez opakowania) | `rodzajZmiany` (KOD słownika, np. `TSU02` → 1 056, `TSU05` → 1 337, `TSU10` → 112 549, `inne` → 19 145; `TSU01` → 0), `dataZmianyOd/Do` (data wpisu zmiany; `2026-09-01` → 0), `czyZmianyDanychUmowy` (bool: `true` = umowa ma JAKĄKOLWIEK zmianę, 133 710; `false` 230 760), `komentarz` (pełnotekstowo) |
+| `inne` | `dataModyfikacjiOd/Do` |
+
+**Zweryfikowane pułapki:**
+- `statusUmowy` przyjmuje **dokładnie** `Aktywna` / `Nieaktywna` (case-sensitive;
+  `AKTYWNA` → błąd 500 „Nieoczekiwany błąd”); `wojewodztwo` — dowolna wielkość liter;
+- `zmianyUmowy.rodzajZmiany` przyjmuje **kod** słownika (`TSU02`, wielkość liter obojętna),
+  nie nazwę („Aneks do umowy” → 0 wyników); `TSU01` (korekta danych) zawsze 0 — korekty nie
+  są publikowane jako zmiany;
+- filtry łączą się spójnikiem I także między sekcjami: `jsfp.regon` + `zmianyUmowy.rodzajZmiany`
+  = umowy tego zamawiającego z aneksem (UWr + `TSU02` → 0 — UWr nie ma aneksów, nie błąd);
+- `przedmiotUmowy` działa pełnotekstowo na przedmiocie umowy (wielowyrazowe frazy OK);
+- `limit` jest obcinany serwerowo do **50**; `sortKey` spoza listy → błąd walidacji
+  (`Invalid sort key value`);
+- nieistniejący `idUmowy` (i nie-UUID) → **HTTP 500**, nie 404 — silnik waliduje UUID
+  przed wysłaniem;
+- nieznane ścieżki API (`/api`, `/api-dp/v1/cokolwiek`) → **200 z HTML-em SPA** — nie
+  traktuj 200 jako sukcesu bez sprawdzenia Content-Type/JSON.
+
+## `sortKey` (pełna lista wartości)
+
+`unitNameAsc/Desc` (nazwa JSFP), `unitVoivodeshipAsc/Desc`, `unitDistrictAsc/Desc`
+(powiat), `unitCommuneAsc/Desc` (gmina), `unitCityAsc/Desc` (miejscowość),
+`modificationDateAsc/Desc`, `lastChangeDateAsc/Desc` (data przyczyny aktualizacji),
+`publicationDateAsc/Desc`, `executionDateAsc/Desc` (zawarcie), `periodAsc/Desc` (okres),
+`priceAsc/Desc` (wartość). Bez `sortKey` sortowanie jest niezdefiniowane (stabilne po id).
+
+## Słowniki (`/dictionary?name=…`)
+
+- `kraje` — kody ISO + nazwy PL,
+- `strony_umowy` — `SU01` Przedsiębiorca, `SU02` Osoba fizyczna, `SU03` JSFP,
+- `rodzaje_zmian_umowy` — `TSU01` Korekta danych, `TSU02` Aneks do umowy, `TSU03` Zmiana
+  w zakresie wyłączenia jawności, `TSU04` Zmiana danych strony, `TSU05` Rozwiązanie,
+  `TSU06` Wypowiedzenie, `TSU07` Odstąpienie, `TSU10` Wygaśnięcie, `TSU11` Cesja, `inne`,
+- `podstawy_wylaczenia_jawnosci`, `zakres_wylaczenia_jawnosci` — `SC02` Dane strony,
+  `SC03` Przedmiot umowy, `SC04` Wartość umowy.
+
+## Kształt danych
+
+**Wiersz wyszukiwania:** `idUmowy` (UUID), `nazwa regon` (JSFP), `dataZawarciaUmowy`,
+`dataZakonczeniaUmowy` (null = czas nieoznaczony LUB brak danych), `wartoscPrzedmiotuUmowy`,
+`przedmiotUmowy`, `statusUmowy`. Wykonawcy NIE ma w wierszu — jest w szczegółach.
+
+**Szczegóły (`/agreement/{id}`):** `idUmowy`, `podstawoweDane{statusUmowy numerUmowy
+brakNumeruUmowy dataZawarciaUmowy dataZakonczeniaUmowy}`, `okresObowiazywania{
+umowaNaCzasNieoznaczony okres}` („154 dni”), `szczegolyUmowy{przedmiotUmowy
+niejawnoscPrzedmiotu wartoscPrzedmiotu niejawnoscWartosciPrzedmiotu
+opisWartosciPrzedmiotu}` (**`opisWartosciPrzedmiotu` to dowolny tekst wpisany przez jednostkę
+— „opis wartości", np. „zakup środków czystości"; BYWA kwotą słownie, często `null`, także
+przy umowach na miliardy — nie traktuj go jak pola kontrolnego kwoty**), `stronyUmowy[{kraj rodzaj nazwa nip
+regon imie nazwisko czyKonsorcjum daneAdresowe{ulica numerNieruchomosci numerLokalu
+wojewodztwo powiat gminaMiastoDzielnica miejscowosc kodPocztowy} niejawnoscStrony}]`
+(`rodzaj` ∈ JSFP | Przedsiębiorca | Osoba fizyczna), `finansowanaZeSrodkow` (bool —
+środki z art. 5 ust. 1 pkt 2–3 u.f.p.), `zmianyUmowy[{rodzajZmiany dataZmiany
+komentarz}]` (w szczegółach `rodzajZmiany` to NAZWA — „Aneks do umowy"; w filtrze — KOD
+`TSU02`), `dataPublikacji`, `dataModyfikacji`. Bloki wyłączenia jawności (`niejawnoscStrony`,
+`niejawnoscPrzedmiotu`, `niejawnoscWartosciPrzedmiotu`) mają kształt `{podstawa zakres
+organLubOsobaWylaczajaca komentarz}` (każde pole może być `null`; przy niejawnej stronie
+`nazwa/nip/regon/daneAdresowe` są puste) — silnik drukuje je jako „zakres: …; podstawa: …;
+wyłączający: …; komentarz: …".
+
+Link do umowy w przeglądarce: `https://rejestrumow.gov.pl/umowa/{idUmowy}`.
+
+## Mapowanie komend `rejestrumow.py` → API
+
+`najnowsze` → `{}` + `sortKey=publicationDateDesc`; `szukaj FRAZA` →
+`menuGlowne.przedmiotUmowy`; `--jsfp/--regon/--nip` → **`jsfp.nazwa/regon/nip`** (tylko
+zamawiający; `--rola dowolna` → `menuGlowne.*` = dowolna strona, `--rola wykonawca` →
+`inneStronyUmowy.*`); `--wykonawca(-nip/-regon)` → `inneStronyUmowy.nazwa/nip/regon`;
+`--woj/--powiat/--gmina/--miejscowosc` → `jsfp.*` (adres zamawiającego — także przy
+`--rola dowolna`); `--od/--do` → `dataZawarciaOd/Do`, `--pub-od/--pub-do` →
+`dataPublikacjiOd/Do`, `--wartosc-od/-do` → `wartoscOd/Do`, `--status` → `statusUmowy`;
+`--zmiana-rodzaj KOD` → `zmianyUmowy.rodzajZmiany`, `--zmiana-od/--zmiana-do` →
+`zmianyUmowy.dataZmianyOd/Do`; `--zapytanie '<json>'` → body przekazane wprost (bez walidacji
+nazw pól — patrz „ignorowane po cichu"); `--limit/--strona` → `limit/offset = strona × limit`
+(limit > 50 → obcięty do 50 z komunikatem na stderr; `--strona` ≥ 10 000/limit → silnik nie
+pyta o tę stronę, pobiera realny total i kończy komunikatem „poza oknem API"); `umowa` →
+`/agreement/{uuid}`; `slownik` → `/dictionary?name=…`.
+
+## Wskazówki
+
+- Rejestr ruszył **1.07.2026** (najstarsza `dataZawarciaUmowy` = 01.07.2026) i rośnie
+  o kilkanaście tysięcy umów dziennie — wyniki szybko się dezaktualizują, podawaj datę
+  sprawdzenia.
+- Dane wpisują jednostki (kierownicy JSFP są ich administratorami) — jakość nierówna:
+  skróty nazw, literówki, daty obchodzone aneksami („system uniemożliwił wprowadzenie
+  daty wstecznej” w komentarzach zmian). Do identyfikacji podmiotów używaj NIP/REGON.
+- Bądź uprzejmy dla serwera: ≤2 zapytania/s (limitów nie udokumentowano).
+- Osobny portal `jsfp.rejestrumow.gov.pl` służy jednostkom do wprowadzania danych
+  (wymaga logowania — poza zakresem skilla).

--- a/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py
+++ b/plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do publicznego API Centralnego Rejestru Umów JSFP (https://rejestrumow.gov.pl).
+Tylko biblioteka standardowa Pythona (urllib/json/re) — brak zależności pip.
+Operacje WYŁĄCZNIE read-only, bez klucza i bez autoryzacji (rejestr jest jawny —
+art. 34a ust. 11 ustawy o finansach publicznych; ponowne wykorzystywanie bezpłatne —
+art. 34b ust. 7).
+
+Rejestr (od 1.07.2026) zawiera umowy zawierane przez jednostki sektora finansów
+publicznych (JSFP): zamawiający, wykonawca (przedsiębiorca / osoba fizyczna / inna JSFP),
+przedmiot, wartość, okres, zmiany umowy (aneksy, rozwiązania), wyłączenia jawności.
+Identyfikator umowy: UUID (idUmowy). Treść przepisów bierz z ELI (skill prawo-pl-eli);
+ogłoszenia o zamówieniach publicznych są w BZP/TED (poza tym skillem).
+
+Komendy:
+  najnowsze [--limit N]                          ostatnio opublikowane umowy
+  szukaj ["<fraza przedmiotu>"] [--jsfp N] [--regon R] [--nip N] [--rola zamawiajacy|wykonawca|dowolna]
+         [--wykonawca W] [--wykonawca-nip N] [--wykonawca-regon R]
+         [--woj W] [--status Aktywna|Nieaktywna] [--od RRRR-MM-DD] [--do RRRR-MM-DD]
+         [--wartosc-od N] [--wartosc-do N] [--zmiana-rodzaj KOD] [--zmiana-od D] [--zmiana-do D]
+         [--sort KLUCZ] [--limit N] [--strona N]
+  umowa <idUmowy>                                pełne szczegóły umowy (strony, adresy, zmiany)
+  slownik <nazwa>                                słownik API (kraje, strony_umowy, …)
+Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (blokuje wynik, gdy nie udało się zweryfikować jego kompletności)
+
+Sekcje body wyszukiwania (API ignoruje nieznane pola PO CICHU — zła nazwa = cały rejestr):
+  jsfp.*            zamawiający (JSFP): nazwa/regon/nip/adres      ← --jsfp/--regon/--nip/--woj…
+  inneStronyUmowy.* druga strona (wykonawca): nazwa/regon/nip      ← --wykonawca*
+  menuGlowne.*      nazwa/regon/nip DOWOLNEJ strony + przedmiot, status, daty, wartość
+  zmianyUmowy.*     rodzajZmiany (kod TSU02…), dataZmianyOd/Do, czyZmianyDanychUmowy
+"""
+import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+BASE = "https://rejestrumow.gov.pl/api-dp/v1"
+
+SORTY = ["unitNameAsc", "unitNameDesc", "unitVoivodeshipAsc", "unitVoivodeshipDesc",
+         "unitDistrictAsc", "unitDistrictDesc", "unitCommuneAsc", "unitCommuneDesc",
+         "unitCityAsc", "unitCityDesc", "modificationDateAsc", "modificationDateDesc",
+         "lastChangeDateAsc", "lastChangeDateDesc", "publicationDateAsc", "publicationDateDesc",
+         "executionDateAsc", "executionDateDesc", "periodAsc", "periodDesc",
+         "priceAsc", "priceDesc"]
+SLOWNIKI = ["kraje", "strony_umowy", "rodzaje_zmian_umowy",
+            "podstawy_wylaczenia_jawnosci", "zakres_wylaczenia_jawnosci"]
+OKNO = 10000  # API przegląda maks. 10 000 wyników na zapytanie (zawężaj filtrami dat)
+LIMIT_API = 50  # serwer tnie stronę do 50 niezależnie od żądanego limitu
+ROLE = ["zamawiajacy", "wykonawca", "dowolna"]  # --rola: w której sekcji szukać --jsfp/--regon/--nip
+KOD_ZMIANY = re.compile(r"TSU\d{2}|inne", re.I)  # kody słownika rodzaje_zmian_umowy
+ZAWEZ = "zawęź filtry (daty: --od/--do, --pub-od/--pub-do; --woj; --wartosc-od/--wartosc-do)"
+
+
+def _req(path, params=None, body=None):
+    """GET (body=None) albo POST JSON, z jednym ponowieniem na błąd przejściowy."""
+    url = BASE + path
+    if params:
+        q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "")})
+        if q:
+            url += "?" + q
+    dane = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=dane, headers={
+        "User-Agent": f"prawo-pl-rejestr-umow/{__version__} (+https://github.com/jamarpl21/prawo-pl-eli)",
+        "Accept": "application/json",
+        **({"Content-Type": "application/json"} if dane is not None else {})})
+    for attempt in (1, 2):
+        try:
+            with urllib.request.urlopen(req, timeout=40) as r:
+                tresc = r.read().decode("utf-8", "replace")
+            break
+        except urllib.error.HTTPError as e:
+            szcz = ""
+            try:
+                blad = json.loads(e.read().decode("utf-8", "replace"))
+                szcz = "; ".join(f"{k}: {v}" for k, v in (blad.get("details") or {}).items()) \
+                       or blad.get("message", "")
+            except Exception:  # noqa: BLE001
+                pass
+            if e.code >= 500 and "/agreement/" in path:
+                sys.exit(f"BŁĄD HTTP {e.code}: {url}\n"
+                         "Zwykle oznacza nieistniejące idUmowy — podaj UUID z wyników komendy "
+                         "'szukaj' (np. 0002c775-2526-484f-9b93-5a60e2b934c4).")
+            if e.code >= 500 and attempt == 1:
+                time.sleep(2); continue
+            if e.code in (401, 403):
+                sys.exit(f"BŁĄD HTTP {e.code}: {url}\n"
+                         "API rejestru zaczęło wymagać autoryzacji na tym endpointcie — sprawdź "
+                         "https://rejestrumow.gov.pl (dotąd działało bez klucza)."
+                         + (f"\nSzczegóły: {szcz}" if szcz else ""))
+            sys.exit(f"BŁĄD HTTP {e.code}: {url}" + (f"\nSzczegóły: {szcz}" if szcz else ""))
+        except Exception as e:  # noqa: BLE001
+            if attempt == 1:
+                time.sleep(2); continue
+            sys.exit(f"BŁĄD sieci: {url} ({e})")
+    try:
+        return json.loads(tresc)
+    except json.JSONDecodeError:
+        sys.exit(f"BŁĄD: API rejestru zwróciło nie-JSON dla {url} (nieznana ścieżka zwraca "
+                 "stronę HTML aplikacji) — sprawdź endpoint / spróbuj ponownie.")
+
+
+def _uuid_ok(s):
+    """idUmowy to UUID (małe/wielkie litery hex)."""
+    return bool(re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+                             r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", s or ""))
+
+
+def _data(s):
+    """Walidacja daty filtra: API przyjmuje RRRR-MM-DD (odpowiedzi zwracają DD.MM.RRRR)."""
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", s or ""):
+        sys.exit(f"Zła data {s!r} — format RRRR-MM-DD (np. 2026-07-01).")
+    return s
+
+
+def _liczba(s):
+    """'1 000 000,50' / '1000000.50' → float (kwoty w PLN)."""
+    try:
+        return float(str(s).replace(" ", "").replace(" ", "").replace(",", "."))
+    except ValueError:
+        sys.exit(f"Zła kwota {s!r} — podaj liczbę, np. 50000 albo 49999,99.")
+
+
+def _kwota(v):
+    """5015 → '5 015,00 zł' (separator tysięcy = spacja, przecinek dziesiętny)."""
+    if v is None:
+        return "—"
+    try:
+        return f"{float(v):,.2f}".replace(",", " ").replace(".", ",") + " zł"
+    except (TypeError, ValueError):
+        return str(v)
+
+
+def _pelne(d):
+    return {k: v for k, v in d.items() if v not in (None, "")}
+
+
+def _ident(s):
+    """NIP/REGON: API porównuje dosłownie ('896-000-54-08' → 0 trafień) — zostawiamy same cyfry."""
+    return re.sub(r"[\s-]", "", s) if s else s
+
+
+def _kod_zmiany(k):
+    """Kod słownika rodzaje_zmian_umowy (TSU02, TSU05, inne…) — nazwa ('Aneks do umowy') daje 0."""
+    if not KOD_ZMIANY.fullmatch(k or ""):
+        sys.exit(f"--zmiana-rodzaj {k!r}: podaj KOD słownika (np. TSU02 = aneks, TSU05 = rozwiązanie, "
+                 "TSU10 = wygaśnięcie, inne), nie nazwę — lista: komenda 'slownik rodzaje_zmian_umowy'.")
+    return "inne" if k.lower() == "inne" else k.upper()
+
+
+def _filtry(a):
+    """Argumenty CLI → body zapytania POST /agreements/search (sekcje wg formularza UI).
+    Nieznane sekcje/pola API ignoruje po cichu — trzymaj się nazw z references/api.md.
+    Sekcje stron (zweryfikowane na REGON 000001301): jsfp.* = tylko zamawiający (455),
+    inneStronyUmowy.* = tylko druga strona (17), menuGlowne.* = dowolna strona (472 = 455 + 17)."""
+    menu = _pelne({
+        "przedmiotUmowy": a.fraza,
+        "statusUmowy": a.status,
+        "dataZawarciaOd": _data(a.od) if a.od else None,
+        "dataZawarciaDo": _data(a.do) if a.do else None,
+        "dataPublikacjiOd": _data(a.pub_od) if a.pub_od else None,
+        "dataPublikacjiDo": _data(a.pub_do) if a.pub_do else None,
+        "wartoscOd": _liczba(a.wartosc_od) if a.wartosc_od is not None else None,
+        "wartoscDo": _liczba(a.wartosc_do) if a.wartosc_do is not None else None,
+    })
+    podmiot = _pelne({"nazwa": a.jsfp, "regon": _ident(a.regon), "nip": _ident(a.nip)})
+    jsfp = _pelne({"wojewodztwo": a.woj, "powiat": a.powiat,
+                   "gmina": a.gmina, "miejscowosc": a.miejscowosc})
+    wykonawca = _pelne({"nazwa": a.wykonawca, "nip": _ident(a.wykonawca_nip),
+                        "regon": _ident(a.wykonawca_regon)})
+    rola = getattr(a, "rola", None) or "zamawiajacy"
+    if rola == "dowolna":
+        menu.update(podmiot)          # menuGlowne.* = obie strony umowy
+    elif rola == "wykonawca":
+        if wykonawca and podmiot:
+            sys.exit("--rola wykonawca kieruje --jsfp/--regon/--nip do sekcji drugiej strony — "
+                     "nie łącz tego z --wykonawca/--wykonawca-nip/--wykonawca-regon (jedna para).")
+        wykonawca.update(podmiot)
+    else:
+        jsfp.update(podmiot)          # domyślnie: tylko zamawiający (JSFP)
+    zmiany = _pelne({
+        "rodzajZmiany": _kod_zmiany(a.zmiana_rodzaj) if getattr(a, "zmiana_rodzaj", None) else None,
+        "dataZmianyOd": _data(a.zmiana_od) if getattr(a, "zmiana_od", None) else None,
+        "dataZmianyDo": _data(a.zmiana_do) if getattr(a, "zmiana_do", None) else None,
+    })
+    body = {}
+    if menu:
+        body["menuGlowne"] = menu
+    if jsfp:
+        body["jsfp"] = jsfp
+    if wykonawca:
+        body["inneStronyUmowy"] = wykonawca
+    if zmiany:
+        body["zmianyUmowy"] = zmiany
+    return body
+
+
+def _limit(n, glosno=False):
+    """API twardo tnie stronę do 50 — obcinamy JAWNIE, żeby nagłówek i numeracja stron nie kłamały
+    (przy --limit 100 silnik pobierał 50, a pisał „po 100"). glosno=True → komunikat na stderr
+    (stdout zostaje czysty także przy --json)."""
+    if glosno and n > LIMIT_API:
+        print(f"UWAGA: --limit {n} obcięty do {LIMIT_API} (maksimum API); kolejne wyniki: --strona N.",
+              file=sys.stderr)
+    return max(1, min(n, LIMIT_API))
+
+
+def _szukaj(body, limit=10, strona=0, sort=None):
+    """POST /agreements/search?offset&limit&sortKey — lista umów (limit obcinany do 50)."""
+    limit = _limit(limit)
+    return _req("/agreements/search",
+                {"offset": max(0, strona) * limit, "limit": limit, "sortKey": sort}, body)
+
+
+def _wiersz(it):
+    print(f"  [{it.get('idUmowy', '?')}]")
+    print(f"    JSFP: {it.get('nazwa', '?')} (REGON {it.get('regon', '?')})")
+    print(f"    zawarta {it.get('dataZawarciaUmowy') or '?'}, "
+          f"koniec {it.get('dataZakonczeniaUmowy') or '—'}, "
+          f"status: {it.get('statusUmowy') or '?'}, "
+          f"wartość: {_kwota(it.get('wartoscPrzedmiotuUmowy'))}")
+    przedmiot = re.sub(r"\s+", " ", it.get("przedmiotUmowy") or "").strip()
+    if przedmiot:
+        print(f"    {przedmiot[:300]}{'…' if len(przedmiot) > 300 else ''}")
+    print(f"    → umowa {it.get('idUmowy', '?')}")
+    print()
+
+
+def _sprawdz_okno_strict(a, d):
+    """Strict: zbiór trafień większy niż okno API jest NIEKOMPLETNY (części wyników nie da się
+    obejrzeć żadną stroną) — nie zwracamy go jako pełnego, tylko każemy zawęzić filtry."""
+    ile = d.get("totalMatchingElements") if isinstance(d, dict) else None
+    if getattr(a, "strict", False) and isinstance(ile, int) and ile > OKNO:
+        sys.exit(f"BŁĄD: {ile} pasujących umów, a API przegląda maks. {OKNO} na zapytanie — tryb strict "
+                 "nie zwróci niekompletnego zbioru. Zawęź filtrami: --od/--do, --pub-od/--pub-do, "
+                 "--woj, --wartosc-od (albo uruchom bez --strict, świadomie biorąc tylko okno).")
+
+
+def _stron(ile, limit):
+    """Liczba stron osiągalnych przez API (okno 10 000 ucina ogon większych zbiorów)."""
+    return -(-min(ile, OKNO) // limit) if ile else 0
+
+
+def _brak_wynikow():
+    sys.exit("Brak wyników. Fraza szuka w PRZEDMIOCIE umowy; nazwy JSFP wpisują jednostki "
+             "(bywają skróty/literówki) — spróbuj krótszej frazy, --regon/--nip albo --wykonawca; "
+             "--jsfp/--regon/--nip szukają tylko ZAMAWIAJĄCEGO (podmiot jako wykonawca: --wykonawca*, "
+             "w dowolnej roli: --rola dowolna).\n"
+             "Pamiętaj: rejestr obejmuje umowy zawarte od 1.07.2026.")
+
+
+def _sprawdz_strone(d, limit, strona):
+    """Pusta strona ≠ zero trafień: odróżniamy prawdziwe zero, stronę poza zbiorem i stronę
+    poza oknem API (offset ≥ 10 000, gdzie API zwraca pustą listę i ZANIŻA total do 10 000)."""
+    tresc = d.get("content") or []
+    ile = d.get("totalMatchingElements")
+    if not isinstance(ile, int):
+        ile = len(tresc)
+    if tresc:
+        return ile
+    if ile == 0:
+        _brak_wynikow()
+    stron = _stron(ile, limit)
+    if strona * limit >= OKNO and ile > strona * limit:
+        sys.exit(f"Strona {strona} poza oknem API: okno {OKNO} wyników wyczerpane (pasujących umów: {ile}, "
+                 f"osiągalne strony 0–{stron - 1} po {limit}) — {ZAWEZ}.")
+    if strona * limit >= ile:
+        sys.exit(f"Strona {strona} poza zakresem (stron: {stron}, numeracja od 0 — ostatnia to "
+                 f"--strona {stron - 1}; pasujących umów: {ile}).")
+    sys.exit(f"BŁĄD: API zwróciło pustą stronę {strona} mimo {ile} pasujących umów — spróbuj ponownie.")
+
+
+def _lista(d, limit, strona):
+    ile = _sprawdz_strone(d, limit, strona)
+    tresc = d.get("content") or []
+    print(f"Pasujących umów: {ile}  (strona {strona}, po {limit})\n")
+    for it in tresc:
+        _wiersz(it)
+    nastepny = (strona + 1) * limit
+    if ile > OKNO:
+        print(f"UWAGA: API przegląda maks. {OKNO} wyników na zapytanie — {ZAWEZ}.")
+    if nastepny < min(ile, OKNO):
+        print(f"Kolejna strona: --strona {strona + 1}")
+    elif nastepny >= OKNO and ile > nastepny:
+        print(f"Okno {OKNO} wyników wyczerpane — {ZAWEZ}.")
+    else:
+        print(f"Ostatnia strona (stron: {_stron(ile, limit)}).")
+
+
+def cmd_najnowsze(a):
+    a.limit = _limit(a.limit, glosno=True)
+    d = _szukaj({}, a.limit, sort="publicationDateDesc")
+    if not isinstance(d, dict):
+        sys.exit("BŁĄD: API rejestru zwróciło nieoczekiwaną odpowiedź (lista umów).")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Ostatnio opublikowane w Centralnym Rejestrze Umów "
+          f"(wszystkich umów: {d.get('totalMatchingElements', '?')}):\n")
+    for it in d.get("content") or []:
+        _wiersz(it)
+
+
+def cmd_szukaj(a):
+    if a.zapytanie:
+        try:
+            body = json.loads(a.zapytanie)
+        except json.JSONDecodeError as e:
+            sys.exit(f"--zapytanie: niepoprawny JSON ({e}).")
+    else:
+        body = _filtry(a)
+    if not body:
+        sys.exit("Podaj kryterium: frazę przedmiotu umowy, --jsfp/--regon/--nip, --wykonawca, "
+                 "--woj, --status, zakres dat/wartości albo --zapytanie '<json>'.\n"
+                 "Pełną listę bez filtra daje komenda 'najnowsze'.")
+    a.limit = _limit(a.limit, glosno=True)
+    if a.strona < 0:
+        sys.exit("--strona: numer strony od 0.")
+    if a.strona * a.limit >= OKNO:
+        # offset ≥ 10 000: API zwraca pustą listę i ZANIŻA totalMatchingElements do 10 000 —
+        # realną liczbę trafień bierzemy z pierwszej strony (limit 1), żeby komunikat nie kłamał
+        d = _szukaj(body, 1, 0, a.sort)
+        if isinstance(d, dict):
+            d["content"] = []
+    else:
+        d = _szukaj(body, a.limit, a.strona, a.sort)
+    if not isinstance(d, dict):
+        sys.exit("BŁĄD: API rejestru zwróciło nieoczekiwaną odpowiedź (wyniki wyszukiwania).")
+    _sprawdz_okno_strict(a, d)
+    _sprawdz_strone(d, a.limit, a.strona)  # zero / poza zakresem / poza oknem → komunikat + exit ≠ 0, także z --json
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    _lista(d, a.limit, a.strona)
+
+
+def _strona_umowy(i, s):
+    kto = s.get("nazwa") or " ".join(x for x in (s.get("imie"), s.get("nazwisko")) if x) \
+        or ("(dane strony niejawne)" if s.get("niejawnoscStrony") else "?")
+    idn = "  ".join(f"{k} {v}" for k, v in (("NIP", s.get("nip")), ("REGON", s.get("regon"))) if v)
+    print(f"  {i}. [{s.get('rodzaj') or '?'}] {kto}{' (konsorcjum)' if s.get('czyKonsorcjum') else ''}"
+          + (f"   {idn}" if idn else ""))
+    adr = s.get("daneAdresowe") or {}
+    ulica = " ".join(x for x in (adr.get("ulica"), adr.get("numerNieruchomosci")) if x)
+    if ulica and adr.get("numerLokalu"):
+        ulica += f"/{adr['numerLokalu']}"
+    czesci = [ulica, " ".join(x for x in (adr.get("kodPocztowy"), adr.get("miejscowosc")) if x),
+              f"gmina/dzielnica {adr['gminaMiastoDzielnica']}" if adr.get("gminaMiastoDzielnica") else "",
+              f"powiat {adr['powiat']}" if adr.get("powiat") else "",
+              f"woj. {adr['wojewodztwo'].lower()}" if adr.get("wojewodztwo") else "",
+              s.get("kraj") if s.get("kraj") not in (None, "Polska") else ""]
+    linia = ", ".join(c for c in czesci if c)
+    if linia:
+        print(f"     {linia}")
+    if s.get("niejawnoscStrony"):
+        print(f"     WYŁĄCZENIE JAWNOŚCI strony: {_niejawnosc(s['niejawnoscStrony'])}")
+
+
+def _niejawnosc(n):
+    """Blok wyłączenia jawności {podstawa zakres organLubOsobaWylaczajaca komentarz} → jedna linia
+    (pola puste pomijane; nigdy surowy dict / None)."""
+    if not isinstance(n, dict):
+        return str(n)
+    pola = (("zakres", "zakres"), ("podstawa", "podstawa"),
+            ("organLubOsobaWylaczajaca", "wyłączający"), ("komentarz", "komentarz"))
+    czesci = [f"{opis}: {n[k]}" for k, opis in pola if n.get(k) not in (None, "")]
+    inne = [f"{k}: {v}" for k, v in n.items() if k not in dict(pola) and v not in (None, "")]
+    return "; ".join(czesci + inne) or "(bez szczegółów)"
+
+
+def _zmiana(z):
+    if not isinstance(z, dict):
+        print(f"  - {z}"); return
+    rodzaj = z.get("rodzajZmiany") or z.get("rodzaj") or "zmiana"
+    data = z.get("dataZmiany") or z.get("data") or "?"
+    print(f"  - {rodzaj} ({data})")
+    if z.get("komentarz"):
+        print(f"    {z['komentarz']}")
+    reszta = {k: v for k, v in z.items() if v not in (None, "", [])
+              and k not in ("rodzajZmiany", "rodzaj", "dataZmiany", "data", "komentarz")}
+    if reszta:
+        print(f"    {json.dumps(reszta, ensure_ascii=False)}")
+
+
+def cmd_umowa(a):
+    if not _uuid_ok(a.id):
+        sys.exit(f"idUmowy {a.id!r} nie wygląda na UUID — podaj identyfikator z wyników "
+                 "komendy 'szukaj' (np. 0002c775-2526-484f-9b93-5a60e2b934c4).")
+    d = _req(f"/agreement/{a.id.lower()}")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    pd = d.get("podstawoweDane") or {}
+    okres = d.get("okresObowiazywania") or {}
+    szcz = d.get("szczegolyUmowy") or {}
+    numer = "bez numeru" if pd.get("brakNumeruUmowy") else (pd.get("numerUmowy") or "?")
+    print(f"# Umowa {numer}   [{d.get('idUmowy', a.id)}]")
+    print(f"  Status:      {pd.get('statusUmowy', '?')}")
+    koniec = "na czas nieoznaczony" if okres.get("umowaNaCzasNieoznaczony") \
+        else (pd.get("dataZakonczeniaUmowy") or "—")
+    print(f"  Obowiązuje:  zawarta {pd.get('dataZawarciaUmowy') or '?'} → {koniec}"
+          + (f"   (okres: {okres['okres']})" if okres.get("okres") else ""))
+    print(f"  Wartość:     {_kwota(szcz.get('wartoscPrzedmiotu'))}"
+          + (f"   ({szcz['opisWartosciPrzedmiotu']})" if szcz.get("opisWartosciPrzedmiotu") else ""))
+    print(f"  Publikacja:  {d.get('dataPublikacji') or '?'}   "
+          f"ostatnia modyfikacja: {d.get('dataModyfikacji') or '—'}")
+    if d.get("finansowanaZeSrodkow") is not None:
+        print(f"  Środki z art. 5 ust. 1 pkt 2–3 u.f.p. (UE/zagraniczne): "
+              f"{'tak' if d['finansowanaZeSrodkow'] else 'nie'}")
+    print(f"  Rejestr:     https://rejestrumow.gov.pl/umowa/{d.get('idUmowy', a.id)}")
+    przedmiot = (szcz.get("przedmiotUmowy") or "").strip()
+    print(f"\n## Przedmiot umowy\n{przedmiot or '(brak / wyłączenie jawności)'}")
+    for pole, opis in (("niejawnoscPrzedmiotu", "przedmiotu"), ("niejawnoscWartosciPrzedmiotu", "wartości")):
+        if szcz.get(pole):
+            print(f"WYŁĄCZENIE JAWNOŚCI {opis}: {_niejawnosc(szcz[pole])}")
+    strony = d.get("stronyUmowy") or []
+    print(f"\n## Strony umowy ({len(strony)})")
+    for i, s in enumerate(strony, 1):
+        _strona_umowy(i, s)
+    zmiany = d.get("zmianyUmowy") or []
+    if zmiany:
+        print(f"\n## Zmiany umowy ({len(zmiany)})")
+        for z in zmiany:
+            _zmiana(z)
+
+
+def cmd_slownik(a):
+    d = _req("/dictionary", {"name": a.nazwa})
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    if not isinstance(d, list) or not d:
+        sys.exit(f"Pusty/nieznany słownik {a.nazwa!r}. Znane: {', '.join(SLOWNIKI)}.")
+    print(f"Słownik {a.nazwa!r} ({len(d)}):")
+    for it in d:
+        print(f"  {it.get('code', '?'):<8} {it.get('name', '?')}")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Publiczne API Centralnego Rejestru Umów JSFP (read-only, bez klucza): "
+                    "umowy jednostek sektora finansów publicznych zawierane od 1.07.2026.")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="zakończ błędem, gdy nie udało się zweryfikować kompletności wyniku")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    n = sub.add_parser("najnowsze")
+    n.add_argument("--limit", type=int, default=10, help="ile wyników (1–50)")
+    n.set_defaults(func=cmd_najnowsze)
+
+    s = sub.add_parser("szukaj")
+    s.add_argument("fraza", nargs="?", default=None,
+                   help="fraza z PRZEDMIOTU umowy (np. 'remont drogi')")
+    s.add_argument("--jsfp", help="nazwa JSFP-zamawiającego, np. 'urząd gminy' (sekcja jsfp)")
+    s.add_argument("--regon", help="REGON JSFP-zamawiającego")
+    s.add_argument("--nip", help="NIP JSFP-zamawiającego")
+    s.add_argument("--rola", choices=ROLE, default="zamawiajacy",
+                   help="w jakiej roli szukać podmiotu z --jsfp/--regon/--nip: zamawiajacy (domyślnie, "
+                        "sekcja jsfp), wykonawca (sekcja inneStronyUmowy), dowolna (menuGlowne — obie strony)")
+    s.add_argument("--wykonawca", help="nazwa drugiej strony umowy (wykonawcy)")
+    s.add_argument("--wykonawca-nip", help="NIP wykonawcy")
+    s.add_argument("--wykonawca-regon", help="REGON wykonawcy")
+    s.add_argument("--woj", help="województwo JSFP (np. mazowieckie)")
+    s.add_argument("--powiat", help="powiat JSFP")
+    s.add_argument("--gmina", help="gmina JSFP")
+    s.add_argument("--miejscowosc", help="miejscowość JSFP")
+    s.add_argument("--status", choices=["Aktywna", "Nieaktywna"],
+                   help="status umowy (dokładnie tak: Aktywna / Nieaktywna)")
+    s.add_argument("--od", help="data zawarcia od (RRRR-MM-DD)")
+    s.add_argument("--do", help="data zawarcia do (RRRR-MM-DD)")
+    s.add_argument("--pub-od", help="data publikacji od (RRRR-MM-DD)")
+    s.add_argument("--pub-do", help="data publikacji do (RRRR-MM-DD)")
+    s.add_argument("--wartosc-od", help="wartość umowy od (PLN)")
+    s.add_argument("--wartosc-do", help="wartość umowy do (PLN)")
+    s.add_argument("--zmiana-rodzaj", help="umowy ze zmianą danego rodzaju — KOD słownika "
+                                           "rodzaje_zmian_umowy (TSU02 aneks, TSU05 rozwiązanie, TSU10 wygaśnięcie…)")
+    s.add_argument("--zmiana-od", help="data zmiany umowy od (RRRR-MM-DD)")
+    s.add_argument("--zmiana-do", help="data zmiany umowy do (RRRR-MM-DD)")
+    s.add_argument("--sort", choices=SORTY, default=None,
+                   help="sortowanie, np. priceDesc, publicationDateDesc, executionDateAsc")
+    s.add_argument("--zapytanie", help="surowe body JSON zapytania (pełny dostęp do wszystkich "
+                                       "sekcji filtrów — zob. references/api.md)")
+    s.add_argument("--limit", type=int, default=10, help="ile wyników (1–50; API obcina do 50)")
+    s.add_argument("--strona", type=int, default=0, help="numer strony (od 0)")
+    s.set_defaults(func=cmd_szukaj)
+
+    u = sub.add_parser("umowa")
+    u.add_argument("id", help="idUmowy (UUID z wyników 'szukaj')")
+    u.set_defaults(func=cmd_umowa)
+
+    sl = sub.add_parser("slownik")
+    sl.add_argument("nazwa", help=f"nazwa słownika: {', '.join(SLOWNIKI)}")
+    sl.set_defaults(func=cmd_slownik)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="zakończ błędem, gdy nie udało się zweryfikować kompletności wyniku")
+
+    a = ap.parse_args()
+    a.func(a)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/prawo-pl-uodo/.claude-plugin/plugin.json
+++ b/plugins/prawo-pl-uodo/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "prawo-pl-uodo",
+  "description": "Decyzje Prezesa UODO z oficjalnego API Portalu Orzeczeń UODO (orzeczenia.uodo.gov.pl): kary pieniężne za naruszenia RODO, upomnienia, nakazy oraz powiązane orzeczenia sądów. Wyszukiwanie pełnotekstowe (regex) i po tytule/dacie; pełna treść decyzji po sygnaturze (np. DKN.5131.9.2025). Read-only, bez klucza. Treść RODO: prawo-eu-eurlex; kontrola sądowa decyzji (WSA/NSA): prawo-pl-cbosa.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT"
+}

--- a/plugins/prawo-pl-uodo/.codex-plugin/plugin.json
+++ b/plugins/prawo-pl-uodo/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "prawo-pl-uodo",
+  "version": "2.0.0",
+  "description": "Decyzje Prezesa UODO z oficjalnego API Portalu Orzeczeń UODO (orzeczenia.uodo.gov.pl): kary za naruszenia RODO, upomnienia, nakazy. Wyszukiwanie pełnotekstowe i po tytule/dacie; pełna treść decyzji po sygnaturze. Read-only, bez klucza.",
+  "author": {
+    "name": "Krzysztof Gibek"
+  },
+  "homepage": "https://github.com/jamarpl21/prawo-pl-eli",
+  "repository": "https://github.com/jamarpl21/prawo-pl-eli",
+  "license": "MIT",
+  "keywords": ["prawo", "polish-law", "rodo", "gdpr", "uodo", "ochrona-danych", "data-protection", "legal"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prawo PL — decyzje UODO (RODO)",
+    "shortDescription": "Decyzje Prezesa UODO z oficjalnego API portalu orzeczeń.",
+    "category": "Productivity"
+  }
+}

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/SKILL.md
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: prawo-pl-uodo
+version: 2.0.0
+description: >-
+  Odpytuje OFICJALNE API Portalu Orzeczeń UODO (orzeczenia.uodo.gov.pl) — decyzje Prezesa
+  Urzędu Ochrony Danych Osobowych: kary pieniężne za naruszenia RODO, upomnienia, nakazy,
+  oraz powiązane orzeczenia sądów. Używaj przy pytaniach o praktykę polskiego organu ochrony
+  danych: „czy UODO karał za…", „decyzja UODO w sprawie…", „jak UODO interpretuje art. X RODO",
+  „jaka kara za brak analizy ryzyka/zgłoszenia naruszenia", przy DPIA, analizie naruszeń
+  ochrony danych, audytach RODO i pismach do UODO. Wyszukiwanie pełnotekstowe i po
+  tytule/dacie decyzji lub publikacji; pełna treść decyzji po sygnaturze (np. DKN.5131.9.2025)
+  wraz z historią kontroli sądowej (uchylona / utrzymana / w toku). Read-only, bez klucza.
+  Treść RODO → skill prawo-eu-eurlex; wyroki WSA/NSA ze skarg na decyzje UODO →
+  prawo-pl-cbosa. Decisions of the Polish DPA (UODO) from its official public API.
+---
+
+# Decyzje Prezesa UODO z oficjalnego API portalu orzeczeń
+
+Skill do **praktyki decyzyjnej polskiego organu ochrony danych** (Prezesa UODO). Sięga do
+oficjalnego API **Portalu Orzeczeń UODO** (`https://orzeczenia.uodo.gov.pl`, uruchomionego
+w 2025 r.): decyzje administracyjne Prezesa UODO — kary pieniężne, upomnienia, nakazy — oraz
+powiązane orzeczenia sądów w tych sprawach. Używaj go, gdy pytanie dotyczy tego, **jak UODO
+stosuje RODO w praktyce**: wysokość kar, przesłanki upomnienia, wymagania wobec analizy ryzyka,
+zgłaszania naruszeń, powierzenia przetwarzania.
+
+## Podział ról (który skill do czego)
+
+1. **Decyzje Prezesa UODO → ten skill.** Kary, upomnienia, nakazy, umorzenia — z pełną treścią.
+2. **Treść RODO → prawo-eu-eurlex** (rozporządzenie 2016/679, CELEX 32016R0679); polska ustawa
+   o ochronie danych osobowych → **prawo-pl-eli** (Dz.U.).
+3. **Wyroki WSA/NSA ze skarg na decyzje UODO → prawo-pl-cbosa.** Portal UODO zna FAKT kontroli
+   sądowej (`decyzja` drukuje blok „Kontrola sądowa": data, uchylona / utrzymana / w toku, sygnatura
+   wyroku), ale NIE ma treści wyroków — zakres uchylenia (cała decyzja czy np. sama kara) czytaj
+   w CBOSA: `prawo-pl-cbosa sygnatura "<sygnatura wyroku>"`. Rekordy wyroków w listach portalu
+   (ok. 200 z 700) są bez treści — silnik nie oferuje dla nich `decyzja`, tylko odsyła do CBOSA.
+4. **Delegując research subagentowi**, wpisz: „decyzje UODO pobieraj przez `scripts/uodo.py`
+   (skill prawo-pl-uodo); treść RODO przez `scripts/eurlex.py` (prawo-eu-eurlex)".
+
+## Narzędzie
+
+Wszystko robi helper `scripts/uodo.py` (tylko biblioteka standardowa Pythona — bez instalacji).
+Skrypt leży **obok tego pliku SKILL.md** (`<katalog skilla>/scripts/uodo.py`) — NIE zakładaj, że to
+`~/.claude/skills/prawo-pl-uodo` (skill zainstalowany jako plugin leży w katalogu pluginów; w Claude
+Code: `${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo`). Uruchamiaj wyłącznie helper z bieżącego pakietu:
+
+```
+# Claude Code: przy ładowaniu skilla podstawia ${CLAUDE_PLUGIN_ROOT} (pełna ścieżka poniżej).
+UODO="${CLAUDE_PLUGIN_ROOT}/skills/prawo-pl-uodo/scripts/uodo.py"
+# Codex / Claude Desktop / instalacja ręczna: katalog TEGO pliku SKILL.md (Claude Code podaje go
+# jako „Base directory for this skill”, Codex w liście skilli) — podstaw go zamiast <katalog skilla>.
+[ -f "$UODO" ] || UODO="<katalog skilla>/scripts/uodo.py"
+[ -f "$UODO" ] || { echo "BŁĄD: brak helpera obok SKILL.md: $UODO" >&2; exit 1; }
+python3 "$UODO" <komenda> [...]
+```
+
+Nie pobieraj helpera z sieci i nie szukaj go przez `find` po katalogach użytkownika ani systemu.
+
+(W przykładach niżej `python3 scripts/uodo.py` oznacza `python3 "$UODO"`, jeśli nie jesteś w katalogu skilla.)
+
+### Komendy
+
+- **najnowsze** — ostatnio WYDANE dokumenty (API sortuje po dacie decyzji/orzeczenia, nie po
+  dacie publikacji w portalu; starsze decyzje dopisane niedawno tu nie trafią):
+  `python3 scripts/uodo.py najnowsze --limit 10`
+- **szukaj** — wyszukiwanie pełnotekstowe / po tytule / po dacie DECYZJI (`--od/--do`) / po dacie
+  PUBLIKACJI w portalu (`--pub-od/--pub-do`):
+  `python3 scripts/uodo.py szukaj "biometr" --limit 5`
+  `python3 scripts/uodo.py szukaj --tytul "pieniężn" --od 2026-01-01`
+  `python3 scripts/uodo.py szukaj --pub-od 2026-01-01 --pub-do 2026-03-31 --limit 100` (co opublikowano w Q1)
+  `--od/--do` filtrują po dacie wydania decyzji (tak działa API) — decyzja z 2025 r. opublikowana
+  w 2026 r. NIE wpadnie w `--od 2026-01-01`; do „co nowego w portalu" służy `--pub-od`. `--pub-od`
+  idzie do API, gdy nie ma innego warunku; z frazą/tytułem filtr publikacji działa tylko w obrębie
+  pobranej strony (silnik to wypisuje) — wtedy zwiększ `--limit` i przeglądaj `--strona`.
+  Fraza działa jak **regex bez rozróżniania wielkości liter**, dopasowuje DOSŁOWNIE — szukaj
+  RDZENIA słowa („biometr" znajdzie „biometryczne/biometrii"). Tytuły to zdania w formie
+  ODMIENIONEJ („nałożenie kary pieniężnej…"), więc mianownik („kara pieniężna") nie trafia
+  w nic — zero wyników z mianownika to NIE dowód, że takich decyzji nie ma.
+  API stosuje **jeden warunek na zapytanie** (fraza ALBO tytuł; zakres dat można łączyć
+  z warunkiem). Zaawansowane: `--warunek
+  "indeks:operator:wartość"` (indeksy i operatory: `references/api.md`). `--limit N`, `--strona N`.
+- **decyzja** — pełna decyzja po sygnaturze albo URN:
+  `python3 scripts/uodo.py decyzja DKN.5131.9.2025`
+  Pokazuje metadane (status, data decyzji i publikacji), **blok „Kontrola sądowa"** (każdy wyrok
+  z meta: data, UCHYLONA / utrzymana / w toku, sygnatura + odsyłacz do prawo-pl-cbosa), przedmiot
+  i pełną treść (z `body.html` portalu: numeracja list i przypisy `[1]` jak na stronie portalu).
+  Decyzja uchylona (także w części, przy statusie `final`) zaczyna się od nagłówka
+  **„DECYZJA UCHYLONA PRZEZ SĄD (w całości lub w części)"** — treść poniżej to tekst PIERWOTNY;
+  zakres uchylenia ustal w sentencji wyroku (CBOSA), zanim zacytujesz karę.
+  Do długich decyzji: `--fragment "pieniężn"` (wycina okna wokół frazy; też podawaj rdzeń).
+  Sygnatura sądowa (`decyzja "III OSK 377/23"`) to rekord bez treści — silnik to wyjaśnia i odsyła do CBOSA.
+- każda komenda przyjmuje `--json` oraz `--strict`; obie flagi działają przed komendą i po niej.
+  **Kontrakt `--strict`:** w `decyzja` kończy błędem (bez wyniku, także z `--json`) decyzję bez pełnej
+  treści ORAZ decyzję z wpisem uchylenia przez sąd (komunikat podaje sygnaturę wyroku i odsyła do
+  CBOSA); decyzja NIEPRAWOMOCNA przechodzi z ostrzeżeniem „UWAGA: decyzja NIEPRAWOMOCNA".
+  W `najnowsze`/`szukaj` `--strict` nic nie zmienia (listy to metadane, nie ma czego weryfikować).
+  Zero trafień / nierozpoznana odpowiedź API kończą się komunikatem i kodem wyjścia ≠ 0 — także z `--json`
+  (nie dostaniesz pustego JSON-a, który wyglądałby jak „sprawdzone, nic nie ma”).
+
+Typowy przepływ: `szukaj "<rdzeń frazy>"` → wybierz sygnaturę → `decyzja <sygnatura>`
+→ jeśli blok „Kontrola sądowa" pokazuje wyrok: `prawo-pl-cbosa sygnatura "<sygnatura wyroku>"`
+(zakres uchylenia / utrzymania); jeśli nie — i tak sprawdź CBOSA (`szukaj "<sygnatura decyzji>"`),
+bo portal nie musi znać każdej skargi.
+
+## Zasady (ważne — dlaczego)
+
+1. **Portal jest młody (od 2025 r.)** — publikowane są nowe decyzje oraz sukcesywnie starsze
+   (sygnatury 2018–2024 pojawiają się z opóźnieniem). Brak decyzji w portalu ≠ jej nieistnienie
+   (silnik to wypisuje przy 404); sprawdź wyszukiwarkę https://uodo.gov.pl (dawne adresy
+   `uodo.gov.pl/decyzje/<sygnatura>` już nie działają) — i zaznacz to w odpowiedzi.
+2. **Status `final` ≠ kara się ostała; `inforce` ≠ w obrocie.** `status` ∈ final (prawomocna wg
+   portalu) / nonfinal (nieprawomocna — dopisz zastrzeżenie; przysługuje skarga do WSA) / repealed
+   (uchylona). Kontrolę sądową portal zapisuje w `dates[]` (uchylona / utrzymana / w toku) i przy
+   statusie `final` może istnieć wpis uchylenia części decyzji (ZSPR.421.3.2018: kara 943 470 zł
+   uchylona przez WSA II SA/Wa 1030/19, status nadal `final`). Pole `inforce` API jest `true` nawet
+   dla decyzji uchylonych — nie cytuj go jako „w obrocie". Zanim podasz karę z decyzji z blokiem
+   „Kontrola sądowa", przeczytaj sentencję wyroku w CBOSA.
+3. **Zawsze podawaj sygnaturę + datę** (np. „decyzja Prezesa UODO z 7.08.2025, DKN.5131.9.2025")
+   — sygnatura jest stabilnym identyfikatorem (URN w API).
+4. **Kwoty kar i stan prawny weryfikuj w treści decyzji**, nie w tytule — tytuł to opis redakcyjny.
+5. Pełna lista endpointów, indeksów i operatorów: `references/api.md`.
+
+## Czego ten skill NIE obejmuje
+
+- **treści RODO i innych przepisów** (RODO → **prawo-eu-eurlex**; polskie ustawy → **prawo-pl-eli**),
+- **wyroków sądów administracyjnych** ze skarg na decyzje UODO (→ **prawo-pl-cbosa**),
+- **orzeczeń SN/TK/sądów powszechnych** (→ **prawo-pl-saos**),
+- decyzji innych organów (UOKiK, KNF), wytycznych EROD (te bierz z edpb.europa.eu — internet).
+Jeśli zagadnienie wymaga tych źródeł — powiedz to wprost, nie udawaj, że portal UODO je pokryje.
+
+## Przykładowy przepływ
+
+Pytanie: „czy UODO nakładał kary za brak zgłoszenia naruszenia ochrony danych i jak je uzasadnia?"
+1. `szukaj "zgłoszen" --tytul "kara"` → jeśli pusto: `szukaj "art. 33"` (jeden warunek na raz).
+2. `decyzja <sygnatura> --fragment "art. 33"` → argumentacja organu wokół obowiązku zgłoszenia.
+3. (opcjonalnie) treść art. 33 RODO: skill prawo-eu-eurlex
+   (`tekst 02016R0679-20160504 --fragment "art. 33"`).
+4. Kontrola sądowa: blok „Kontrola sądowa" z `decyzja` → `prawo-pl-cbosa sygnatura "<wyrok>"`
+   (zakres uchylenia); bez wpisów w bloku — `prawo-pl-cbosa szukaj "<sygnatura decyzji>"`.
+5. W odpowiedzi: sygnatura + data + status (nieprawomocna? uchylona — w jakim zakresie?) + kwota
+   kary z treści decyzji, skorygowana o wynik kontroli sądowej.

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/references/api.md
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/references/api.md
@@ -1,0 +1,113 @@
+# API Portalu Orzeczeń UODO — referencja endpointów
+
+Baza: `https://orzeczenia.uodo.gov.pl/api`  ·  Dokumentacja: `https://orzeczenia.uodo.gov.pl/api-doc/`
+(OpenAPI 3.1: `/api-doc/schemas/openapi.yml`)  ·  Instrukcja portalu: `/manual/`
+Wszystko **GET** (read-only), bez klucza (spec deklaruje basicAuth na wyszukiwaniu, ale endpointy
+działają anonimowo — silnik obsługuje 401/403 czytelnym komunikatem, gdyby to się zmieniło).
+Portal uruchomiony w 2025 r.; publikuje decyzje Prezesa UODO (z treścią) oraz rekordy powiązane —
+orzeczenia sądów, akty prawne, wytyczne EROD — **bez treści** (same metadane; ok. 200 z 700 rekordów indeksu).
+
+## Endpointy (zweryfikowane na żywo, 2026-07)
+
+| Ścieżka | Zwraca |
+|---|---|
+| `/documents/search` | mapa typów dokumentów i ich indeksów wyszukiwawczych |
+| `/documents/search/PublicDocument` | lista dokumentów (najnowsze) |
+| `/documents/search/PublicDocument/{timespan}` | jw., zawężona do zakresu dat **ogłoszenia** (`date_announcement` = data decyzji/orzeczenia) — NIE publikacji |
+| `/documents/search/PublicDocument/{timespan}/{warunek}` | jw., z JEDNYM warunkiem filtrującym |
+| `/documents/events/{id}` | pełne metadane po wewnętrznym `id` |
+| `/documents/public/items/{refid}/meta.json` | **metadane po URN** (refid) |
+| `/documents/public/items/{refid}:0/{content}.{format}` | **treść części 0**: `content` ∈ `meta units body title toc summary dates refs pub`; `format` ∈ `txt json html xml md`; parametry `lang=pl`, `date=RRRR-MM-DD` |
+
+## Parametry wyszukiwania (query string)
+
+`from` (od którego wyniku, domyślnie 0), `count` (ile, domyślnie 100), `order` (`-id` = od
+najnowszych — tak sortuje silnik), `fields` (lista pól przez przecinek, np.
+`id,refid,refname,title,dates,kind`; `*` = pełny obiekt indeksu).
+
+## `{timespan}` i `{warunek}`
+
+- `timespan` = `RRRR-MM-DD,RRRR-MM-DD` po dacie **OGŁOSZENIA** (`dates[].use=announcement` — data
+  wydania decyzji / orzeczenia), NIE po dacie publikacji w portalu (zweryfikowane 2026-08:
+  `2026-07-01,` → 0 wyników, choć w lipcu 2026 opublikowano kilka decyzji wydanych wcześniej); każda
+  strona może być pusta (`,` = wszystko; `2026-01-01,` = od; `,2026-06-30` = do). Skróty: `1M,` `1Y,`.
+  Filtr po dacie publikacji: warunek `date_publication:ge:RRRR-MM-DD` (działa; silnik: `--pub-od`);
+  górną granicę (`--pub-do`) silnik sprawdza po stronie klienta i zawęża `timespan` do niej
+  (ogłoszenie ≤ publikacja).
+- `warunek` = `indeks:operator:wartość`. Operatory: `lt gt le ge eq ne in notin glob notglob regex`.
+- Indeksy `PublicDocument`: `id time mtime kind refid refname status publicator_country
+  publicator_type publicator_subtype publicator_year date_announcement date_publication
+  keywords title_pl content_pl`.
+
+**Zweryfikowane pułapki:**
+- do pełnego tekstu (`content_pl`) używaj **`regex`, nie `glob`** — glob dopasowuje całą wartość
+  i na wielolinijkowej treści zawodzi (`content_pl:glob:*biometri*` → 0; `content_pl:regex:biometr.*` → trafienia);
+- regex działa **bez rozróżniania wielkości liter**;
+- `order=-id` sortuje po `id`, które koduje datę OGŁOSZENIA — „najnowsze" = ostatnio wydane, nie
+  ostatnio opublikowane (starsze decyzje dopisywane do portalu lądują głęboko w liście);
+- **łańcuch warunków** (`/{warunek1}/{warunek2}`) zwraca 200, ale drugi warunek bywa ignorowany —
+  silnik stosuje JEDEN warunek na zapytanie i uprzedza na stderr;
+- `fields=keywords`/`publicator_year` potrafią zwrócić `null` (płaskie nazwy indeksów ≠ ścieżki
+  w meta JSON) — po pełne dane sięgnij po `meta.json` konkretnego dokumentu;
+- eksport CSV istnieje tylko jako przycisk UI — w API go nie ma (silnik: `--json`).
+
+## Identyfikatory
+
+- **Sygnatura** (refname): `DKN.5131.9.2025`, `DKE.561.1.2026`, `ZSOŚS.440.259.2019`.
+- **Rekordy powiązane** (bez treści, `parts: 0`, `publication.status: published`): orzeczenia sądów
+  `urn:ndoc:court:pl:sa:{rok}:{wydział}_{rodzaj}[-{miasto}]_{nr}` (`…:2019:ii_sa-wa_1030` = II SA/Wa 1030/19,
+  `…:2021:iii_osk_3945` = III OSK 3945/21; bywa sufiks `_p`/`_p_RRRRMMDD`, miasto z diakrytykiem `sa-łd`),
+  sądy powszechne `court:pl:sp:…`, TSUE `urn:ndoc:court:eu:tsue:{rok}:c_{nr}`, Dz.U. `urn:ndoc:pro:pl:durp:{rok}:{poz}`,
+  akty UE `urn:ndoc:pro:eu:ojol:…`, EROD `urn:ndoc:gov:eu:edpb:…`. Ich `meta.json` istnieje (HTTP 200),
+  `body.*` → 404. Treść wyroków WSA/NSA: skill prawo-pl-cbosa (`sygnatura "<sygn>"`).
+- **URN** (refid): `urn:ndoc:gov:pl:uodo:{rok}:{sygnatura_bez_roku}` — małe litery,
+  kropki→podkreślenia, polskie znaki transliterowane do ASCII
+  (`DKN.5131.9.2025` → `urn:ndoc:gov:pl:uodo:2025:dkn_5131_9`;
+  `ZSOŚS.440.259.2019` → `…:2019:zsoss_440_259`). Rok = ostatni 4-cyfrowy człon sygnatury.
+- Wewnętrzne `id`: `PublicDocument-RRRRMMDD-000000-000-{32hex}` (data = ogłoszenie).
+
+## Kształt metadanych (`meta.json`)
+
+`type version id time languages name{pl} title{pl} refid refname kind publication{status
+inforce version pubid} publicator{type subtype name country year extids[]} dates[{date use
+type status scope refid text}] parts resources{} entities[] terms`.
+
+- `publication.status` ∈ `final` (prawomocna wg portalu) | `nonfinal` (nieprawomocna) | `repealed`
+  (uchylona — 3 decyzje w indeksie) | `published` (rekordy niebędące decyzjami). Indeks 2026-08:
+  final 420, published 200, nonfinal 77, repealed 3.
+- `publication.inforce` jest `true` TAKŻE dla decyzji uchylonych (ZSPR.421.2.2019: status `repealed`,
+  inforce `true`) — **nie oznacza „w obrocie"**; silnik drukuje je jako „publication.inforce wg API".
+- `dates[].use` ∈ `announcement` (data decyzji / orzeczenia) | `publication` (publikacja w portalu) |
+  `validation` | **`repealed`** (uchylenie przez sąd — w całości lub w części, `refid` wyroku) |
+  **`defended`** (skargę oddalono; `refid` wyroku) | **`trial`** (skarga w toku; `refid` sprawy) |
+  `other` (na rekordach sądowych: „Data wpływu", bez refid).
+- **Kontrola sądowa jest tylko w `dates[]`** — status `final` nie znaczy, że kara się ostała:
+  ZSPR.421.3.2018 ma status `final`, a `dates[]` zawiera `repealed` 2019-12-11 (II SA/Wa 1030/19 —
+  uchylony pkt 2 = kara 943 470 zł) i `defended` 2023-09-19 (III OSK 2538/21 — oddalono skargę kasacyjną
+  od wyroku WSA). Zakres uchylenia wynika wyłącznie z sentencji wyroku (CBOSA). Silnik: blok
+  „Kontrola sądowa", nagłówek „DECYZJA UCHYLONA PRZEZ SĄD", `--strict` blokuje takie decyzje.
+
+## Mapowanie komend `uodo.py` → API
+
+`najnowsze`→`/search/PublicDocument/,` + `order=-id`; `szukaj FRAZA`→warunek
+`content_pl:regex:FRAZA`, `--tytul`→`title_pl:regex:…`, `--warunek`→przekazany wprost,
+`--od/--do`→`{timespan}` (data OGŁOSZENIA), `--pub-od`→warunek `date_publication:ge:…` (gdy nie ma
+innego warunku; inaczej filtr po stronie klienta), `--pub-do`→po stronie klienta + zawężenie `timespan`,
+`--limit/--strona`→`count/from`; `decyzja`→`meta.json` + `meta.json` każdego wyroku z `dates[].refid`
+(sygnatura i sąd) + `body.html` (część `:0`, `lang=pl`; awaryjnie `body.txt`).
+
+## Wskazówki
+
+- Wyniki wyszukiwania zawierają żądane `fields` — tytuł to opis redakcyjny przedmiotu decyzji
+  (bywa bardzo długi; na rekordach sądowych to początek sentencji albo tezy); kwoty kar i podstawy
+  prawne bierz z treści.
+- **Treść: `body.html`, nie `body.txt`.** `body.txt` API gubi numerację list (`a)` → `a`, `2)` → `2`),
+  usuwa odnośniki przypisów `[1]` z tekstu i drukuje każdy przypis DWA razy sklejony. `body.html`
+  (ten sam HTML, który renderuje strona portalu `/document/<urn>/content`) ma numerację, odnośniki
+  `<sup>[1]</sup>` i jeden blok `<div class="glosses">` — silnik parsuje go (stdlib `html.parser`)
+  i tekst jest akapit w akapit zgodny ze stroną portalu (zweryfikowane na DKN.5131.34.2023).
+- Portal publikuje też starsze decyzje z opóźnieniem (od 2025 r.; sygnatury 2018–2024 pojawiają się
+  sukcesywnie) — brak w portalu ≠ decyzja nie istnieje. Dawne strony `uodo.gov.pl/decyzje/<sygnatura>`
+  zwracają HTTP 500 (nie linkuj ich) — szukaj sygnatury w wyszukiwarce https://uodo.gov.pl.
+- Bądź uprzejmy dla serwera: ≤2 zapytania/s (limitów nie udokumentowano).
+- Dane publiczne; przy cytowaniu podawaj sygnaturę i datę decyzji.

--- a/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py
+++ b/plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper do OFICJALNEGO API Portalu Orzeczeń UODO (https://orzeczenia.uodo.gov.pl/api-doc/).
+Tylko biblioteka standardowa Pythona (urllib/json/re/html.parser) — brak zależności pip.
+Operacje WYŁĄCZNIE read-only (GET), bez klucza i bez autoryzacji.
+
+Portal (od 2025 r.) publikuje DECYZJE PREZESA UODO (kary za naruszenia RODO, upomnienia, nakazy)
+oraz rekordy powiązane (orzeczenia sądów, akty prawne) BEZ treści — z samymi metadanymi.
+Identyfikatory: sygnatura (np. DKN.5131.9.2025) i URN (urn:ndoc:gov:pl:uodo:2025:dkn_5131_9).
+Treść RODO bierz z EUR-Lex (skill prawo-eu-eurlex); wyroki WSA/NSA ze skarg na decyzje UODO
+— z CBOSA (prawo-pl-cbosa). Portal zapisuje kontrolę sądową decyzji w meta.json (dates[] z
+use=repealed/defended/trial + refid wyroku) — silnik ją pokazuje, a --strict blokuje decyzje uchylone.
+
+Komendy:
+  najnowsze [--limit N]                          ostatnio WYDANE dokumenty (API sortuje po dacie decyzji)
+  szukaj ["<fraza>"] [--tytul F] [--od RRRR-MM-DD] [--do RRRR-MM-DD] (po dacie DECYZJI = announcement)
+         [--pub-od RRRR-MM-DD] [--pub-do RRRR-MM-DD] (po dacie publikacji w portalu)
+         [--warunek "indeks:operator:wartość"] [--limit N] [--strona N]
+  decyzja <sygnatura|URN> [--fragment "<fraza>"]  metadane + kontrola sądowa + pełna treść decyzji
+Globalnie: --json  (zrzut surowego JSON zamiast podsumowania)
+           --strict  (decyzja: blokuje wynik bez treści albo UCHYLONY przez sąd; na listach nie działa)
+"""
+import sys, json, re, time, argparse, urllib.request, urllib.parse, urllib.error
+from html.parser import HTMLParser
+
+__version__ = "2.0.0"  # trzymaj w zgodzie z plugin.json (sprawdza tools/validate.py)
+BASE = "https://orzeczenia.uodo.gov.pl/api"
+CONTENT_HOSTS = ("orzeczenia.uodo.gov.pl",)
+POLA = "id,refid,refname,title,dates,kind,parts,publication"  # domyślne pola listy wyników
+URN_UODO = "urn:ndoc:gov:pl:uodo:"          # decyzje Prezesa UODO (jedyne rekordy z treścią)
+DATY_PODSTAWOWE = ("announcement", "publication", "validation")
+ZNACZENIE_USE = {                           # dates[].use poza datami podstawowymi = kontrola sądowa
+    "repealed": "UCHYLONA (w całości lub w części)",
+    "defended": "utrzymana (oddalono skargę)",
+    "trial": "w toku (skarga rozpoznawana)",
+    "other": "inne",
+}
+STATUS_PL = {"final": "prawomocna wg portalu", "nonfinal": "NIEPRAWOMOCNA",
+             "repealed": "UCHYLONA", "published": "rekord niebędący decyzją"}
+HEDGE_BRAK = ("UWAGA: brak w portalu ≠ nieistnienie decyzji (portal działa od 2025 r., starsze decyzje "
+              "dodawane sukcesywnie) — sprawdź wyszukiwarkę na https://uodo.gov.pl i zaznacz to w odpowiedzi.")
+
+
+def _wymus_https(url):
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    dozwolony = any(host == allowed or host.endswith("." + allowed)
+                    for allowed in CONTENT_HOSTS)
+    if parsed.scheme.lower() == "http" and dozwolony:
+        return "https" + url[len(parsed.scheme):]
+    return url
+
+
+class _PrzekierowaniaHttps(urllib.request.HTTPRedirectHandler):
+    """Podnosi HTTP na hostach treści UODO, a obce cele HTTP odrzuca."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        bezpieczny_url = _wymus_https(newurl)
+        if urllib.parse.urlsplit(bezpieczny_url).scheme.lower() == "http":
+            raise urllib.error.URLError(
+                f"odrzucono przekierowanie treści na niezaufany host po HTTP: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, bezpieczny_url)
+
+
+_opener = urllib.request.build_opener(_PrzekierowaniaHttps())
+
+
+def _get(path, params=None, raw=False, brak_ok=False):
+    """GET z jednym ponowieniem na błąd przejściowy. raw=True: zwróć tekst (body.txt/html).
+    brak_ok=True: HTTP 404 zwraca None zamiast kończyć program."""
+    url = BASE + path
+    if params:
+        q = urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "", False)})
+        if q:
+            url += "?" + q
+    req = urllib.request.Request(url, headers={
+        "User-Agent": f"prawo-pl-uodo/{__version__} (+https://github.com/jamarpl21/prawo-pl-eli)",
+        "Accept": "text/plain" if raw else "application/json"})
+    for attempt in (1, 2):
+        try:
+            with _opener.open(req, timeout=40) as r:
+                tresc = r.read().decode("utf-8", "replace")
+            break
+        except urllib.error.HTTPError as e:
+            if e.code >= 500 and attempt == 1:
+                time.sleep(2); continue
+            if e.code == 404:
+                if brak_ok:
+                    return None
+                sys.exit(f"BŁĄD HTTP 404 (nie znaleziono): {url}\n"
+                         "Sprawdź sygnaturę/URN — format np. DKN.5131.9.2025 albo "
+                         f"urn:ndoc:gov:pl:uodo:2025:dkn_5131_9.\n{HEDGE_BRAK}")
+            if e.code in (401, 403):
+                sys.exit(f"BŁĄD HTTP {e.code}: {url}\n"
+                         "API UODO zaczęło wymagać autoryzacji na tym endpointcie — sprawdź "
+                         "https://orzeczenia.uodo.gov.pl/api-doc/ (dotąd działało bez klucza).")
+            sys.exit(f"BŁĄD HTTP {e.code}: {url}")
+        except Exception as e:  # noqa: BLE001
+            if attempt == 1:
+                time.sleep(2); continue
+            sys.exit(f"BŁĄD sieci: {url} ({e})")
+    if raw:
+        return tresc
+    try:
+        return json.loads(tresc)
+    except json.JSONDecodeError:
+        sys.exit(f"BŁĄD: API UODO zwróciło nie-JSON dla {url} — spróbuj ponownie za chwilę.")
+
+
+def _get_opcjonalnie(path, params=None, raw=False):
+    """GET danych pomocniczych: każda awaria (404, sieć, 5xx) → None, bez przerywania programu."""
+    try:
+        return _get(path, params, raw=raw, brak_ok=True)
+    except SystemExit:
+        return None
+
+
+def _pl(v):
+    """Pole wielojęzyczne ({'pl': …}) albo zwykły string → tekst."""
+    if isinstance(v, dict):
+        return v.get("pl") or next(iter(v.values()), "")
+    return v or ""
+
+
+def _expect_list(d, what):
+    if not isinstance(d, list):
+        sys.exit(f"BŁĄD: API UODO zwróciło nieoczekiwaną odpowiedź ({what}).")
+    return d
+
+
+def _expect_dict(d, what):
+    if not isinstance(d, dict):
+        sys.exit(f"BŁĄD: API UODO zwróciło nieoczekiwaną odpowiedź ({what}).")
+    return d
+
+
+def _daty(item):
+    """Lista dates[] → {use: data} dla dat podstawowych (announcement = data decyzji,
+    publication = publikacja w portalu, validation). Wpisy sądowe: _kontrola_sadowa()."""
+    out = {}
+    for d in item.get("dates") or []:
+        out[d.get("use", "")] = d.get("date", "")
+    return out
+
+
+def _sygnatura_z_urn(refid):
+    """URN orzeczenia → sygnatura: urn:ndoc:court:pl:sa:2019:ii_sa-wa_1030 → 'II SA/Wa 1030/19',
+    urn:ndoc:court:pl:sa:2021:iii_osk_3945 → 'III OSK 3945/21', TSUE …:c_621 → 'C-621/22'.
+    Gdy nie umiemy odtworzyć — zwraca URN bez zmian."""
+    refid = (refid or "").strip()
+    m = re.fullmatch(r"urn:ndoc:court:pl:(sa|sp):(\d{4}):([^:]+)", refid.lower())
+    if m:
+        rok, reszta = m.group(2), re.sub(r"_p(_\d{8})?$", "", m.group(3))
+        czl = reszta.split("_")
+        if len(czl) >= 3 and czl[-1].isdigit():
+            baza, _, miasto = czl[1].partition("-")
+            baza = {"aca": "ACa", "pa": "Pa", "ca": "Ca"}.get(baza, baza.upper())
+            if miasto:
+                baza += "/" + miasto[:1].upper() + miasto[1:]
+            return f"{czl[0].upper()} {baza} {czl[-1]}/{rok[2:]}"
+    m = re.fullmatch(r"urn:ndoc:court:eu:tsue:(\d{4}):c_(\d+)", refid.lower())
+    if m:
+        return f"C-{m.group(2)}/{m.group(1)[2:]}"
+    return refid
+
+
+def _kontrola_sadowa(item):
+    """Wpisy dates[] o use=repealed/defended/trial/other z refid orzeczenia — historia kontroli
+    sądowej decyzji, którą portal zapisuje w meta.json (a body/status jej nie odzwierciedlają)."""
+    out = []
+    for d in item.get("dates") or []:
+        use = d.get("use", "")
+        refid = d.get("refid") or ""
+        if use in DATY_PODSTAWOWE or (not refid and use not in ("repealed", "defended", "trial")):
+            continue
+        out.append({"date": d.get("date", ""), "use": use,
+                    "znaczenie": ZNACZENIE_USE.get(use, use), "refid": refid,
+                    "sygnatura": _sygnatura_z_urn(refid) if refid else "", "sad": ""})
+    return out
+
+
+def _uchylona(meta, kontrola):
+    """Decyzja uchylona (w całości lub w części): status 'repealed' ALBO jakikolwiek wpis use=repealed
+    — portal zostawia status 'final' przy częściowym uchyleniu (np. samej kary)."""
+    return (meta.get("publication") or {}).get("status") == "repealed" or \
+        any(k["use"] == "repealed" for k in kontrola)
+
+
+def _czy_decyzja(refid):
+    return not refid or refid.lower().startswith(URN_UODO)
+
+
+def _wskazowka_zrodla(refid, refname):
+    """Rekordy powiązane (bez treści w portalu UODO) → gdzie jest ich treść."""
+    r = (refid or "").lower()
+    if r.startswith("urn:ndoc:court:pl:"):
+        return f'(orzeczenie sądu — bez treści w portalu UODO; treść: prawo-pl-cbosa sygnatura "{refname}")'
+    if r.startswith("urn:ndoc:court:eu:tsue:"):
+        return f"(wyrok TSUE — bez treści w portalu UODO; treść: prawo-eu-eurlex, CELEX {refname})"
+    if r.startswith("urn:ndoc:pro:pl:durp:"):
+        return f"(akt prawny — bez treści w portalu UODO; treść: prawo-pl-eli, {refname})"
+    if r.startswith("urn:ndoc:pro:eu:ojol:"):
+        return f"(akt prawa UE — bez treści w portalu UODO; treść: prawo-eu-eurlex, CELEX {refname})"
+    if r.startswith("urn:ndoc:gov:eu:edpb:"):
+        return f"(wytyczne EROD {refname} — bez treści w portalu UODO; źródło: edpb.europa.eu)"
+    return f"(rekord powiązany {refid} — bez treści w portalu UODO)"
+
+
+def _status_opis(status):
+    return f"{status or '?'}" + (f" ({STATUS_PL[status]})" if status in STATUS_PL else "")
+
+
+def _refid(s):
+    """Sygnatura (DKN.5131.9.2025) albo URN → URN. Rok = ostatni 4-cyfrowy człon sygnatury.
+    URN-y portalu są w ASCII — polskie znaki sygnatur transliterujemy (ZSOŚS → zsoss).
+    Sygnatura sądowa (II SA/Wa 1030/19, III OSK 377/23) → URN rekordu powiązanego
+    (urn:ndoc:court:pl:sa:2019:ii_sa-wa_1030) — taki rekord nie ma treści w portalu."""
+    s = s.strip()
+    if s.lower().startswith("urn:"):
+        return s.lower()
+    m = re.fullmatch(r"([IVXLivxl]+)\s+([A-Za-z]+)(?:/([A-Za-zĄ-ż]+))?\s+(\d+)/(\d{2}|\d{4})", s)
+    if m:
+        wydz, rodzaj, miasto, nr, rr = m.groups()
+        rok = rr if len(rr) == 4 else ("20" if int(rr) < 50 else "19") + rr
+        typ = "sa" if rodzaj.lower() in ("sa", "sab", "osk", "oz", "ops", "gsk", "gz", "gps",
+                                         "fsk", "fz", "fps", "nsa") else "sp"
+        czlon = rodzaj.lower() + (f"-{miasto.lower()}" if miasto else "")
+        return f"urn:ndoc:court:pl:{typ}:{rok}:{wydz.lower()}_{czlon}_{nr}"
+    czlony = [c for c in re.split(r"[.\s/]+", s) if c]
+    rok = next((c for c in reversed(czlony) if re.fullmatch(r"(19|20)\d{2}", c)), None)
+    if not rok or len(czlony) < 2:
+        sys.exit(f"Nie umiem zbudować URN z {s!r}. Podaj sygnaturę (np. DKN.5131.9.2025) "
+                 "albo pełny URN (urn:ndoc:gov:pl:uodo:2025:dkn_5131_9).")
+    reszta = "_".join(c.lower().translate(str.maketrans("ąćęłńóśźż", "acelnoszz"))
+                      for c in czlony if c != rok)
+    return f"urn:ndoc:gov:pl:uodo:{rok}:{reszta}"
+
+
+def _timespan(od, do):
+    return f"{od or ''},{do or ''}"
+
+
+def _szukaj(timespan, warunek=None, limit=10, strona=0):
+    """GET /documents/search/PublicDocument/{timespan}[/{warunek}] — lista dokumentów.
+    timespan filtruje po dacie DECYZJI/orzeczenia (announcement), NIE po dacie publikacji."""
+    sciezka = f"/documents/search/PublicDocument/{urllib.parse.quote(timespan, safe=',')}"
+    if warunek:
+        sciezka += "/" + urllib.parse.quote(warunek, safe=":,()")
+    return _get(sciezka, {"order": "-id", "from": max(0, strona) * limit,
+                          "count": max(1, min(limit, 100)), "fields": POLA})
+
+
+def _wiersz(item):
+    refname = item.get("refname") or item.get("refid") or "?"
+    refid = item.get("refid") or ""
+    daty = _daty(item)
+    status = (item.get("publication") or {}).get("status", "")
+    tytul = re.sub(r"\s+", " ", _pl(item.get("title"))).strip()
+    print(f"  [{refname}]  (decyzja/orzeczenie {daty.get('announcement', '?')}, publikacja "
+          f"{daty.get('publication', '—')})  {item.get('kind', '')}  status: {_status_opis(status)}")
+    if tytul:
+        print(f"    {tytul[:400]}{'…' if len(tytul) > 400 else ''}")
+    if _czy_decyzja(refid):
+        kontrola = _kontrola_sadowa(item)
+        if kontrola:
+            print("    kontrola sądowa: " + "; ".join(
+                f"{k['znaczenie']} — {k['sygnatura'] or k['use']} ({k['date']})" for k in kontrola)
+                + " → treść wyroku: prawo-pl-cbosa")
+        print(f"    → decyzja {refname}")
+    else:
+        print(f"    {_wskazowka_zrodla(refid, refname)}")
+    print()
+
+
+def cmd_najnowsze(a):
+    d = _expect_list(_szukaj(_timespan(None, None), limit=a.limit), "najnowsze dokumenty")
+    if not d:
+        sys.exit("Brak wyników — spróbuj ponownie za chwilę.")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    print(f"Ostatnio WYDANE dokumenty w portalu orzeczeń UODO ({len(d)}) — API sortuje po dacie "
+          "decyzji/orzeczenia (announcement), NIE po dacie publikacji w portalu\n"
+          "(ostatnio opublikowane, także starsze decyzje: szukaj --pub-od RRRR-MM-DD).\n")
+    for it in d:
+        _wiersz(it)
+
+
+def _w_zakresie(data, od, do):
+    return bool(data) and (not od or data >= od) and (not do or data <= do)
+
+
+def cmd_szukaj(a):
+    warunki = []
+    if a.warunek:
+        warunki.append(a.warunek)
+    if a.fraza:
+        warunki.append(f"content_pl:regex:{a.fraza}")
+    if a.tytul:
+        warunki.append(f"title_pl:regex:{a.tytul}")
+    pub_od, pub_do = a.pub_od, a.pub_do
+    if not warunki and not (a.od or a.do or pub_od or pub_do):
+        sys.exit("Podaj kryterium: frazę (pełnotekstowo) albo --tytul / --warunek / zakres dat "
+                 "--od/--do (data decyzji) lub --pub-od/--pub-do (data publikacji).")
+    pub_serwer = False
+    if pub_od and not warunki:   # jeden warunek na zapytanie — wolny → filtr publikacji po stronie API
+        warunki.append(f"date_publication:ge:{pub_od}"); pub_serwer = True
+    if len(warunki) > 1:
+        print(f"UWAGA: API UODO stosuje JEDEN warunek na zapytanie — używam: {warunki[0]!r} "
+              f"(pomijam: {', '.join(repr(w) for w in warunki[1:])}).\n", file=sys.stderr)
+    do = a.do
+    if pub_do and (not do or pub_do < do):
+        do = pub_do  # data decyzji ≤ data publikacji — bezpieczne zawężenie okna API
+    d = _szukaj(_timespan(a.od, do), warunki[0] if warunki else None, a.limit, a.strona)
+    d = _expect_list(d, "wyniki wyszukiwania")
+    pobrane = len(d)
+    if pub_od or pub_do:
+        d = [it for it in d if _w_zakresie(_daty(it).get("publication"), pub_od, pub_do)]
+    if not d:
+        if pobrane:
+            sys.exit(f"Brak wyników po filtrze daty publikacji ({pub_od or '…'}–{pub_do or '…'}) "
+                     f"spośród {pobrane} pobranych rekordów tej strony. Filtr publikacji działa "
+                     "po stronie klienta (API przyjmuje jeden warunek) — sprawdź kolejne strony "
+                     f"(--strona {a.strona + 1}) albo zawęź --od/--do po dacie decyzji. "
+                     "To NIE dowód, że takich decyzji nie ma.")
+        sys.exit("Brak wyników. Fraza działa jak regex (bez rozróżniania wielkości liter) i szuka "
+                 "DOSŁOWNIE — a tytuły i treści są po polsku ODMIENIONE ('nałożenie kary "
+                 "pieniężnej', nie 'kara pieniężna'). Podaj RDZEŃ bez końcówki: 'pieniężn', "
+                 "'biometr', 'monitoring'. To NIE dowód, że takich decyzji nie ma.")
+    if a.json:
+        print(json.dumps(d, ensure_ascii=False, indent=2)); return
+    filtry = []
+    if a.od or do:
+        filtry.append(f"filtr po dacie decyzji (announcement): {a.od or '…'}–{do or '…'}")
+    if pub_od or pub_do:
+        filtry.append(f"filtr po dacie publikacji: {pub_od or '…'}–{pub_do or '…'} "
+                      + ("(od: po stronie API; do: po stronie klienta)" if pub_serwer
+                         else f"(po stronie klienta, tylko w obrębie {pobrane} pobranych rekordów)"))
+    print(f"Znaleziono: {len(d)}  (strona {a.strona}, po {a.limit}; sortowanie API od najnowszych "
+          "po dacie decyzji)" + ("\n  " + "; ".join(filtry) if filtry else "") + "\n")
+    for it in d:
+        _wiersz(it)
+    if pobrane == a.limit:
+        print(f"Kolejna strona: --strona {a.strona + 1}")
+
+
+class _TekstZHtml(HTMLParser):
+    """body.html portalu → tekst. Zachowuje numerację list (<dt>: '1.', 'a)'), odnośniki przypisów
+    [n] w tekście (<sup>) i JEDEN blok przypisów (<div class="glosses">) — body.txt API gubi
+    numerację i odnośniki, a przypisy dubluje."""
+    BLOKI = {"div", "dd", "dt", "h1", "h2", "h3", "h4", "p", "li", "tr", "br", "table", "ul", "ol"}
+
+    NAGLOWKI = ("h1", "h2", "h3", "h4")
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.linie, self._buf, self._etykieta = [], [], None
+        self._dl = []                   # stos <dl>: True = lista zagnieżdżona (wcina), False = first_level
+        self._w_dt = self._w_h = False
+        self._div = 0                   # głębokość <div>; przypisy od poziomu _glosy
+        self._glosy = None
+
+    @property
+    def _wciecie(self):
+        return sum(1 for zagniezdzona in self._dl if zagniezdzona)
+
+    def _flush(self):
+        tekst = re.sub(r"\s+", " ", "".join(self._buf)).strip()
+        self._buf = []
+        if not tekst:
+            return
+        if self._w_dt:
+            self._etykieta = tekst
+            return
+        if self._w_h:
+            self.linie += ["", tekst, ""]
+            return
+        if self._etykieta:
+            sep = "" if self._etykieta in ("„", "\"", "«", "»") else " "
+            tekst, self._etykieta = self._etykieta + sep + tekst, None
+        self.linie.append(("" if self._glosy is not None else "  " * self._wciecie) + tekst)
+
+    def _granica(self, tag):
+        """Granica bloku: wewnątrz nagłówka tylko odstęp (numer + tytuł w jednej linii)."""
+        if tag in self.BLOKI:
+            if self._w_h and tag not in self.NAGLOWKI:
+                self._buf.append(" ")
+            else:
+                self._flush()
+
+    def handle_starttag(self, tag, attrs):
+        self._granica(tag)
+        klasa = dict(attrs).get("class") or ""
+        if tag == "div":
+            self._div += 1
+            if "glosses" in klasa and self._glosy is None:
+                self._glosy = self._div
+                self.linie += ["", "Przypisy:"]
+        elif tag == "dl":
+            self._dl.append("first_level" not in klasa)
+        elif tag == "dt":
+            self._w_dt = True
+        elif tag in self.NAGLOWKI:
+            self._w_h = True
+
+    def handle_endtag(self, tag):
+        self._granica(tag)
+        if tag == "div":
+            if self._glosy is not None and self._div <= self._glosy:
+                self._glosy = None
+            self._div = max(0, self._div - 1)
+        elif tag == "dl" and self._dl:
+            self._dl.pop()
+        elif tag == "dt":
+            self._w_dt = False
+        elif tag in self.NAGLOWKI:
+            self._w_h = False
+
+    def handle_data(self, data):
+        self._buf.append(data)
+
+    def tekst(self):
+        self._flush()
+        return re.sub(r"\n{3,}", "\n\n", "\n".join(self.linie)).strip()
+
+
+def _tekst_z_html(html):
+    p = _TekstZHtml()
+    p.feed(html or "")
+    p.close()
+    return p.tekst()
+
+
+def _tresc(refid):
+    """Treść części 0 decyzji: z body.html (numeracja list, odnośniki i pojedynczy blok
+    przypisów), awaryjnie body.txt API. Zwraca (tekst, źródło)."""
+    czesc = urllib.parse.quote(refid + ":0", safe=":")
+    html = _get_opcjonalnie(f"/documents/public/items/{czesc}/body.html", {"lang": "pl"}, raw=True)
+    if html:
+        txt = _tekst_z_html(html)
+        if txt:
+            return txt, "body.html"
+    txt = _get(f"/documents/public/items/{czesc}/body.txt", params={"lang": "pl"}, raw=True)
+    return (txt or "").strip(), "body.txt"
+
+
+def _rozwin_kontrole(kontrola):
+    """Dla wpisów kontroli sądowej dociąga meta.json orzeczenia (sygnatura i sąd z portalu);
+    bez odpowiedzi zostaje sygnatura odtworzona z URN."""
+    for k in kontrola:
+        if not k["refid"]:
+            continue
+        m = _get_opcjonalnie(f"/documents/public/items/{urllib.parse.quote(k['refid'], safe=':')}/meta.json")
+        if isinstance(m, dict):
+            k["sygnatura"] = m.get("refname") or k["sygnatura"]
+            k["sad"] = re.sub(r"\s+", " ", _pl(m.get("name"))).strip()
+    return kontrola
+
+
+def _wyjasnij_rekord_powiazany(meta, refid):
+    refname = meta.get("refname") or refid
+    daty = _daty(meta)
+    tytul = re.sub(r"\s+", " ", _pl(meta.get("title"))).strip()
+    sys.exit(f"To NIE jest decyzja Prezesa UODO, lecz rekord powiązany bez treści w portalu: "
+             f"{_pl(meta.get('name')) or meta.get('kind', '?')} {refname} "
+             f"(data orzeczenia/aktu: {daty.get('announcement', '?')}; URN {meta.get('refid', refid)}).\n"
+             + (f"Początek sentencji/tezy z metadanych: {tytul[:400]}{'…' if len(tytul) > 400 else ''}\n"
+                if tytul else "")
+             + f"Pełna treść: {_wskazowka_zrodla(meta.get('refid', refid), refname)}")
+
+
+def cmd_decyzja(a):
+    refid = _refid(a.id)
+    meta = _get(f"/documents/public/items/{urllib.parse.quote(refid, safe=':')}/meta.json", brak_ok=True)
+    if meta is None:
+        if not _czy_decyzja(refid):
+            sys.exit(f"Nie znaleziono w portalu UODO rekordu {a.id} (URN {refid}) — to sygnatura "
+                     "orzeczenia sądu, a portal UODO i tak nie ma treści wyroków. Treść: "
+                     f'prawo-pl-cbosa sygnatura "{a.id}".')
+        sys.exit(f"Nie znaleziono w portalu orzeczeń UODO: {a.id} (URN {refid}).\n"
+                 "Sprawdź sygnaturę — format np. DKN.5131.9.2025 albo URN "
+                 f"urn:ndoc:gov:pl:uodo:2025:dkn_5131_9.\n{HEDGE_BRAK}")
+    meta = _expect_dict(meta, "metadane decyzji")
+    if not _czy_decyzja(meta.get("refid") or refid) or meta.get("parts") == 0:
+        _wyjasnij_rekord_powiazany(meta, refid)
+    kontrola = _rozwin_kontrole(_kontrola_sadowa(meta))
+    uchylona = _uchylona(meta, kontrola)
+    txt, zrodlo = _tresc(refid)
+    refname = meta.get("refname", a.id)
+    pub = meta.get("publication") or {}
+    uchylajace = [k for k in kontrola if k["use"] == "repealed"]
+    if getattr(a, "strict", False):
+        if uchylona:
+            wyroki = ", ".join(f"{k['sygnatura']} z {k['date']}" for k in uchylajace) or "wg statusu portalu"
+            sys.exit(f"BŁĄD: tryb strict blokuje decyzję {refname} — UCHYLONA przez sąd (w całości "
+                     f"lub w części): {wyroki}. Treść decyzji nie odzwierciedla stanu prawnego; zakres "
+                     "uchylenia ustal w sentencji wyroku: "
+                     + "; ".join(f'prawo-pl-cbosa sygnatura "{k["sygnatura"]}"' for k in uchylajace)
+                     + ". Bez --strict decyzja wyświetli się z ostrzeżeniem.")
+        if not txt:
+            sys.exit(f"BŁĄD: tryb strict blokuje decyzję {refname} bez zweryfikowanej pełnej treści.")
+    if a.json:
+        meta["_body"] = txt
+        meta["_tresc_zrodlo"] = zrodlo
+        meta["_kontrola_sadowa"] = kontrola
+        meta["_uchylona"] = uchylona
+        print(json.dumps(meta, ensure_ascii=False, indent=2)); return
+    daty = _daty(meta)
+    if uchylona:
+        wyroki = ", ".join(f"{k['sygnatura']} z {k['date']}" for k in uchylajace) or "(brak wpisu wyroku w meta)"
+        print(f"!!! DECYZJA UCHYLONA PRZEZ SĄD (w całości lub w części) — sprawdź zakres w wyroku {wyroki}: "
+              + ("; ".join(f'prawo-pl-cbosa sygnatura "{k["sygnatura"]}"' for k in uchylajace)
+                 or "prawo-pl-cbosa") + " !!!\n")
+    print(f"# {_pl(meta.get('name')) or refname}   [{refname}]")
+    print(f"  URN:        {meta.get('refid', refid)}")
+    inforce = "tak" if pub.get("inforce") else "nie/brak danych"
+    print(f"  Rodzaj:     {meta.get('kind', '?')}   status: {_status_opis(pub.get('status'))}"
+          f"   publication.inforce wg API: {inforce}"
+          + (" (pole nie odzwierciedla uchylenia)" if uchylona else ""))
+    print(f"  Daty:       decyzja (ogłoszenie) {daty.get('announcement', '?')}, publikacja w portalu "
+          f"{daty.get('publication', '?')}, walidacja {daty.get('validation', '—')}")
+    print(f"  Portal:     https://orzeczenia.uodo.gov.pl (API: {BASE}/documents/public/items/{refid}/meta.json)")
+    if pub.get("status") == "nonfinal":
+        print("  UWAGA:      decyzja NIEPRAWOMOCNA (status nonfinal) — przysługuje skarga do WSA; "
+              "cytuj z zastrzeżeniem (kontrola sądowa: prawo-pl-cbosa).")
+    if kontrola:
+        print("\n## Kontrola sądowa (wg meta.json portalu; treść wyroków: skill prawo-pl-cbosa)")
+        for k in kontrola:
+            opis = f"{k['sad']}, " if k["sad"] else ""
+            print(f"  {k['date']}  {k['znaczenie']}  {opis}{k['sygnatura'] or k['refid'] or '?'}"
+                  + (f'  → prawo-pl-cbosa sygnatura "{k["sygnatura"]}"' if k["sygnatura"] else ""))
+        print("  (zakres uchylenia — cała decyzja czy tylko niektóre punkty, np. kara — wynika "
+              "WYŁĄCZNIE z sentencji wyroku; kolejne orzeczenia, np. NSA, odnoszą się do wcześniejszego "
+              "wyroku; poniżej jest tekst PIERWOTNY decyzji.)")
+    tytul = _pl(meta.get("title"))
+    if tytul:
+        print(f"\n## Przedmiot\n{tytul.strip()}")
+    print(f"\n## Treść decyzji ({len(txt)} znaków, źródło: {zrodlo})")
+    if not txt:
+        print("(brak treści w API — zob. portal wyżej)")
+        return
+    if a.fragment:
+        spans = _fragmenty(txt, a.fragment)
+        if not spans:
+            sys.exit(f"Nie znaleziono frazy {a.fragment!r} w treści ({len(txt)} znaków). Tekst jest "
+                     "po polsku odmieniony — podaj RDZEŃ bez końcówki ('pieniężn' zamiast 'kara "
+                     "pieniężna'). To NIE dowód, że decyzja o tym nie mówi.")
+        for i, (s, e) in enumerate(spans):
+            if i:
+                print("\n[...]\n")
+            print(txt[s:e].strip())
+        print(f"\n(okna: {len(spans)} — pominięto resztę; pełna treść: bez --fragment)")
+        return
+    if len(txt) > 40000:
+        print(f"(UWAGA: długa decyzja {len(txt)} znaków — do wycinka użyj --fragment \"<fraza>\")\n")
+    print(txt)
+
+
+def _fragmenty(txt, fraza, maks=6, okno=600):
+    """Okna tekstu wokół wystąpień frazy (bez rozróżniania wielkości liter) — jak w saos.py."""
+    low, f = txt.lower(), fraza.lower().strip()
+    if not f:
+        return []
+    spans, p = [], low.find(f)
+    while p != -1 and len(spans) < maks:
+        start = max(0, p - okno // 3)
+        end = min(len(txt), p + len(f) + okno)
+        if spans and start <= spans[-1][1]:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], end))
+        else:
+            spans.append((start, end))
+        p = low.find(f, p + len(f))
+    return spans
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Oficjalne API Portalu Orzeczeń UODO (read-only, bez klucza): "
+                    "decyzje Prezesa UODO (z treścią i historią kontroli sądowej) oraz rekordy "
+                    "powiązane (orzeczenia sądów, akty prawne — same metadane).")
+    ap.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    ap.add_argument("--json", action="store_true", help="zrzut surowego JSON")
+    ap.add_argument("--strict", action="store_true",
+                    help="decyzja: zakończ błędem, gdy brak pełnej treści albo decyzja została "
+                         "UCHYLONA przez sąd (w całości lub w części); na listach nic nie zmienia")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    n = sub.add_parser("najnowsze", help="ostatnio WYDANE dokumenty (API sortuje po dacie decyzji, nie publikacji)")
+    n.add_argument("--limit", type=int, default=10, help="ile wyników (1–100)")
+    n.set_defaults(func=cmd_najnowsze)
+
+    s = sub.add_parser("szukaj")
+    s.add_argument("fraza", nargs="?", default=None,
+                   help="wyszukiwanie pełnotekstowe (regex, bez rozróżniania wielkości liter)")
+    s.add_argument("--tytul", help="fraza w tytule/przedmiocie decyzji (regex)")
+    s.add_argument("--warunek", help='surowy warunek API: "indeks:operator:wartość", '
+                                     'np. "publicator_subtype:eq:uodo" (operatory: eq ne lt gt le ge in glob regex)')
+    s.add_argument("--od", help="data DECYZJI/orzeczenia (announcement) od (RRRR-MM-DD) — tak filtruje API; "
+                                "to NIE jest data publikacji w portalu")
+    s.add_argument("--do", help="data DECYZJI/orzeczenia (announcement) do (RRRR-MM-DD)")
+    s.add_argument("--pub-od", dest="pub_od", help="data PUBLIKACJI w portalu od (RRRR-MM-DD); po stronie API, "
+                                                    "gdy nie ma innego warunku, inaczej tylko w obrębie pobranej strony")
+    s.add_argument("--pub-do", dest="pub_do", help="data PUBLIKACJI w portalu do (RRRR-MM-DD); filtr po stronie klienta")
+    s.add_argument("--limit", type=int, default=10, help="ile wyników (1–100)")
+    s.add_argument("--strona", type=int, default=0, help="numer strony (od 0)")
+    s.set_defaults(func=cmd_szukaj)
+
+    d = sub.add_parser("decyzja")
+    d.add_argument("id", help="sygnatura (DKN.5131.9.2025) albo URN (urn:ndoc:gov:pl:uodo:2025:dkn_5131_9)")
+    d.add_argument("--fragment", help='wytnij okna wokół frazy w treści — podawaj RDZEŃ, np. "pieniężn"')
+    d.set_defaults(func=cmd_decyzja)
+
+    # Flagi globalne działają też PO komendzie (modele piszą je właśnie tam); SUPPRESS sprawia,
+    # że brak flagi w subparserze nie kasuje wartości podanej przed komendą
+    for p in sub.choices.values():
+        p.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                       help="zrzut surowego JSON")
+        p.add_argument("--strict", action="store_true", default=argparse.SUPPRESS,
+                       help="decyzja: zakończ błędem przy braku treści albo uchyleniu przez sąd")
+
+    a = ap.parse_args()
+    a.func(a)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_cbosa.py
+++ b/tools/test_cbosa.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for cbosa.py pure functions (no network). Run: python3 tools/test_cbosa.py"""
+import os
+import io
+import json
+import sys
+import importlib.util
+import pathlib
+import ssl
+import unittest
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "cbosa", ROOT / "plugins/prawo-pl-cbosa/skills/prawo-pl-cbosa/scripts/cbosa.py")
+cbosa = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cbosa)
+
+
+class TestSad(unittest.TestCase):
+    def test_nsa(self):
+        self.assertEqual(cbosa._sad("NSA"), "Naczelny Sąd Administracyjny")
+        self.assertEqual(cbosa._sad("nsa"), "Naczelny Sąd Administracyjny")
+
+    def test_wsa_miasta(self):
+        cases = [
+            ("WSA Warszawa", "Wojewódzki Sąd Administracyjny w Warszawie"),
+            ("wsa warszawa", "Wojewódzki Sąd Administracyjny w Warszawie"),
+            ("WSA Wrocław", "Wojewódzki Sąd Administracyjny we Wrocławiu"),
+            ("wsa wroclaw", "Wojewódzki Sąd Administracyjny we Wrocławiu"),
+            ("WSA w Krakowie", "Wojewódzki Sąd Administracyjny w Krakowie"),  # forma z „w"
+            ("Łódź", "Wojewódzki Sąd Administracyjny w Łodzi"),
+            ("gorzów wlkp.", "Wojewódzki Sąd Administracyjny w Gorzowie Wlkp."),
+        ]
+        for inp, want in cases:
+            self.assertEqual(cbosa._sad(inp), want, f"sąd: {inp!r}")
+
+    def test_pelna_nazwa_przechodzi(self):
+        # pełna nazwa z formularza CBOSA (też historyczne ośrodki zamiejscowe) idzie bez zmian
+        for nazwa in ("Naczelny Sąd Administracyjny",
+                      "Wojewódzki Sąd Administracyjny w Gliwicach",
+                      "NSA oz. w Katowicach"):
+            self.assertEqual(cbosa._sad(nazwa), nazwa)
+
+    def test_domyslny(self):
+        self.assertEqual(cbosa._sad(None), "dowolny")
+        self.assertEqual(cbosa._sad("dowolny"), "dowolny")
+
+    def test_nieznany_exits(self):
+        with self.assertRaises(SystemExit):
+            cbosa._sad("WSA Pcim")
+
+
+class TestRodzaj(unittest.TestCase):
+    def test_aliasy(self):
+        for inp, want in [("wyrok", "Wyrok"), ("POSTANOWIENIE", "Postanowienie"),
+                          ("uchwala", "Uchwała"), ("uchwała", "Uchwała")]:
+            self.assertEqual(cbosa._rodzaj(inp), want)
+
+    def test_domyslny(self):
+        self.assertEqual(cbosa._rodzaj(None), "dowolny")
+
+    def test_nieznany_exits(self):
+        with self.assertRaises(SystemExit):
+            cbosa._rodzaj("apelacja")
+
+
+class TestData(unittest.TestCase):
+    def test_pelna_data_bez_zmian(self):
+        self.assertEqual(cbosa._data("2024-01-31"), "2024-01-31")
+
+    def test_pusta(self):
+        self.assertEqual(cbosa._data(None), "")
+        self.assertEqual(cbosa._data(""), "")
+
+    def test_skroty_uzupelniane_zaleznie_od_konca(self):
+        self.assertEqual(cbosa._data("2024"), "2024-01-01")
+        self.assertEqual(cbosa._data("2024", koniec=True), "2024-12-31")
+        self.assertEqual(cbosa._data("2024-02"), "2024-02-01")
+        self.assertEqual(cbosa._data("2024-02", koniec=True), "2024-02-29")  # rok przestępny
+        self.assertEqual(cbosa._data("2023-02", koniec=True), "2023-02-28")
+
+    def test_separatory_i_zera(self):
+        self.assertEqual(cbosa._data("2024.1.5"), "2024-01-05")
+
+    def test_zly_format_exits(self):
+        # regresja: CBOSA odpowiada wtedy stroną błędu, nie do odróżnienia od przeciążenia
+        for zla in ("31-12-2024", "2024-13-01", "2024-02-30", "wczoraj", "01/2024"):
+            with self.assertRaises(SystemExit, msg=f"data: {zla!r}"):
+                cbosa._data(zla)
+
+
+class TestFormularz(unittest.TestCase):
+    """Mapowanie argumentów CLI na pola formularza CBOSA."""
+
+    class _Args:
+        fraza = sygnatura = sad = rodzaj = symbol = sedzia = od = do = None
+
+    def _form(self, **kw):
+        a = self._Args()
+        for k, v in kw.items():
+            setattr(a, k, v)
+        return cbosa._formularz(a)
+
+    def test_samo_od_dostaje_gorna_granice(self):
+        # regresja: CBOSA na samo `odDaty` (puste `doDaty`) zwraca ZERO wyników
+        f = self._form(od="2024-01-01")
+        self.assertEqual(f["odDaty"], "2024-01-01")
+        self.assertEqual(f["doDaty"], cbosa.DO_OTWARTE)
+
+    def test_samo_do_bez_zmian(self):
+        f = self._form(do="2020-12-31")  # ta strona zakresu działa w CBOSA otwarta
+        self.assertEqual(f["odDaty"], "")
+        self.assertEqual(f["doDaty"], "2020-12-31")
+
+    def test_oba_konce_zachowane(self):
+        f = self._form(od="2024", do="2025")
+        self.assertEqual((f["odDaty"], f["doDaty"]), ("2024-01-01", "2025-12-31"))
+
+    def test_bez_dat_puste(self):
+        f = self._form(fraza="RODO")
+        self.assertEqual((f["odDaty"], f["doDaty"]), ("", ""))
+        self.assertEqual(f["wszystkieSlowa"], "RODO")
+
+
+class TestWyniki(unittest.TestCase):
+    # zminiaturyzowana struktura żywej strony wyników CBOSA (2026-07)
+    HTML = """
+    <table class="top-linki"><tr><td>Znaleziono 1878 orzeczeń, Str. 1 z 188</td></tr></table>
+    <table class="info-list">
+      <tr class="niezaznaczona"><td class="info-list-value " style="font-size: 12pt; border: none;">
+        <a href="/doc/8889489BE0"  >\n II FSK 2870/18 - Wyrok NSA z 2021-02-10 </a>
+        <a href="/cbo/pow/8889489BE0"><img src="/img/copy.png"/></a></td></tr>
+      <tr class="niezaznaczona"><td class="info-list-value " style="font-size: 10pt; border: none;">
+        uchylono zaskarżony wyrok... 6112 Podatek dochodowy<BR/></td></tr>
+      <tr><td><span class="powiazane"><a href="/doc/109C7D1883"  >
+        I SA/Bk 226/18 - Wyrok WSA w Białymstoku z 2018-06-06<br/></a></span></td></tr>
+    </table>"""
+
+    # strona CBOSA bez trafień: formularz z komunikatem, bez licznika „Znaleziono N"
+    HTML_ZERO = """<form name="QueryForm" method="post" action="/cbo/search">
+      <div class="warning"> Nie znaleziono orzeczeń spełniających podany warunek! </div>
+      <div class="forma"><TABLE id="qt"></TABLE></div></form>"""
+    HTML_ZLA_DATA = """<form name="QueryForm" method="post" action="/cbo/search">
+      <div class="warning"> Niepoprawny format daty, podaj RRRR-MM-DD! </div>
+      <div class="forma"><TABLE id="qt"></TABLE></div></form>"""
+
+    def test_total_i_pozycje(self):
+        total, poz, _ = cbosa._wyniki(self.HTML)
+        self.assertEqual(total, 1878)
+        self.assertEqual(len(poz), 2)
+
+    def test_glowny_wynik(self):
+        _, poz, _ = cbosa._wyniki(self.HTML)
+        glowny = poz[0]
+        self.assertEqual(glowny["doc_id"], "8889489BE0")
+        self.assertFalse(glowny["powiazane"])
+        self.assertIn("II FSK 2870/18", glowny["opis"])
+        self.assertIn("6112", glowny["snippet"])
+
+    def test_powiazane_oznaczone(self):
+        _, poz, _ = cbosa._wyniki(self.HTML)
+        self.assertTrue(poz[1]["powiazane"])
+        self.assertEqual(poz[1]["doc_id"], "109C7D1883")
+
+    def test_brak_trafien_to_zweryfikowane_zero(self):
+        # regresja: bez tego każde puste wyszukiwanie wyglądało jak awaria serwera
+        total, poz, komunikat = cbosa._wyniki(self.HTML_ZERO)
+        self.assertEqual(total, 0)
+        self.assertEqual(poz, [])
+        self.assertIn("Nie znaleziono orzeczeń", komunikat)
+
+    def test_blad_formularza_zwraca_komunikat(self):
+        total, poz, komunikat = cbosa._wyniki(self.HTML_ZLA_DATA)
+        self.assertIsNone(total)  # to nie zero — zapytanie w ogóle nie zostało wykonane
+        self.assertEqual(poz, [])
+        self.assertIn("Niepoprawny format daty", komunikat)
+
+    def test_strona_z_wynikami_bez_komunikatu(self):
+        self.assertEqual(cbosa._wyniki(self.HTML)[2], "")
+
+    def test_pusty_html(self):
+        # Strona bez rozpoznanego licznika/listy jest teraz UNKNOWN, nie cichym
+        # sentinelem (None, [], "") - patch found/verified_absent/unknown.
+        with self.assertRaises(cbosa.VerificationUnknown):
+            cbosa._wyniki("<html><body>Brak wyników</body></html>")
+
+
+class TestOrzeczenie(unittest.TestCase):
+    HTML = """
+    <TITLE>II FSK 2870/18 - Wyrok NSA z 2021-02-10</TITLE>
+    <table><tr><td class="lista-label"><td class="info-list-label">Data orzeczenia</td>
+      <td class="info-list-value">2021-02-10</td></tr>
+    <tr><td class="info-list-label">Sąd</td><td class="info-list-value">Naczelny Sąd Administracyjny</td></tr>
+    <tr><td class="info-list-label">Sygn. powiązane</td>
+      <td class="info-list-value"><a href="/doc/109C7D1883">I SA/Bk 226/18 - Wyrok WSA</a></td></tr></table>
+    <td class="info-list-label-uzasadnienie"><div class="lista-label">Sentencja</div>
+      <span class="info-list-value-uzasadnienie"><P>Naczelny Sąd Administracyjny uchyla wyrok.</P></span></td>
+    <td class="info-list-label-uzasadnienie"><div class="lista-label">Uzasadnienie</div>
+      <span class="info-list-value-uzasadnienie"><P>1. Wyrokiem z 6 czerwca 2018 r.&nbsp;sąd oddalił skargę.</P></span></td>
+    """
+
+    def test_tytul_i_sygnatura(self):
+        d = cbosa._orzeczenie(self.HTML, "8889489BE0")
+        self.assertEqual(d["sygnatura"], "II FSK 2870/18")
+        self.assertEqual(d["doc_id"], "8889489BE0")
+
+    def test_metadane(self):
+        d = cbosa._orzeczenie(self.HTML, "X")
+        self.assertEqual(d["metadane"]["Data orzeczenia"], "2021-02-10")
+        self.assertEqual(d["metadane"]["Sąd"], "Naczelny Sąd Administracyjny")
+
+    def test_powiazane_doc_id(self):
+        d = cbosa._orzeczenie(self.HTML, "X")
+        self.assertEqual(d["powiazane"][0]["doc_id"], "109C7D1883")
+
+    def test_sekcje(self):
+        d = cbosa._orzeczenie(self.HTML, "X")
+        self.assertIn("uchyla wyrok", d["sentencja"])
+        self.assertIn("oddalił skargę", d["uzasadnienie"])
+        self.assertNotIn("<P>", d["uzasadnienie"])
+        self.assertNotIn("\xa0", d["uzasadnienie"])  # NBSP znormalizowany
+
+
+class TestFetchPonowienia(unittest.TestCase):
+    """Krótkie okna, w których CBOSA ucina połączenia, muszą przeżyć kilka ponowień."""
+
+    def _bez_sieci(self, awarie):
+        """Podmienia opener: pierwsze `awarie` prób pada, kolejna zwraca stronę. Zwraca licznik."""
+        licznik = {"proby": 0, "spanie": []}
+
+        class _Odpowiedz:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def read(self_inner):
+                return b"<html>OK</html>"
+
+        class _Opener:
+            def open(self_inner, req, timeout=None):
+                licznik["proby"] += 1
+                if licznik["proby"] <= awarie:
+                    raise OSError("Remote end closed connection without response")
+                return _Odpowiedz()
+
+        return licznik, _Opener()
+
+    def _uruchom(self, awarie):
+        licznik, opener = self._bez_sieci(awarie)
+        oryg_opener, oryg_sleep = cbosa.urllib.request.build_opener, cbosa.time.sleep
+        cbosa.urllib.request.build_opener = lambda *a, **k: opener
+        cbosa.time.sleep = lambda s: licznik["spanie"].append(s)
+        try:
+            return licznik, cbosa._fetch("/cbo/search", data={"submit": "Szukaj"})
+        finally:
+            cbosa.urllib.request.build_opener, cbosa.time.sleep = oryg_opener, oryg_sleep
+
+    def test_przezywa_kilkunastosekundowe_okno(self):
+        licznik, html = self._uruchom(awarie=4)  # cztery zerwane połączenia z rzędu
+        self.assertIn("OK", html)
+        self.assertEqual(licznik["proby"], 5)
+        self.assertGreaterEqual(sum(s for s in licznik["spanie"] if s > 0.5), 26)
+
+    def test_trwala_awaria_konczy_bledem(self):
+        # Trwala awaria transportu to teraz UNKNOWN (nie SystemExit) na poziomie
+        # _fetch - main() dopiero mapuje to na polski komunikat i exit (patch
+        # found/verified_absent/unknown, patrz VerificationUnknown ponizej).
+        with self.assertRaises(cbosa.VerificationUnknown):
+            self._uruchom(awarie=99)
+
+
+class TestText(unittest.TestCase):
+    def test_akapity_i_encje(self):
+        t = cbosa._text("<P>art.&nbsp;116</P><BR/>dalej &amp; koniec")
+        self.assertIn("art. 116", t)
+        self.assertIn("dalej & koniec", t)
+        self.assertNotIn("<", t)
+
+
+class TestFragmenty(unittest.TestCase):
+    def test_okno_wokol_frazy(self):
+        txt = ("X" * 50) + "FRAZA" + ("Y" * 50)
+        spans = cbosa._fragmenty(txt, "fraza")
+        self.assertEqual(len(spans), 1)
+        self.assertIn("FRAZA", txt[spans[0][0]:spans[0][1]])
+
+    def test_brak_trafien(self):
+        self.assertEqual(cbosa._fragmenty("dowolny tekst", "nie ma"), [])
+
+    # audyt D3: okna cięte w środku słowa („kupno i sprz", „aluty tradycyjne") bez znacznika
+
+    @staticmethod
+    def _tekst(przed=40, po=120):
+        slowa_przed = " ".join(f"wyraz{i:03d}" for i in range(przed))
+        slowa_po = " ".join(f"slowo{i:03d}" for i in range(po))
+        return f"{slowa_przed} INTERPRETACJA indywidualna {slowa_po}."
+
+    def test_brzegi_na_granicy_wyrazu(self):
+        txt = self._tekst()
+        (s, e), = cbosa._fragmenty(txt, "interpretacja")
+        self.assertGreater(s, 0)
+        self.assertLess(e, len(txt))
+        self.assertTrue(txt[s - 1].isspace(), f"początek w środku słowa: {txt[s - 5:s + 5]!r}")
+        self.assertTrue(txt[e].isspace(), f"koniec w środku słowa: {txt[e - 5:e + 5]!r}")
+        self.assertIn("INTERPRETACJA", txt[s:e])
+
+    def test_brzegi_wola_granice_zdania(self):
+        zdania = " ".join(f"Zdanie numer {i} ma kilka wyrazów i kończy się kropką." for i in range(6))
+        txt = zdania + " Tu pada fraza KRYPTOWALUTA i dalej tekst. " + \
+            " ".join(f"Dalsze zdanie {i} o niczym w szczególności." for i in range(30))
+        (s, e), = cbosa._fragmenty(txt, "kryptowaluta")
+        self.assertTrue(txt[s].isupper(), f"okno nie zaczyna się od zdania: {txt[s:s + 20]!r}")
+        self.assertEqual(txt[e - 2], ".", f"okno nie kończy się zdaniem: {txt[e - 20:e]!r}")
+
+    def test_skrot_nie_konczy_zdania(self):
+        # „art.", „2018 r." — kropka po skrócie nie jest granicą zdania
+        txt = "Wyrokiem z 6 czerwca 2018 r. sąd oddalił skargę na podstawie art. 151 p.p.s.a. Skarżący wniósł skargę.\nNaczelny Sąd"
+        granice = cbosa._granice_zdan(txt, 0, len(txt))
+        self.assertEqual([txt[g:g + 8] for g in granice], ["Skarżący", "Naczelny"])
+
+    def test_fraza_zostaje_w_oknie_po_scaleniu(self):
+        txt = self._tekst(po=5) + " " + self._tekst(przed=5, po=200)
+        spans = cbosa._fragmenty(txt, "interpretacja")
+        self.assertEqual(len(spans), 1)  # dwa bliskie trafienia → jedno okno
+        s, e = spans[0]
+        self.assertEqual(txt[s:e].upper().count("INTERPRETACJA"), 2)
+
+    def test_wydruk_ma_znaczniki_uciecia(self):
+        html = TestOrzeczenie.HTML.replace(
+            "<P>1. Wyrokiem z 6 czerwca 2018 r.&nbsp;sąd oddalił skargę.</P>",
+            "<P>" + self._tekst(przed=60, po=200) + "</P>")
+        args = mock.Mock(doc_id="8889489BE0", json=False, strict=False, fragment="interpretacja")
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value=html), redirect_stdout(out):
+            cbosa.cmd_orzeczenie(args)
+        okno = out.getvalue().split("## Uzasadnienie", 1)[1].split("\n")[1]
+        self.assertTrue(okno.startswith("…"), okno[:40])
+        self.assertTrue(okno.endswith(" …"), okno[-40:])
+        self.assertRegex(okno, r"^…wyraz\d{3} ")  # pełne słowo tuż za znacznikiem
+        self.assertRegex(okno, r" slowo\d{3} …$")
+        self.assertIn("„…” oznacza ucięcie", out.getvalue())
+
+    def test_okno_od_poczatku_bez_znacznika(self):
+        html = TestOrzeczenie.HTML.replace("6 czerwca 2018 r.", "6 czerwca 2018 r. interpretacja")
+        args = mock.Mock(doc_id="8889489BE0", json=False, strict=False, fragment="interpretacja")
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value=html), redirect_stdout(out):
+            cbosa.cmd_orzeczenie(args)
+        okno = out.getvalue().split("## Uzasadnienie", 1)[1].split("\n")[1]
+        self.assertFalse(okno.startswith("…"), okno)  # okno zaczyna się na początku tekstu
+        self.assertFalse(okno.endswith("…"), okno)    # i sięga jego końca — nic nie ucięto
+
+
+class TestPrawomocnosc(unittest.TestCase):
+    """Audyt D1/D2: CBOSA oznacza każde orzeczenie „orzeczenie prawomocne / nieprawomocne" w komórce
+    „Data orzeczenia" (zagnieżdżona tabela) — silnik gubił flagę, a --strict przepuszczał wyrok WSA
+    uchylony przez NSA. Fragmenty HTML = żywe strony /doc/109C7D1883, /doc/8889489BE0 (2026-08)."""
+
+    @staticmethod
+    def _html(data, kursywa, sygnatura="I SA/Bk 226/18 - Wyrok WSA w Białymstoku z 2018-06-06",
+              powiazane=True):
+        pow_ = ('<tr class="niezaznaczona"><td class="info-list-label"><table class="noborder-tab"><tr>'
+                '<td class="lista-label">Sygn. powiązane</td></tr></table></td><td class="info-list-value">'
+                '<a href="/doc/8889489BE0">II FSK 2870/18 - Wyrok NSA z 2021-02-10</a></td></tr>'
+                if powiazane else "")
+        return f"""<TITLE>{sygnatura}</TITLE>
+        <table class="info-list">
+        <tr class="niezaznaczona"><td class="info-list-label"><table class="noborder-tab"><tr>
+          <td class="lista-label">Data orzeczenia</td></tr></table></td>
+          <td class="info-list-value"><table cellspacing=0 cellpadding=0 style="width: 100%">
+            <tr><td>{data}</td>
+            <td style="width: 50%; text-align: right; padding-right: 5px; font-style: italic;">{kursywa}</td>
+            </tr></table></td></tr>
+        <tr class="niezaznaczona"><td class="info-list-label"><table class="noborder-tab"><tr>
+          <td class="lista-label">Sąd</td></tr></table></td>
+          <td class="info-list-value">Wojewódzki Sąd Administracyjny w Białymstoku</td></tr>
+        {pow_}
+        <tr class="niezaznaczona"><td class="info-list-label"><table class="noborder-tab"><tr>
+          <td class="lista-label">Treść wyniku</td></tr></table></td>
+          <td class="info-list-value">Oddalono skargę</td></tr></table>
+        <td class="info-list-label-uzasadnienie"><div class="lista-label">Uzasadnienie</div>
+          <span class="info-list-value-uzasadnienie"><P>Sąd uznał, że skarga jest nieprawomocna
+          w ocenie strony, ale to tekst uzasadnienia, nie oznaczenie.</P></span></td>"""
+
+    NIEPRAWOMOCNE = _html.__func__("2018-06-06", "orzeczenie nieprawomocne")
+    PRAWOMOCNE = _html.__func__("2021-02-10", "orzeczenie prawomocne",
+                                sygnatura="II FSK 2870/18 - Wyrok NSA z 2021-02-10")
+    # żywa strona /doc/1A8B8B8130 (postanowienie o wstrzymaniu wykonania, 2026-08-19): pole jest, ale puste
+    PUSTE_POLE = _html.__func__("2026-08-19", "&nbsp;",
+                                sygnatura="VI SA/Wa 707/26 - Postanowienie WSA w Warszawie z 2026-08-19",
+                                powiazane=False)
+
+    def _uruchom(self, html, argv):
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value=html), \
+                mock.patch.object(sys, "argv", ["cbosa.py"] + argv), redirect_stdout(out):
+            try:
+                cbosa.main()
+            except SystemExit as e:
+                return out.getvalue(), e.code
+        return out.getvalue(), 0
+
+    def test_parser_nieprawomocne_i_czysta_data(self):
+        d = cbosa._orzeczenie(self.NIEPRAWOMOCNE, "109C7D1883")
+        self.assertIs(d["prawomocne"], False)
+        self.assertEqual(d["prawomocnosc"], "orzeczenie nieprawomocne")
+        self.assertEqual(d["metadane"]["Data orzeczenia"], "2018-06-06")  # data bez śmieci z kursywy
+        self.assertEqual(d["metadane"]["Treść wyniku"], "Oddalono skargę")
+
+    def test_parser_prawomocne(self):
+        d = cbosa._orzeczenie(self.PRAWOMOCNE, "8889489BE0")
+        self.assertIs(d["prawomocne"], True)
+        self.assertEqual(d["prawomocnosc"], "orzeczenie prawomocne")
+
+    def test_parser_puste_pole_to_none_nie_prawomocne(self):
+        d = cbosa._orzeczenie(self.PUSTE_POLE, "1A8B8B8130")
+        self.assertIsNone(d["prawomocne"])
+        self.assertEqual(d["prawomocnosc"], "")  # pole jest, CBOSA nic nie wpisała
+
+    def test_parser_brak_pola_to_none(self):
+        d = cbosa._orzeczenie(TestOrzeczenie.HTML, "X")  # stary płaski układ bez kursywy
+        self.assertIsNone(d["prawomocne"])
+        self.assertIsNone(d["prawomocnosc"])
+
+    def test_slowo_w_uzasadnieniu_nie_jest_oznaczeniem(self):
+        html = self.PUSTE_POLE.replace("skarga jest nieprawomocna", "orzeczenie nieprawomocne w ocenie")
+        self.assertIsNone(cbosa._orzeczenie(html, "X")["prawomocne"])
+
+    def test_tekst_nieprawomocne_linia_po_dacie_i_glosna_uwaga(self):
+        out, kod = self._uruchom(self.NIEPRAWOMOCNE, ["orzeczenie", "109C7D1883"])
+        self.assertEqual(kod, 0)
+        linie = out.splitlines()
+        i = next(n for n, l in enumerate(linie) if l.startswith("  Data orzeczenia: 2018-06-06"))
+        self.assertEqual(linie[i + 1], "  Prawomocność: NIEPRAWOMOCNE (oznaczenie CBOSA „orzeczenie nieprawomocne”) — zob. UWAGA wyżej")
+        self.assertTrue(out.startswith("UWAGA: I SA/Bk 226/18 jest oznaczone w CBOSA jako ORZECZENIE NIEPRAWOMOCNE"))
+        self.assertIn("uchylone", out)
+        self.assertIn("II FSK 2870/18 - Wyrok NSA z 2021-02-10 → orzeczenie 8889489BE0", out)  # dokąd skoczyć
+
+    def test_tekst_prawomocne_bez_uwagi(self):
+        out, kod = self._uruchom(self.PRAWOMOCNE, ["orzeczenie", "8889489BE0"])
+        self.assertEqual(kod, 0)
+        self.assertIn("  Data orzeczenia: 2021-02-10\n  Prawomocność: prawomocne (oznaczenie CBOSA „orzeczenie prawomocne”)\n", out)
+        self.assertNotIn("UWAGA", out)
+
+    def test_tekst_puste_pole_ma_adnotacje(self):
+        out, kod = self._uruchom(self.PUSTE_POLE, ["orzeczenie", "1A8B8B8130"])
+        self.assertEqual(kod, 0)
+        self.assertIn("Prawomocność: nieznana — CBOSA nie podaje", out)
+        self.assertIn("UWAGA: VI SA/Wa 707/26 — CBOSA nie podaje prawomocności", out)
+
+    def test_json_ma_pole_prawomocne(self):
+        out, _ = self._uruchom(self.NIEPRAWOMOCNE, ["orzeczenie", "109C7D1883", "--json"])
+        d = json.loads(out)
+        self.assertIs(d["prawomocne"], False)
+        self.assertEqual(d["prawomocnosc"], "orzeczenie nieprawomocne")
+        self.assertIn("NIEPRAWOMOCNE", d["uwaga"])
+        self.assertTrue(d["transport_tls_verified"])
+        out, _ = self._uruchom(self.PRAWOMOCNE, ["--json", "orzeczenie", "8889489BE0"])
+        d = json.loads(out)
+        self.assertIs(d["prawomocne"], True)
+        self.assertNotIn("uwaga", d)
+        out, _ = self._uruchom(self.PUSTE_POLE, ["orzeczenie", "1A8B8B8130", "--json"])
+        self.assertIsNone(json.loads(out)["prawomocne"])
+
+    def test_strict_blokuje_nieprawomocne_przed_emisja(self):
+        for argv in (["orzeczenie", "109C7D1883", "--strict"],
+                     ["--strict", "orzeczenie", "109C7D1883"],
+                     ["orzeczenie", "109C7D1883", "--json", "--strict"]):
+            out, kod = self._uruchom(self.NIEPRAWOMOCNE, argv)
+            self.assertEqual(out, "", argv)  # nic na stdout — także z --json
+            self.assertNotEqual(kod, 0)
+            self.assertIn("orzeczenie nieprawomocne — tryb strict nie zwraca treści, której aktualność "
+                          "nie jest potwierdzona; bez --strict dostaniesz tekst z ostrzeżeniem", str(kod))
+            self.assertIn("[8889489BE0]", str(kod))  # odsyła do wyroku NSA w tej sprawie
+            self.assertNotIn("ponownie", str(kod))   # to nie awaria przejściowa
+
+    def test_strict_przepuszcza_prawomocne(self):
+        out, kod = self._uruchom(self.PRAWOMOCNE, ["orzeczenie", "8889489BE0", "--strict"])
+        self.assertEqual(kod, 0)
+        self.assertIn("Prawomocność: prawomocne", out)
+        out, kod = self._uruchom(self.PRAWOMOCNE, ["orzeczenie", "8889489BE0", "--strict", "--json"])
+        self.assertEqual(kod, 0)
+        self.assertIs(json.loads(out)["prawomocne"], True)
+
+    def test_strict_blokuje_brak_oznaczenia(self):
+        out, kod = self._uruchom(self.PUSTE_POLE, ["orzeczenie", "1A8B8B8130", "--strict"])
+        self.assertEqual(out, "")
+        self.assertIn("CBOSA nie podaje prawomocności", str(kod))
+        self.assertIn("bez --strict", str(kod))
+        out, kod = self._uruchom(TestOrzeczenie.HTML, ["orzeczenie", "8889489BE0", "--strict"])
+        self.assertEqual(out, "")
+        self.assertIn("nie znaleziono oznaczenia", str(kod))
+
+    def test_strict_nadal_sprawdza_tls(self):
+        def fake_fetch(path, data=None):
+            cbosa._transport_tls_verified = False
+            return self.PRAWOMOCNE
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", side_effect=fake_fetch), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "orzeczenie", "8889489BE0", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                cbosa.main()
+        cbosa._transport_tls_verified = True
+        self.assertEqual(out.getvalue(), "")
+        self.assertIn("TLS", str(caught.exception.code))
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj", "fraza"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, cbosa.cmd_szukaj
+        cbosa.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            cbosa.main()
+        finally:
+            sys.argv, cbosa.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
+
+class CbosaVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_transport_error_is_unknown(self):
+        opener = mock.Mock()
+        opener.open.side_effect = urllib.error.URLError("offline")
+        cbosa._ostatnie[0] = 0.0
+        with mock.patch.object(cbosa.urllib.request, "build_opener", return_value=opener), \
+                mock.patch.object(cbosa.time, "sleep"):
+            with self.assertRaises(cbosa.VerificationUnknown):
+                cbosa._fetch("/cbo/search")
+
+    def test_no_results_warning_is_verified_absent(self):
+        html = '<div class="warning">Nie znaleziono orzeczeń spełniających kryteria</div>'
+        total, results, message = cbosa._wyniki(html)
+        self.assertEqual(total, 0)
+        self.assertEqual(results, [])
+        self.assertIn("Nie znaleziono", message)
+
+    def test_unrecognized_error_page_is_unknown(self):
+        with self.assertRaises(cbosa.VerificationUnknown):
+            cbosa._wyniki("<html><title>Service unavailable</title></html>")
+
+    def test_http_410_na_doc_to_zweryfikowany_brak(self):
+        # CBOSA odpowiada 410 (Gone) dla nieistniejącego doc_id — to potwierdzone
+        # "nie ma", nie awaria; komunikat nie może odsyłać w pętlę "spróbuj ponownie"
+        err = urllib.error.HTTPError("https://orzeczenia.nsa.gov.pl/doc/DEADBEEF",
+                                     410, "Gone", {}, None)
+        opener = mock.Mock()
+        opener.open.side_effect = err
+        cbosa._ostatnie[0] = 0.0
+        with mock.patch.object(cbosa.urllib.request, "build_opener", return_value=opener), \
+                mock.patch.object(cbosa.time, "sleep"):
+            with self.assertRaisesRegex(SystemExit, "Nie znaleziono orzeczenia") as caught:
+                cbosa._fetch("/doc/DEADBEEF")
+        self.assertNotIn("ponownie", str(caught.exception))
+
+    def test_http_410_na_wyszukiwarce_to_nadal_unknown(self):
+        # 410/404 ma sens "brak dokumentu" tylko na /doc/{id}; na wyszukiwarce to awaria
+        err = urllib.error.HTTPError("https://orzeczenia.nsa.gov.pl/cbo/search",
+                                     410, "Gone", {}, None)
+        opener = mock.Mock()
+        opener.open.side_effect = err
+        cbosa._ostatnie[0] = 0.0
+        with mock.patch.object(cbosa.urllib.request, "build_opener", return_value=opener), \
+                mock.patch.object(cbosa.time, "sleep"):
+            with self.assertRaises(cbosa.VerificationUnknown):
+                cbosa._fetch("/cbo/search")
+
+    def test_t11_strict_blokuje_niezweryfikowany_transport_i_stdout_jest_pusty(self):
+        def fake_fetch(path, data=None):
+            cbosa._transport_tls_verified = False
+            return TestOrzeczenie.HTML
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", side_effect=fake_fetch), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "orzeczenie", "8889489BE0", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                cbosa.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t12_json_strict_nie_emituje_wyniku_gdy_kontrola_nie_przeszla(self):
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_szukaj", side_effect=cbosa.VerificationUnknown("timeout")), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "szukaj", "RODO", "--json", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                cbosa.main()
+        self.assertEqual(out.getvalue(), "")
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value="<html><body>Błąd</body></html>"), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "orzeczenie", "DEADBEEF", "--json", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                cbosa.main()
+        self.assertEqual(out.getvalue(), "")
+
+        out = io.StringIO()
+        with mock.patch.object(cbosa, "_szukaj", return_value=(0, [], "Nie znaleziono")), \
+                mock.patch.object(sys, "argv", ["cbosa.py", "sygnatura", "II", "FSK", "1/24",
+                                                       "--json", "--strict"]), \
+                redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                cbosa.main()
+        self.assertEqual(out.getvalue(), "")
+
+
+class TestT13PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = cbosa.urllib.request.Request("https://orzeczenia.nsa.gov.pl/doc/8889489BE0")
+        handler = cbosa._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://orzeczenia.nsa.gov.pl/doc/8889489BE0")
+        self.assertEqual(nowy.full_url, "https://orzeczenia.nsa.gov.pl/doc/8889489BE0")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/doc/1")
+
+
+class TestZgodaNaObnizenieTls(unittest.TestCase):
+    """Downgrade TLS wymaga jawnej zgody: tresc CBOSA trafia do cytatow w pismach."""
+
+    def setUp(self):
+        cbosa._ostatnie[0] = 0.0
+        cbosa._transport_tls_verified = True
+
+    def tearDown(self):
+        cbosa._transport_tls_verified = True
+
+    class _Odpowiedz:
+        def __init__(self, body=b"<html>OK</html>"):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return self.body
+
+    def _transport(self, zachowanie):
+        """Buduje opener zależny od kontekstu HTTPS i zapisuje kontekst każdej próby."""
+        proby = []
+
+        def build_opener(*handlers):
+            https = next(h for h in handlers if isinstance(h, cbosa.urllib.request.HTTPSHandler))
+            context = https._context
+
+            class _Opener:
+                def open(self, req, timeout=None):
+                    proby.append(context)
+                    return zachowanie(len(proby), context)
+
+            return _Opener()
+
+        return proby, mock.patch.object(cbosa.urllib.request, "build_opener",
+                                        side_effect=build_opener)
+
+    @staticmethod
+    def _blad_certyfikatu():
+        return urllib.error.URLError(ssl.SSLCertVerificationError("certificate verify failed"))
+
+    def test_bez_zgody_konczy_sie_unknown(self):
+        srodowisko = {k: v for k, v in os.environ.items() if k != "CBOSA_INSECURE_TLS"}
+        proby, transport = self._transport(lambda nr, ctx: (_ for _ in ()).throw(
+            self._blad_certyfikatu()))
+        with mock.patch.dict(os.environ, srodowisko, clear=True), transport:
+            with self.assertRaises(cbosa.VerificationUnknown) as ctx:
+                cbosa._fetch("/doc/testowy")
+        komunikat = str(ctx.exception)
+        self.assertIn("certyfikat", komunikat.lower())
+        self.assertIn("CBOSA_INSECURE_TLS", komunikat)
+        self.assertEqual(len(proby), 1)
+
+    def test_bez_zgody_nie_dotyka_kontekstu_ssl(self):
+        srodowisko = {k: v for k, v in os.environ.items() if k != "CBOSA_INSECURE_TLS"}
+        proby, transport = self._transport(lambda nr, ctx: (_ for _ in ()).throw(
+            self._blad_certyfikatu()))
+        with mock.patch.dict(os.environ, srodowisko, clear=True), transport:
+            with self.assertRaises(cbosa.VerificationUnknown):
+                cbosa._fetch("/doc/testowy")
+        self.assertTrue(proby)
+        self.assertTrue(all(ctx.verify_mode != ssl.CERT_NONE for ctx in proby))
+
+    def test_opt_in_przelacza_kontekst_i_realnie_ponawia(self):
+        def zachowanie(nr, context):
+            if context.verify_mode != ssl.CERT_NONE:
+                raise self._blad_certyfikatu()
+            return self._Odpowiedz()
+
+        proby, transport = self._transport(zachowanie)
+        with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
+                transport, mock.patch.object(cbosa.time, "sleep"), redirect_stderr(io.StringIO()):
+            html = cbosa._fetch("/doc/testowy")
+        self.assertIn("OK", html)
+        self.assertEqual(len(proby), 2)
+        self.assertNotEqual(proby[0].verify_mode, ssl.CERT_NONE)
+        self.assertEqual(proby[1].verify_mode, ssl.CERT_NONE)
+        self.assertIsNot(proby[0], proby[1])
+        self.assertFalse(cbosa._transport_tls_verified)
+
+    def test_blad_certyfikatu_w_ostatnim_obiegu_ma_dodatkowa_probe(self):
+        def zachowanie(nr, context):
+            if nr < 5:
+                raise OSError("Remote end closed connection without response")
+            if nr == 5:
+                raise self._blad_certyfikatu()
+            return self._Odpowiedz()
+
+        proby, transport = self._transport(zachowanie)
+        with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
+                transport, mock.patch.object(cbosa.time, "sleep"), redirect_stderr(io.StringIO()):
+            html = cbosa._fetch("/doc/testowy")
+        self.assertIn("OK", html)
+        self.assertEqual(len(proby), 6)
+        self.assertTrue(all(ctx.verify_mode != ssl.CERT_NONE for ctx in proby[:5]))
+        self.assertEqual(proby[5].verify_mode, ssl.CERT_NONE)
+
+    def test_json_niesie_znacznik_nieuwierzytelnionego_transportu(self):
+        body = TestOrzeczenie.HTML.encode("utf-8")
+
+        def zachowanie(nr, context):
+            if context.verify_mode != ssl.CERT_NONE:
+                raise self._blad_certyfikatu()
+            return self._Odpowiedz(body)
+
+        proby, transport = self._transport(zachowanie)
+        args = mock.Mock(doc_id="8889489BE0", json=True, strict=False, fragment=None)
+        stdout = io.StringIO()
+        with mock.patch.dict(os.environ, {"CBOSA_INSECURE_TLS": "1"}, clear=True), \
+                transport, mock.patch.object(cbosa.time, "sleep"), \
+                redirect_stderr(io.StringIO()), redirect_stdout(stdout):
+            cbosa.cmd_orzeczenie(args)
+        wynik = json.loads(stdout.getvalue())
+        self.assertFalse(wynik["transport_tls_verified"])
+        self.assertEqual(len(proby), 2)
+
+    def test_tekst_ma_adnotacje_przy_tresci(self):
+        cbosa._transport_tls_verified = False
+        args = mock.Mock(doc_id="8889489BE0", json=False, strict=False, fragment=None)
+        stdout = io.StringIO()
+        with mock.patch.object(cbosa, "_fetch", return_value=TestOrzeczenie.HTML), \
+                redirect_stdout(stdout):
+            cbosa.cmd_orzeczenie(args)
+        wynik = stdout.getvalue()
+        self.assertIn("transport TLS nie został zweryfikowany", wynik)
+        self.assertLess(wynik.index("transport TLS"), wynik.index("# II FSK"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_eurlex.py
+++ b/tools/test_eurlex.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for eurlex.py pure functions (no network). Run: python3 tools/test_eurlex.py"""
+import argparse
+import json
+import re
+import contextlib
+import io
+import sys
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "eurlex", ROOT / "plugins/prawo-eu-eurlex/skills/prawo-eu-eurlex/scripts/eurlex.py")
+eurlex = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(eurlex)
+
+
+class TestCelexNorm(unittest.TestCase):
+    def test_formy_celex(self):
+        cases = [
+            (["32016R0679"], "32016R0679"),
+            (["celex:32016R0679"], "32016R0679"),
+            (["CELEX: 32024R1689"], "32024R1689"),
+            (["02016R0679-20160504"], "02016R0679-20160504"),
+            (["32016R0679R(02)"], "32016R0679R(02)"),
+            (["12012E/TXT"], "12012E/TXT"),
+            (["12012P/TXT"], "12012P/TXT"),
+            (["12012E016"], "12012E016"),
+            (["32002L0058"], "32002L0058"),
+        ]
+        for sig, want in cases:
+            self.assertEqual(eurlex.celex_norm(sig), want, f"celex: {sig}")
+
+    def test_formy_eli(self):
+        cases = [
+            (["reg/2016/679"], "32016R0679"),
+            (["http://data.europa.eu/eli/reg/2016/679/oj"], "32016R0679"),
+            (["dir/2022/2555"], "32022L2555"),
+            (["dec/2010/87"], "32010D0087"),
+        ]
+        for sig, want in cases:
+            self.assertEqual(eurlex.celex_norm(sig), want, f"eli: {sig}")
+
+    def test_bledny_celex_konczy_program(self):
+        with self.assertRaises(SystemExit):
+            eurlex.celex_norm(["zupełnie błędny identyfikator"])
+        with self.assertRaises(SystemExit):
+            eurlex.celex_norm(["Dz.U. 2024 poz. 18"])  # sygnatura polska → to skill prawo-pl-eli
+
+
+class TestLang(unittest.TestCase):
+    def test_mapowanie(self):
+        self.assertEqual(eurlex._lang("pl"), "POL")
+        self.assertEqual(eurlex._lang("pol"), "POL")
+        self.assertEqual(eurlex._lang("en"), "ENG")
+        self.assertEqual(eurlex._lang(None), "POL")
+        self.assertEqual(eurlex._lang("HUN"), "HUN")  # kod 3-literowy spoza mapy przechodzi
+
+    def test_nieznany_konczy_program(self):
+        with self.assertRaises(SystemExit):
+            eurlex._lang("xx")
+
+
+class TestHtmlToText(unittest.TestCase):
+    def test_normalizes_nbsp(self):
+        self.assertEqual(eurlex.html_to_text("<p>Artykuł\xa028</p>"), "Artykuł 28")
+
+    def test_strips_script(self):
+        t = eurlex.html_to_text("<p>A</p><script>var x=1;</script><p>B</p>")
+        self.assertIn("A", t)
+        self.assertNotIn("var x", t)
+
+
+class TestFragmenty(unittest.TestCase):
+    TXT = ("ROZDZIAŁ I\n\nArtykuł 1\nPrzedmiot.\n\n"
+           "Artykuł 2\n1. Zakres; odesłanie do art. 1 i Artykuł 28 nie na początku linii.\n\n"
+           "Artykuł 28\nPodmiot przetwarzający.\n\n"
+           "Artykuł 281\nPrzepis o dłuższym numerze.\n")
+
+    def _frag(self, fraza):
+        spans = eurlex._fragmenty(self.TXT, fraza)
+        return [self.TXT[s:e] for s, e in spans]
+
+    def test_artykul_po_naglowku_nie_po_odeslaniu(self):
+        frags = self._frag("art. 28")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("Podmiot przetwarzający", frags[0])
+        self.assertNotIn("Zakres", frags[0])
+
+    def test_artykul_nie_lapie_dluzszego_numeru(self):
+        frags = self._frag("artykuł 2")
+        self.assertEqual(len(frags), 1)
+        self.assertIn("Zakres", frags[0])
+        self.assertNotIn("dłuższym", frags[0])
+
+    def test_fraza_pelnotekstowa(self):
+        frags = self._frag("podmiot przetwarzający")
+        self.assertEqual(len(frags), 1)
+        self.assertTrue(frags[0].startswith("Artykuł 28"))
+
+    def test_brak_trafien(self):
+        self.assertEqual(eurlex._fragmenty(self.TXT, "nie ma takiej frazy"), [])
+
+    def test_odeslanie_na_poczatku_linii_nie_jest_naglowkiem(self):
+        # AI Act art. 113 lit. c (EN): „Article 6(1) and the corresponding obligations … shall apply
+        # from 2 August 2027." — linia zaczyna się od „Article 6", ale nagłówkiem nie jest
+        txt = ("Article 113\nEntry into force and application\n(c)\n"
+               "Article 6(1) and the corresponding obligations in this Regulation shall apply from 2 August 2027.\n"
+               "Done at Brussels, 13 June 2024.\n")
+        spans = eurlex._fragmenty(txt, "art. 113")
+        frag = txt[spans[0][0]:spans[0][1]]
+        self.assertIn("2 August 2027", frag)
+        self.assertNotIn("Done at", frag)
+        self.assertEqual(eurlex._fragmenty(txt, "art. 6"), [])  # odesłanie to nie trafienie w art. 6
+
+
+class TestGraniceOstatniegoArtykulu(unittest.TestCase):
+    """Fragment OSTATNIEGO artykułu nie może ciągnąć za sobą podpisów i przypisów końcowych
+    (RODO art. 99: 21 przypisów, AI Act art. 113: 58) — audyt D04/C17."""
+
+    XHTML = ("<div><p>Artykuł 98</p><p>Przepis przedostatni.</p></div>"
+             "<div id=\"art_99\"><p class=\"oj-ti-art\">Artykuł 99</p>"
+             "<p class=\"oj-normal\">1. Niniejsze rozporządzenie wchodzi w życie.</p></div>"
+             "<div class=\"oj-final\"><p class=\"oj-normal\">Niniejsze rozporządzenie wiąże w całości.</p>"
+             "<p class=\"oj-normal\">Sporządzono w Brukseli dnia 27 kwietnia 2016 r.</p>"
+             "<div class=\"oj-signatory\"><p class=\"oj-signatory\">W imieniu Parlamentu Europejskiego</p>"
+             "<p class=\"oj-signatory\">M. SCHULZ</p></div></div>"
+             "<hr class=\"oj-note\"/><p class=\"oj-note\">(1) Dz.U. C 229 z 31.7.2012, s. 90.</p>"
+             "<p class=\"oj-note\">(2) Stanowisko Parlamentu Europejskiego z dnia 12 marca 2014 r.</p>")
+
+    def test_xhtml_aktu_bazowego_daje_znak_granicy_przed_podpisami_i_przypisami(self):
+        txt = eurlex.html_to_text(self.XHTML)
+        self.assertIn(eurlex.GRANICA, txt)
+        spans = eurlex._fragmenty(txt, "art. 99")
+        self.assertEqual(len(spans), 1)
+        frag = eurlex._bez_granic(txt[spans[0][0]:spans[0][1]])
+        self.assertIn("wchodzi w życie", frag)
+        self.assertIn("wiąże w całości", frag)  # formuła końcowa zostaje przy ostatnim artykule
+        for zbedne in ("Sporządzono", "W imieniu", "SCHULZ", "Dz.U. C 229", "Stanowisko"):
+            self.assertNotIn(zbedne, frag)
+        self.assertNotIn(eurlex.GRANICA, frag)
+
+    def test_xhtml_wersji_skonsolidowanej_przypisy_klasa_footnote(self):
+        xhtml = ("<p class=\"title-article-norm\">Artykuł 99</p><p class=\"norm\">Treść.</p>"
+                 "<hr class=\"separator-short\"/>"
+                 "<p class=\"footnote\">(1) Dyrektywa (UE) 2015/1535 (Dz.U. L 241 z 17.9.2015, s. 1).</p>")
+        txt = eurlex.html_to_text(xhtml)
+        spans = eurlex._fragmenty(txt, "art. 99")
+        frag = eurlex._bez_granic(txt[spans[0][0]:spans[0][1]])
+        self.assertIn("Treść.", frag)
+        self.assertNotIn("2015/1535", frag)
+
+    def test_granice_tekstowe_bez_znacznikow(self):
+        # zapas, gdyby XHTML nie miał klas: „Sporządzono w", „W imieniu …", „(1) Dz.U." kończą jednostkę
+        for ogon in ("Sporządzono w Brukseli dnia 1 maja 2020 r.\nX\n",
+                     "W imieniu Rady\nJ. KOWALSKI\n",
+                     "Done at Brussels, 13 June 2024.\n",
+                     "For the European Parliament\nThe President\n",
+                     "(1) Dz.U. C 229 z 31.7.2012, s. 90.\n(2) Dz.U. L 1.\n",
+                     "(1) OJ C 229, 31.7.2012, p. 90.\n"):
+            with self.subTest(ogon=ogon):
+                txt = "Artykuł 5\nTreść piąta.\n\n" + ogon
+                spans = eurlex._fragmenty(txt, "art. 5")
+                frag = txt[spans[0][0]:spans[0][1]]
+                self.assertIn("Treść piąta", frag)
+                self.assertNotIn(ogon.splitlines()[0], frag)
+
+    def test_punkt_aktu_zmieniajacego_po_angielsku_nie_jest_granica(self):
+        # w aktach zmieniających (EN) punkty to „(1) Article 5 is replaced…" — to NIE przypis
+        txt = "Article 1\nRegulation X is amended as follows:\n(1) Article 5 is replaced by the following;\n(2) Article 6 is deleted.\n\nArticle 2\nEntry into force.\n"
+        spans = eurlex._fragmenty(txt, "art. 1")
+        frag = txt[spans[0][0]:spans[0][1]]
+        self.assertIn("Article 6 is deleted", frag)
+        self.assertNotIn("Entry into force", frag)
+
+    def test_fraza_z_przypisu_daje_sam_przypis(self):
+        txt = eurlex.html_to_text(self.XHTML)
+        spans = eurlex._fragmenty(txt, "Dz.U. C 229")
+        frag = eurlex._bez_granic(txt[spans[0][0]:spans[0][1]]).strip()
+        self.assertTrue(frag.startswith("(1)"), frag)
+        self.assertNotIn("Artykuł 99", frag)
+
+    def test_cmd_tekst_nie_wypisuje_znaku_granicy(self):
+        out = io.StringIO()
+        for fragment in ("art. 99", None):
+            with self.subTest(fragment=fragment):
+                out = io.StringIO()
+                args = argparse.Namespace(celex=["32016R0679"], jezyk="pol", json=False,
+                                          strict=False, pdf=None, fragment=fragment)
+                with mock.patch.object(eurlex, "_http", return_value=(self.XHTML.encode(), "text/html")), \
+                        mock.patch.object(eurlex, "_konsolidacje", return_value=[]), \
+                        contextlib.redirect_stdout(out):
+                    eurlex.cmd_tekst(args)
+                self.assertNotIn(eurlex.GRANICA, out.getvalue())
+                self.assertIn("wchodzi w życie", out.getvalue())
+                if fragment:
+                    self.assertNotIn("SCHULZ", out.getvalue())
+                else:
+                    self.assertIn("SCHULZ", out.getvalue())  # pełny tekst: nic nie ginie
+
+
+class TestKonsolidacje(unittest.TestCase):
+    """_konsolidacje buduje prefiks i filtruje wyniki SPARQL (podmieniamy _sparql)."""
+
+    def _z_fake_sparql(self, rows, celex):
+        zapytania = []
+
+        def fake_sparql(q, soft=False):
+            zapytania.append(q)
+            return rows
+        orig = eurlex._sparql
+        eurlex._sparql = fake_sparql
+        try:
+            return eurlex._konsolidacje(celex), zapytania
+        finally:
+            eurlex._sparql = orig
+
+    def test_prefiks_z_aktu_bazowego(self):
+        rows = [{"celex": {"value": "02016R0679-20160504"}}]
+        wynik, zapytania = self._z_fake_sparql(rows, "32016R0679")
+        self.assertEqual(wynik, ["02016R0679-20160504"])
+        self.assertIn('"02016R0679-"', zapytania[0])
+
+    def test_prefiks_z_wersji_skonsolidowanej(self):
+        _, zapytania = self._z_fake_sparql([], "02006L0112-20240101")
+        self.assertIn('"02006L0112-"', zapytania[0])
+
+    def test_odfiltrowuje_celexy_bez_daty(self):
+        rows = [{"celex": {"value": "02016R0679-20160504"}},
+                {"celex": {"value": "02016R0679(01)"}}]
+        wynik, _ = self._z_fake_sparql(rows, "32016R0679")
+        self.assertEqual(wynik, ["02016R0679-20160504"])
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj", "fraza"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, eurlex.cmd_szukaj
+        eurlex.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            eurlex.main()
+        finally:
+            sys.argv, eurlex.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
+
+class EurlexVerificationContractTests(unittest.TestCase):
+    """found/verified_absent/unknown - blad transportu nie moze wygladac jak potwierdzony brak."""
+
+    def test_soft_transport_error_is_unknown(self):
+        with mock.patch.object(eurlex, "_http", side_effect=SystemExit("BŁĄD sieci")):
+            with self.assertRaises(eurlex.VerificationUnknown):
+                eurlex._sparql("SELECT * WHERE {}", soft=True)
+
+    def test_successful_zero_consolidations_is_verified_absent(self):
+        with mock.patch.object(eurlex, "_sparql", return_value=[]):
+            self.assertEqual(eurlex._konsolidacje("32016R0679"), [])
+
+    def test_command_reports_unknown_consolidations(self):
+        args = argparse.Namespace(celex=["32016R0679"], json=False)
+        with mock.patch.object(eurlex, "_konsolidacje",
+                               side_effect=eurlex.VerificationUnknown("timeout")):
+            with self.assertRaisesRegex(SystemExit, "nie udało się zweryfikować.*Spróbuj ponownie"):
+                eurlex.cmd_skonsolidowany(args)
+
+    def test_ostrzezenia_przy_tekscie_nie_blokuja_tresci(self):
+        # przy tekście/meta konsolidacje to informacja POBOCZNA — awaria SPARQL daje
+        # głośne ostrzeżenie zamiast odebrać użytkownikowi treść główną
+        with mock.patch.object(eurlex, "_konsolidacje",
+                               side_effect=eurlex.VerificationUnknown("timeout")):
+            out = eurlex._ostrzezenia_konsolidacja("32016R0679")
+        self.assertEqual(len(out), 1)
+        self.assertIn("nie udało się zweryfikować", out[0])
+        self.assertIn("skonsolidowany 32016R0679", out[0])
+
+    def test_strict_blokuje_wynik_przy_awarii_kontroli_konsolidacji(self):
+        with mock.patch.object(eurlex, "_konsolidacje",
+                               side_effect=eurlex.VerificationUnknown("timeout")):
+            with self.assertRaisesRegex(eurlex.VerificationUnknown, "timeout"):
+                eurlex._ostrzezenia_konsolidacja("32016R0679", strict=True)
+
+    def test_strict_nie_wypisuje_tekstu_przed_kontrola_konsolidacji(self):
+        args = argparse.Namespace(celex=["32016R0679"], jezyk="pol", json=False,
+                                  strict=True, pdf=None, fragment=None)
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_http", return_value=(b"<p>Artykul 1. Tresc.</p>", "text/html")), \
+                mock.patch.object(eurlex, "_konsolidacje",
+                                  side_effect=eurlex.VerificationUnknown("timeout")), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(eurlex.VerificationUnknown, "timeout"):
+                eurlex.cmd_tekst(args)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t05_strict_blokuje_poprawnie_wykryta_nowsza_konsolidacje(self):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_http",
+                               return_value=(b"<p>Artykul 1. Starsza tresc.</p>", "text/html")), \
+                mock.patch.object(eurlex, "_konsolidacje",
+                                  return_value=["02016R0679-20250504", "02016R0679-20160504"]), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "tekst", "02016R0679-20160504", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eurlex.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_t06_json_strict_nie_emituje_danych_gdy_kontrola_nie_przeszla(self):
+        komendy = [
+            ["szukaj", "dane"],
+            ["meta", "32016R0679"],
+            ["tekst", "32016R0679"],
+            ["skonsolidowany", "32016R0679"],
+            ["odniesienia", "32016R0679"],
+        ]
+        for komenda in komendy:
+            with self.subTest(komenda=komenda):
+                out = io.StringIO()
+                with mock.patch.object(eurlex, "_http",
+                                       return_value=(b"<p>Artykul 1. Tresc.</p>", "text/html")), \
+                        mock.patch.object(eurlex, "_sparql",
+                                          side_effect=eurlex.VerificationUnknown("timeout")), \
+                        mock.patch.object(sys, "argv",
+                                          ["eurlex.py", *komenda, "--json", "--strict"]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        eurlex.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertEqual(out.getvalue(), "")
+
+
+class TestT12StrictMetaAktuBazowego(unittest.TestCase):
+    """Metadane aktu bazowego nie są nieaktualne przez to, że istnieje konsolidacja — strict
+    blokuje tam tylko AWARIĘ kontroli; treść (tekst) aktu bazowego z konsolidacjami blokuje."""
+    WIERSZ = [{"type": {"value": "http://publications.europa.eu/resource/authority/resource-type/REG"},
+               "date": {"value": "2016-04-27"}, "inf": {"value": "2016-05-24"},
+               "title": {"value": "Rozporządzenie 2016/679"}}]
+
+    def test_meta_strict_z_konsolidacja_przechodzi_z_ostrzezeniem(self):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_sparql", return_value=self.WIERSZ), \
+                mock.patch.object(eurlex, "_konsolidacje", return_value=["02016R0679-20160504"]), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "meta", "32016R0679", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            eurlex.main()
+        self.assertIn("Akt: CELEX 32016R0679", out.getvalue())
+        self.assertIn("użyj najnowszej: 02016R0679-20160504", out.getvalue())
+
+    def test_meta_strict_awaria_kontroli_blokuje_bez_stdout(self):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_sparql", return_value=self.WIERSZ), \
+                mock.patch.object(eurlex, "_konsolidacje",
+                                  side_effect=eurlex.VerificationUnknown("timeout")), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "meta", "32016R0679", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as caught:
+                eurlex.main()
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+    def test_tekst_aktu_bazowego_z_konsolidacja_strict_blokuje_i_wskazuje_wersje(self):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_http", return_value=(b"<p>Artykul 1.</p>", "text/html")), \
+                mock.patch.object(eurlex, "_konsolidacje", return_value=["02016R0679-20160504"]), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "tekst", "32016R0679", "--strict"]), \
+                contextlib.redirect_stdout(out):
+            with self.assertRaisesRegex(SystemExit, "tekst 02016R0679-20160504"):
+                eurlex.main()
+        self.assertEqual(out.getvalue(), "")
+
+
+def _lit(v):
+    return {"type": "literal", "value": v}
+
+
+def _wiersz(**kw):
+    return {k: _lit(v) for k, v in kw.items()}
+
+
+TYP = "http://publications.europa.eu/resource/authority/resource-type/"
+
+
+class _FakeCellar:
+    """Podmiana _sparql rozpoznająca zapytania po CELEX-ie w literale i po właściwości.
+
+    meta: {celex: [wiersze]}; zmiany: {celex: [celexy aktów zmieniających]} — brak klucza = []."""
+
+    def __init__(self, meta, zmiany=None, awaria_zmian=False):
+        self.meta, self.zmiany, self.awaria_zmian = meta, zmiany or {}, awaria_zmian
+        self.zapytania = []
+
+    def __call__(self, q, soft=False):
+        self.zapytania.append(q)
+        m = re.search(r'resource_legal_id_celex "([^"]+)"', q)
+        celex = m.group(1) if m else None
+        if "resource_legal_amends_resource_legal ?w" in q and "BIND" not in q:
+            if self.awaria_zmian:
+                raise eurlex.VerificationUnknown("timeout")
+            return [_wiersz(c2=c) for c in self.zmiany.get(celex, [])]
+        return self.meta.get(celex, [])
+
+
+class TestSzukajZeroTrafien(unittest.TestCase):
+    """SKILL.md: zero trafień = komunikat + kod wyjścia ≠ 0 TAKŻE z --json (audyt D06/C18)."""
+
+    def test_zero_z_json_i_bez(self):
+        for argv in (["szukaj", "dane osobowe", "--typ", "REG"],
+                     ["szukaj", "dane osobowe", "--typ", "REG", "--json"],
+                     ["--json", "szukaj", "dane osobowe"]):
+            with self.subTest(argv=argv):
+                out = io.StringIO()
+                with mock.patch.object(eurlex, "_sparql", return_value=[]), \
+                        mock.patch.object(sys, "argv", ["eurlex.py", *argv]), \
+                        contextlib.redirect_stdout(out):
+                    with self.assertRaises(SystemExit) as caught:
+                        eurlex.main()
+                self.assertNotEqual(caught.exception.code, 0)
+                self.assertIn("To NIE dowód", str(caught.exception.code))
+                self.assertEqual(out.getvalue(), "")  # żadnego „[]"
+
+
+class TestMetaWersjaSkonsolidowana(unittest.TestCase):
+    """meta na CELEX-ie skonsolidowanym: data „stan na" osobno, daty z AKTU BAZOWEGO (audyt D03/C16)."""
+
+    KONS = "02016R0679-20160504"
+    BAZA = "32016R0679"
+    META = {
+        KONS: [_wiersz(type=TYP + "CONS_TEXT", date="2016-05-04", eiv="2016-05-04",
+                       kons_data="2016-05-04", baza=BAZA, sklad=BAZA, title="Tytuł RODO"),
+               _wiersz(type=TYP + "CONS_TEXT", date="2016-05-04", eiv="2016-05-04",
+                       kons_data="2016-05-04", baza=BAZA, sklad=BAZA + "R(01)", title="Tytuł RODO")],
+        BAZA: [_wiersz(type=TYP + "REG", date="2016-04-27", eiv="2016-05-24", inf="1",
+                       eli="http://data.europa.eu/eli/reg/2016/679/oj", title="Tytuł RODO"),
+               _wiersz(type=TYP + "REG", date="2016-04-27", eiv="2018-05-25", inf="1",
+                       eli="http://data.europa.eu/eli/reg/2016/679/oj", title="Tytuł RODO")],
+    }
+
+    def _meta(self, celex, strict=False, zmiany=None, kons=None, json_=False, awaria=False):
+        out = io.StringIO()
+        fake = _FakeCellar(self.META, zmiany, awaria_zmian=awaria)
+        argv = ["eurlex.py", "meta", celex] + (["--strict"] if strict else []) + (["--json"] if json_ else [])
+        with mock.patch.object(eurlex, "_sparql", fake), \
+                mock.patch.object(eurlex, "_konsolidacje", return_value=kons if kons is not None else [self.KONS]), \
+                mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(out):
+            eurlex.main()
+        return out.getvalue()
+
+    def test_stan_na_i_daty_aktu_bazowego(self):
+        out = self._meta(self.KONS)
+        self.assertIn("Stan na (konsolidacja): 2016-05-04", out)
+        self.assertIn("Akt bazowy: CELEX 32016R0679", out)
+        self.assertIn("Data aktu: 2016-04-27", out)
+        self.assertIn("Wejście w życie / stosowanie: 2016-05-24, 2018-05-25", out)
+        self.assertIn("Uwzględnia: 32016R0679, 32016R0679R(01)", out)
+        self.assertIn("Status:  OBOWIĄZUJE", out)
+        self.assertNotIn("Data aktu: 2016-05-04", out)
+        self.assertNotIn("WEJŚCIE W ŻYCIE / STOSOWANIE", out)
+
+    def test_json_ma_akt_bazowy_i_ostrzezenia(self):
+        d = json.loads(self._meta(self.KONS, json_=True))
+        self.assertTrue(d["wersja_skonsolidowana"])
+        self.assertEqual(d["akt_bazowy"]["celex"], self.BAZA)
+        self.assertEqual(d["akt_bazowy"]["meta"]["eiv"], ["2016-05-24", "2018-05-25"])
+        self.assertEqual(d["zmieniajace"], [])
+        self.assertTrue(any("DOKUMENTACYJNY" in w for w in d["ostrzezenia"]))
+
+    def test_akt_bazowy_bez_zmian_nie_ma_ostrzezenia_o_zmianach(self):
+        out = self._meta(self.BAZA)
+        self.assertIn("Wejście w życie / stosowanie: 2016-05-24, 2018-05-25", out)
+        self.assertNotIn("był zmieniany", out)
+
+    def test_awaria_kontroli_zmian_bez_strict_ostrzega(self):
+        out = self._meta(self.BAZA, awaria=True)
+        self.assertIn("nie udało się zweryfikować, czy akt 32016R0679 był zmieniany", out)
+
+    def test_awaria_kontroli_zmian_w_strict_blokuje(self):
+        with self.assertRaises((SystemExit, eurlex.VerificationUnknown)):
+            self._meta(self.BAZA, strict=True, awaria=True)
+
+
+AI_BAZA, AI_KONS, AI_ZM = "32024R1689", "02024R1689-20260727", "32026R1744"
+
+
+class TestMetaAktZmieniany(unittest.TestCase):
+    """Daty stosowania aktu bazowego po nowelizacji mogą być nieaktualne (AI Act art. 113 po
+    32026R1744) — ostrzeżenie zawsze, w --strict blokada aktu bazowego (audyt D02/C08)."""
+
+    BAZA, KONS, ZM = AI_BAZA, AI_KONS, AI_ZM
+    META = {
+        AI_BAZA: [_wiersz(type=TYP + "REG", date="2024-06-13", eiv=d, inf="1", title="AI Act")
+                  for d in ("2024-08-01", "2025-02-02", "2025-08-02", "2026-08-02", "2027-08-02")],
+        AI_KONS: [_wiersz(type=TYP + "CONS_TEXT", date="2026-07-27", eiv="2026-07-27",
+                          kons_data="2026-07-27", baza=AI_BAZA, sklad=s, title="AI Act")
+                  for s in (AI_BAZA, AI_ZM)],
+        "02024R1689-20240712": [_wiersz(type=TYP + "CONS_TEXT", date="2024-07-12", eiv="2024-07-12",
+                                        kons_data="2024-07-12", baza=AI_BAZA, sklad=AI_BAZA, title="AI Act")],
+    }
+
+    def _meta(self, celex, strict=False, zmiany=None, kons=None):
+        out = io.StringIO()
+        fake = _FakeCellar(self.META, zmiany if zmiany is not None else {self.BAZA: [self.ZM]})
+        argv = ["eurlex.py", "meta", celex] + (["--strict"] if strict else [])
+        with mock.patch.object(eurlex, "_sparql", fake), \
+                mock.patch.object(eurlex, "_konsolidacje",
+                                  return_value=kons if kons is not None else [self.KONS, "02024R1689-20240712"]), \
+                mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(out):
+            eurlex.main()
+        return out.getvalue()
+
+    def test_bez_strict_ostrzezenie_wskazuje_akt_zmieniajacy_i_najnowsza_konsolidacje(self):
+        out = self._meta(self.BAZA)
+        self.assertIn("2027-08-02", out)
+        self.assertRegex(out, r"UWAGA: akt 32024R1689 był zmieniany \(32026R1744\).*mogą być nieaktualne")
+        self.assertIn("najnowszej wersji skonsolidowanej 02024R1689-20260727", out)
+
+    def test_strict_blokuje_akt_bazowy_po_nowelizacji_bez_stdout(self):
+        with self.assertRaises(SystemExit) as caught:
+            self._meta(self.BAZA, strict=True)
+        msg = str(caught.exception.code)
+        self.assertNotEqual(caught.exception.code, 0)
+        self.assertIn("32026R1744", msg)
+        self.assertIn("meta 02024R1689-20260727", msg)
+        self.assertIn("art. o stosowaniu", msg)
+
+    def test_strict_same_sprostowania_nie_blokuja(self):
+        out = self._meta(self.BAZA, strict=True, zmiany={})
+        self.assertIn("Akt: CELEX 32024R1689", out)
+        self.assertNotIn("był zmieniany", out)
+
+    def test_strict_najnowsza_konsolidacja_przechodzi_z_ostrzezeniem(self):
+        out = self._meta(self.KONS, strict=True)
+        self.assertIn("Stan na (konsolidacja): 2026-07-27", out)
+        self.assertIn("Uwzględnia: 32024R1689, 32026R1744", out)
+        self.assertIn("był zmieniany (32026R1744)", out)
+
+    def test_strict_starsza_konsolidacja_blokuje(self):
+        with self.assertRaisesRegex(SystemExit, "nowsza wersja skonsolidowana: 02024R1689-20260727"):
+            self._meta("02024R1689-20240712", strict=True)
+
+
+class TestMetaDyrektywaIEtykiety(unittest.TestCase):
+    """Dyrektywa: termin(y) transpozycji; jedna data = „Wejście w życie", nie łączona etykieta
+    (audyt D05/C10). Tytuł bez ucięcia na 300 znakach (D08/C22)."""
+
+    TYTUL = "Dyrektywa " + "bardzo długa nazwa " * 25 + "(Tekst mający znaczenie dla EOG)"
+
+    def _meta(self, celex, rows):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_sparql", _FakeCellar({celex: rows})), \
+                mock.patch.object(eurlex, "_konsolidacje", return_value=[]), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "meta", celex]), \
+                contextlib.redirect_stdout(out):
+            eurlex.main()
+        return out.getvalue()
+
+    def test_dyrektywa_dwa_terminy_transpozycji(self):
+        rows = [_wiersz(type=TYP + "DIR", date="2019-10-23", eiv="2019-12-16", inf="1", trans=t,
+                        title="Dyrektywa 2019/1937") for t in ("2021-12-17", "2023-12-17")]
+        out = self._meta("32019L1937", rows)
+        self.assertIn("Wejście w życie: 2019-12-16", out)
+        self.assertIn("Termin transpozycji: 2021-12-17, 2023-12-17", out)
+        self.assertIn("prawo-pl-eli", out)
+        self.assertNotIn("STOSOWANIE", out)
+
+    def test_dyrektywa_bez_terminu_w_cellar_mowi_to_wprost(self):
+        out = self._meta("31999L0001", [_wiersz(type=TYP + "DIR", date="1999-01-01", eiv="1999-02-01", inf="0")])
+        self.assertIn("Termin transpozycji: brak w CELLAR", out)
+
+    def test_rozporzadzenie_jedna_data_to_wejscie_w_zycie(self):
+        out = self._meta("32020R0001", [_wiersz(type=TYP + "REG", date="2020-01-01", eiv="2020-01-21", inf="1")])
+        self.assertIn("Wejście w życie: 2020-01-21", out)
+        self.assertNotIn("stosowanie", out.lower().split("tekst:")[0].split("wejście w życie:")[1].split("\n")[0])
+
+    def test_tytul_w_calosci(self):
+        assert len(self.TYTUL) > 300
+        out = self._meta("32019L1937", [_wiersz(type=TYP + "DIR", date="2019-10-23", title=self.TYTUL)])
+        self.assertEqual(re.sub(r"\s+", " ", out.split("Tytuł:")[1].split("Typ:")[0]).strip(), self.TYTUL)
+
+
+class TestOdniesieniaUchylenia(unittest.TestCase):
+    """Relacje uchylenia w obie strony + jasny status NIE OBOWIĄZUJE (audyt D01/C06)."""
+
+    def _odn(self, celex, rows):
+        out = io.StringIO()
+        with mock.patch.object(eurlex, "_sparql", return_value=rows), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "odniesienia", celex]), \
+                contextlib.redirect_stdout(out):
+            eurlex.main()
+        return out.getvalue()
+
+    def test_zapytanie_pyta_o_uchylenia_w_obie_strony(self):
+        fake = _FakeCellar({})
+        with mock.patch.object(eurlex, "_sparql", fake), \
+                mock.patch.object(sys, "argv", ["eurlex.py", "odniesienia", "31995L0046"]), \
+                contextlib.redirect_stdout(io.StringIO()):
+            eurlex.main()
+        q = fake.zapytania[0]
+        self.assertIn("?x cdm:resource_legal_repeals_resource_legal ?w", q)
+        self.assertIn("?w cdm:resource_legal_repeals_resource_legal ?o", q)
+        self.assertIn("resource_legal_implicitly_repeals_resource_legal", q)
+
+    def test_uchylony_przez_rodo(self):
+        rows = [_wiersz(kier=eurlex._KIERUNKI[0], c2="32016R0679", inf="0", eov="2018-05-24"),
+                _wiersz(kier=eurlex._KIERUNKI[2], c2="32003R1882", inf="0", eov="2018-05-24")]
+        out = self._odn("31995L0046", rows)
+        self.assertIn("AKT UCHYLONY przez 32016R0679 (koniec obowiązywania: 2018-05-24) — NIE OBOWIĄZUJE", out)
+        self.assertIn("## UCHYLONY PRZEZ", out)
+        self.assertNotIn("aktualny stan czytaj z wersji skonsolidowanej", out)
+
+    def test_rodo_uchyla_95_46(self):
+        rows = [_wiersz(kier=eurlex._KIERUNKI[4], c2="31995L0046", inf="1", eov="9999-12-31"),
+                _wiersz(kier=eurlex._KIERUNKI[5], c2="32003R1882", inf="1", eov="9999-12-31"),
+                _wiersz(kier=eurlex._KIERUNKI[3], c2="32016R0679R(01)", inf="1", eov="9999-12-31")]
+        out = self._odn("32016R0679", rows)
+        self.assertIn("## Uchyla (akty uchylone przez ten akt)  (1)\n  - 31995L0046", out)
+        self.assertIn("## Uchyla w sposób dorozumiany", out)
+        self.assertNotIn("NIE OBOWIĄZUJE", out)
+
+
+class TestTekst404Konsolidacji(unittest.TestCase):
+    """404 na wersji skonsolidowanej z listy skonsolidowany: CELLAR nie serwuje wersji zastąpionej —
+    nie każ „sprawdzać numeru CELEX" (audyt D07/C21)."""
+
+    def _tekst(self, celex, kons):
+        args = argparse.Namespace(celex=[celex], jezyk="pol", json=False, strict=False, pdf=None,
+                                  fragment="art. 5")
+        blad = SystemExit(f"BŁĄD: nie znaleziono zasobu (404): https://publications.europa.eu/resource/celex/{celex}\n"
+                          "Sprawdź numer CELEX")
+        with mock.patch.object(eurlex, "_http", side_effect=blad), \
+                mock.patch.object(eurlex, "_konsolidacje", **kons), \
+                contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(SystemExit) as caught:
+                eurlex.cmd_tekst(args)
+        return str(caught.exception.code)
+
+    def test_wersja_zastapiona(self):
+        msg = self._tekst("02024R1689-20240712", dict(return_value=["02024R1689-20260727", "02024R1689-20240712"]))
+        self.assertIn("nie udostępnia już tekstu wersji skonsolidowanej 02024R1689-20240712", msg)
+        self.assertIn("Najnowsza wersja: 02024R1689-20260727", msg)
+        self.assertNotIn("Sprawdź numer CELEX", msg)
+
+    def test_najnowsza_wersja_bez_tekstu_w_jezyku(self):
+        msg = self._tekst("02024R1689-20260727", dict(return_value=["02024R1689-20260727"]))
+        self.assertIn("najnowszej wersji skonsolidowanej 02024R1689-20260727 w języku pol", msg)
+
+    def test_nieznana_wersja(self):
+        msg = self._tekst("02024R1689-20990101", dict(return_value=["02024R1689-20260727"]))
+        self.assertIn("nie zna wersji skonsolidowanej 02024R1689-20990101", msg)
+
+    def test_awaria_listy_wersji_nie_udaje_pewnosci(self):
+        msg = self._tekst("02024R1689-20240712", dict(side_effect=eurlex.VerificationUnknown("timeout")))
+        self.assertIn("nie udało się zweryfikować", msg)
+
+    def test_akt_bazowy_404_zostaje_generyczny(self):
+        args = argparse.Namespace(celex=["39999R9999"], jezyk="pol", json=False, strict=False, pdf=None, fragment=None)
+        with mock.patch.object(eurlex, "_http", side_effect=SystemExit("BŁĄD: nie znaleziono zasobu (404): x")):
+            with self.assertRaisesRegex(SystemExit, "nie znaleziono zasobu"):
+                eurlex.cmd_tekst(args)
+
+
+class TestT07WymusHttps(unittest.TestCase):
+    """CELLAR nazywa zasoby przez http:// URI, ale pobierac mamy po https."""
+
+    def test_dziewiec_przypadkow_url(self):
+        cases = [
+            ("http://publications.europa.eu/resource/celex/X?x=1#f",
+             "https://publications.europa.eu/resource/celex/X?x=1#f"),
+            ("http://notreally-europa.eu/resource/celex/X",
+             "http://notreally-europa.eu/resource/celex/X"),
+            ("http://publications.europa.eu@notreally-europa.eu/resource/celex/X",
+             "http://publications.europa.eu@notreally-europa.eu/resource/celex/X"),
+            ("http://PUBLICATIONS.EUROPA.EU/resource/celex/X",
+             "https://PUBLICATIONS.EUROPA.EU/resource/celex/X"),
+            ("HTTP://publications.europa.eu/resource/celex/X",
+             "https://publications.europa.eu/resource/celex/X"),
+            ("http://publications.europa.eu./resource/celex/X",
+             "https://publications.europa.eu./resource/celex/X"),
+            ("http://publications.europa.eu:443/resource/celex/X",
+             "https://publications.europa.eu:443/resource/celex/X"),
+            ("http://publications.europa.eu:8080/resource/celex/X",
+             "https://publications.europa.eu:8080/resource/celex/X"),
+            ("http://api.publications.europa.eu/resource/celex/X",
+             "https://api.publications.europa.eu/resource/celex/X"),
+        ]
+        for url, expected in cases:
+            with self.subTest(url=url):
+                self.assertEqual(eurlex._wymus_https(url), expected)
+
+    def test_nie_daje_sie_nabrac_na_nadhosta(self):
+        url = "http://publications.europa.eu.evil.example/resource/celex/X"
+        self.assertEqual(eurlex._wymus_https(url), url)
+
+    def test_data_europa_i_poddomena_sa_na_bialej_liscie(self):
+        cases = [
+            ("http://data.europa.eu/eli/reg/2016/679/oj",
+             "https://data.europa.eu/eli/reg/2016/679/oj"),
+            ("http://api.data.europa.eu/eli/reg/2016/679/oj",
+             "https://api.data.europa.eu/eli/reg/2016/679/oj"),
+        ]
+        for url, expected in cases:
+            with self.subTest(url=url):
+                self.assertEqual(eurlex._wymus_https(url), expected)
+
+    def test_http_przekazuje_request_z_podniesionym_url(self):
+        odpowiedz = mock.MagicMock()
+        odpowiedz.__enter__.return_value = odpowiedz
+        odpowiedz.read.return_value = b"OK"
+        odpowiedz.headers.get.return_value = "text/plain"
+        with mock.patch.object(eurlex._opener, "open", return_value=odpowiedz) as otworz:
+            eurlex._http("http://publications.europa.eu/resource/celex/X")
+        request = otworz.call_args.args[0]
+        self.assertEqual(request.full_url, "https://publications.europa.eu/resource/celex/X")
+
+    def test_przekierowanie_303_na_http_cellar_jest_podnoszone(self):
+        # CELLAR odpowiada 303 z Location http:// nawet na żądanie https — bez podniesienia
+        # schematu w celu przekierowania treść i tak popłynęłaby czystym HTTP.
+        req = eurlex.urllib.request.Request("https://publications.europa.eu/resource/celex/X")
+        nowy = eurlex._PrzekierowaniaHttps().redirect_request(
+            req, None, 303, "See Other", {},
+            "http://publications.europa.eu/resource/cellar/abc.0018.03/DOC_1")
+        self.assertEqual(nowy.full_url,
+                         "https://publications.europa.eu/resource/cellar/abc.0018.03/DOC_1")
+
+    def test_przekierowanie_303_na_http_data_europa_jest_podnoszone(self):
+        req = eurlex.urllib.request.Request("https://publications.europa.eu/resource/celex/X")
+        nowy = eurlex._PrzekierowaniaHttps().redirect_request(
+            req, None, 303, "See Other", {}, "http://data.europa.eu/eli/reg/2016/679/oj")
+        self.assertEqual(nowy.full_url, "https://data.europa.eu/eli/reg/2016/679/oj")
+
+    def test_przekierowanie_na_obcy_host_po_http_jest_odrzucone(self):
+        req = eurlex.urllib.request.Request("https://publications.europa.eu/resource/celex/X")
+        with self.assertRaisesRegex(eurlex.urllib.error.URLError,
+                                    "odrzucono przekierowanie.*niezaufany host"):
+            eurlex._PrzekierowaniaHttps().redirect_request(
+                req, None, 303, "See Other", {}, "http://example.test/legal-content")
+
+    def test_uri_przestrzeni_nazw_zostaja_http(self):
+        # Zmiana ich postaci zerwalaby dopasowanie w zapytaniach SPARQL.
+        for stala in (eurlex.CDM, eurlex.LANG_AUTH, eurlex.TYPE_AUTH, eurlex.XSD_STR):
+            self.assertTrue(stala.startswith("http://"), stala)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_rejestrumow.py
+++ b/tools/test_rejestrumow.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for rejestrumow.py pure functions (no network). Run: python3 tools/test_rejestrumow.py"""
+import contextlib
+import io
+import sys
+import importlib.util
+import pathlib
+import types
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "rejestrumow", ROOT / "plugins/prawo-pl-rejestr-umow/skills/prawo-pl-rejestr-umow/scripts/rejestrumow.py")
+rejestrumow = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rejestrumow)
+
+
+def ns(**kw):
+    """Namespace jak z argparse dla komendy szukaj (wszystkie filtry puste, chyba że podane)."""
+    base = dict(fraza=None, jsfp=None, regon=None, nip=None, rola="zamawiajacy",
+                wykonawca=None, wykonawca_nip=None, wykonawca_regon=None,
+                woj=None, powiat=None, gmina=None, miejscowosc=None,
+                status=None, od=None, do=None, pub_od=None, pub_do=None,
+                wartosc_od=None, wartosc_do=None,
+                zmiana_rodzaj=None, zmiana_od=None, zmiana_do=None)
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+class TestFiltry(unittest.TestCase):
+    def test_puste(self):
+        self.assertEqual(rejestrumow._filtry(ns()), {})
+
+    def test_fraza_do_przedmiotu(self):
+        self.assertEqual(rejestrumow._filtry(ns(fraza="remont drogi")),
+                         {"menuGlowne": {"przedmiotUmowy": "remont drogi"}})
+
+    def test_sekcje_rozdzielone(self):
+        # --jsfp/--regon/--nip → sekcja jsfp (TYLKO zamawiający), nie menuGlowne (dowolna strona):
+        # na żywo REGON 000001301: jsfp 455, inneStronyUmowy 17, menuGlowne 472 = 455 + 17
+        body = rejestrumow._filtry(ns(jsfp="gmina", woj="dolnośląskie", wykonawca="KAMA"))
+        self.assertEqual(body, {"jsfp": {"wojewodztwo": "dolnośląskie", "nazwa": "gmina"},
+                                "inneStronyUmowy": {"nazwa": "KAMA"}})
+
+    def test_regon_nip_domyslnie_tylko_zamawiajacy(self):
+        body = rejestrumow._filtry(ns(regon="000001301", nip="8960005408"))
+        self.assertEqual(body, {"jsfp": {"regon": "000001301", "nip": "8960005408"}})
+        self.assertNotIn("menuGlowne", body)
+
+    def test_rola_dowolna_to_menu_glowne(self):
+        body = rejestrumow._filtry(ns(regon="000001301", rola="dowolna"))
+        self.assertEqual(body, {"menuGlowne": {"regon": "000001301"}})
+
+    def test_rola_wykonawca_to_inne_strony(self):
+        body = rejestrumow._filtry(ns(nip="8960005408", rola="wykonawca"))
+        self.assertEqual(body, {"inneStronyUmowy": {"nip": "8960005408"}})
+
+    def test_rola_wykonawca_konflikt_z_wykonawca_exits(self):
+        with self.assertRaises(SystemExit):
+            rejestrumow._filtry(ns(nip="8960005408", rola="wykonawca", wykonawca="KAMA"))
+
+    def test_nip_regon_bez_kresek(self):
+        # API porównuje dosłownie: '896-000-54-08' → 0 trafień na żywo
+        body = rejestrumow._filtry(ns(nip="896-000-54-08", wykonawca_regon="000 001 301"))
+        self.assertEqual(body, {"jsfp": {"nip": "8960005408"},
+                                "inneStronyUmowy": {"regon": "000001301"}})
+
+    def test_zmiany_umowy_sekcja_najwyzszego_poziomu(self):
+        # na żywo: {"zmianyUmowy":{"rodzajZmiany":"TSU02"}} → 1056; zagnieżdżenie 'zmianyUmowie' → cały rejestr
+        body = rejestrumow._filtry(ns(zmiana_rodzaj="tsu02", zmiana_od="2026-08-15", zmiana_do="2026-08-23"))
+        self.assertEqual(body, {"zmianyUmowy": {"rodzajZmiany": "TSU02", "dataZmianyOd": "2026-08-15",
+                                                "dataZmianyDo": "2026-08-23"}})
+        self.assertEqual(rejestrumow._filtry(ns(zmiana_rodzaj="INNE")), {"zmianyUmowy": {"rodzajZmiany": "inne"}})
+
+    def test_zmiana_rodzaj_nazwa_zamiast_kodu_exits(self):
+        with self.assertRaises(SystemExit):  # 'Aneks do umowy' → 0 trafień na żywo; wymagamy kodu
+            rejestrumow._filtry(ns(zmiana_rodzaj="Aneks do umowy"))
+
+    def test_daty_i_wartosci(self):
+        body = rejestrumow._filtry(ns(od="2026-07-01", pub_do="2026-07-23", wartosc_od="100 000,50"))
+        self.assertEqual(body["menuGlowne"], {"dataZawarciaOd": "2026-07-01",
+                                              "dataPublikacjiDo": "2026-07-23",
+                                              "wartoscOd": 100000.50})
+
+    def test_zla_data_exits(self):
+        with self.assertRaises(SystemExit):
+            rejestrumow._filtry(ns(od="01.07.2026"))  # API wymaga RRRR-MM-DD
+
+
+class TestLiczba(unittest.TestCase):
+    def test_spacje_i_przecinek(self):
+        self.assertEqual(rejestrumow._liczba("1 000 000,50"), 1000000.50)
+
+    def test_kropka(self):
+        self.assertEqual(rejestrumow._liczba("49999.99"), 49999.99)
+
+    def test_zla_exits(self):
+        with self.assertRaises(SystemExit):
+            rejestrumow._liczba("sto złotych")
+
+
+class TestKwota(unittest.TestCase):
+    def test_format_polski(self):
+        # separator tysięcy = spacja niełamliwa, przecinek dziesiętny
+        self.assertEqual(rejestrumow._kwota(2733508), "2 733 508,00 zł")
+
+    def test_grosze(self):
+        self.assertEqual(rejestrumow._kwota(1188.31), "1 188,31 zł")
+
+    def test_none(self):
+        self.assertEqual(rejestrumow._kwota(None), "—")
+
+
+class TestUuid(unittest.TestCase):
+    def test_poprawny(self):
+        self.assertTrue(rejestrumow._uuid_ok("0002c775-2526-484f-9b93-5a60e2b934c4"))
+
+    def test_wielkie_litery(self):
+        self.assertTrue(rejestrumow._uuid_ok("0002C775-2526-484F-9B93-5A60E2B934C4"))
+
+    def test_niepoprawne(self):
+        # API zwraca 500 (nie 404) na złe id — walidacja przed wysłaniem jest konieczna
+        for zly in ("xyz", "", None, "0002c775-2526-484f-9b93", "0002c775252648 f9b935a60e2b934c4"):
+            self.assertFalse(rejestrumow._uuid_ok(zly))
+
+
+class TestData(unittest.TestCase):
+    def test_ok(self):
+        self.assertEqual(rejestrumow._data("2026-07-01"), "2026-07-01")
+
+    def test_format_polski_exits(self):
+        with self.assertRaises(SystemExit):
+            rejestrumow._data("23.07.2026")
+
+
+class TestPelne(unittest.TestCase):
+    def test_usuwa_puste(self):
+        self.assertEqual(rejestrumow._pelne({"a": 1, "b": None, "c": "", "d": 0}),
+                         {"a": 1, "d": 0})
+
+
+class TestLimit(unittest.TestCase):
+    """API tnie stronę do 50 — nagłówek i numeracja stron muszą mówić o REALNEJ wielkości."""
+
+    def test_obciete_do_50(self):
+        self.assertEqual(rejestrumow._limit(100), 50)
+        self.assertEqual(rejestrumow._limit(50), 50)
+
+    def test_male_wartosci_bez_zmian(self):
+        self.assertEqual(rejestrumow._limit(10), 10)
+        self.assertEqual(rejestrumow._limit(1), 1)
+
+    def test_zero_i_ujemne_podnoszone(self):
+        self.assertEqual(rejestrumow._limit(0), 1)
+        self.assertEqual(rejestrumow._limit(-5), 1)
+
+    def test_obciecie_jest_jawne_na_stderr(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(rejestrumow._limit(100, glosno=True), 50)
+            self.assertEqual(rejestrumow._limit(50, glosno=True), 50)
+        self.assertIn("--limit 100 obcięty do 50", err.getvalue())
+        self.assertEqual(err.getvalue().count("obcięty"), 1)  # 50 nie jest obcinane → bez komunikatu
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, rejestrumow.cmd_szukaj
+        rejestrumow.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            rejestrumow.main()
+        finally:
+            sys.argv, rejestrumow.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+
+class TestStrict(unittest.TestCase):
+    """--strict: więcej trafień niż okno API = zbiór NIEKOMPLETNY → blokada (domyślnie ostrzeżenie).
+    Zero trafień kończy się komunikatem także z --json."""
+    UMOWA = {"idUmowy": "0f3c1c3e-1111-4222-8333-444455556666", "nazwa": "Gmina X", "regon": "1",
+             "dataZawarciaUmowy": "2026-07-02", "statusUmowy": "obowiązująca",
+             "wartoscPrzedmiotuUmowy": 1000, "przedmiotUmowy": "remont drogi"}
+
+    def _uruchom(self, argv, odp):
+        out = io.StringIO()
+        with mock.patch.object(rejestrumow, "_req", return_value=odp), \
+                mock.patch.object(sys, "argv", ["rejestrumow.py", *argv]), \
+                contextlib.redirect_stdout(out):
+            try:
+                rejestrumow.main()
+            except SystemExit as e:
+                return out.getvalue(), e
+        return out.getvalue(), None
+
+    def test_strict_blokuje_zbior_ponad_oknem_api_i_stdout_jest_pusty(self):
+        odp = {"content": [self.UMOWA], "totalMatchingElements": rejestrumow.OKNO + 1}
+        for argv in (["szukaj", "remont", "--strict"], ["szukaj", "remont", "--json", "--strict"]):
+            out, e = self._uruchom(argv, odp)
+            self.assertIsNotNone(e, argv)
+            self.assertIn("zawęź", str(e).lower())
+            self.assertEqual(out, "")
+
+    def test_domyslnie_zbior_ponad_oknem_ostrzega(self):
+        odp = {"content": [self.UMOWA], "totalMatchingElements": rejestrumow.OKNO + 1}
+        out, e = self._uruchom(["szukaj", "remont"], odp)
+        self.assertIsNone(e)
+        self.assertIn("UWAGA: API przegląda maks.", out)
+
+    def test_strict_w_granicach_okna_przechodzi(self):
+        odp = {"content": [self.UMOWA], "totalMatchingElements": 1}
+        out, e = self._uruchom(["szukaj", "remont", "--strict"], odp)
+        self.assertIsNone(e)
+        self.assertIn("remont drogi", out)
+
+    def test_json_zero_trafien_konczy_sie_komunikatem(self):
+        out, e = self._uruchom(["szukaj", "zzqq", "--json"], {"content": [], "totalMatchingElements": 0})
+        self.assertIsNotNone(e)
+        self.assertIn("Brak wyników", str(e))
+        self.assertEqual(out, "")
+
+
+class TestStronicowanie(unittest.TestCase):
+    """Pusta strona ≠ zero trafień. Na żywo (woj. podlaskie, 11 076 umów): offset 9950 → 50 wierszy,
+    offset 10 000 → pusta lista i total ZANIŻONY do 10 000. Strona spoza zbioru (455 umów, --strona 12)
+    też zwraca pustą listę — to nie jest 'Brak wyników'."""
+    UMOWA = TestStrict.UMOWA
+
+    def _uruchom(self, argv, odp):
+        out, wywolania = io.StringIO(), []
+
+        def fake_req(path, params=None, body=None):
+            wywolania.append(dict(params or {}))
+            return odp(params) if callable(odp) else odp
+        with mock.patch.object(rejestrumow, "_req", side_effect=fake_req), \
+                mock.patch.object(sys, "argv", ["rejestrumow.py", *argv]), \
+                contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+            try:
+                rejestrumow.main()
+            except SystemExit as e:
+                return out.getvalue(), e, wywolania
+        return out.getvalue(), None, wywolania
+
+    def test_strona_poza_zakresem_nie_jest_zerem(self):
+        odp = {"content": [], "totalMatchingElements": 455}
+        for argv in (["szukaj", "--regon", "1", "--strona", "12", "--limit", "50"],
+                     ["szukaj", "--regon", "1", "--strona", "12", "--limit", "50", "--json"]):
+            out, e, _ = self._uruchom(argv, odp)
+            self.assertIsNotNone(e, argv)
+            self.assertIn("poza zakresem", str(e))
+            self.assertIn("stron: 10", str(e))
+            self.assertIn("--strona 9", str(e))
+            self.assertNotIn("Brak wyników", str(e))
+            self.assertEqual(out, "")
+
+    def test_strona_za_oknem_api_pobiera_realny_total_i_kaze_zawezic(self):
+        def odp(params):  # API: offset ≥ 10 000 → pusta lista, total zaniżony do 10 000
+            if params["offset"] >= rejestrumow.OKNO:
+                return {"content": [], "totalMatchingElements": rejestrumow.OKNO}
+            return {"content": [self.UMOWA] * params["limit"], "totalMatchingElements": 11076}
+        for argv in (["szukaj", "--woj", "podlaskie", "--strona", "200", "--limit", "50"],
+                     ["szukaj", "--woj", "podlaskie", "--strona", "200", "--limit", "50", "--json"]):
+            out, e, wyw = self._uruchom(argv, odp)
+            self.assertIsNotNone(e, argv)
+            self.assertIn("poza oknem API", str(e))
+            self.assertIn("11076", str(e))          # realny total, nie zaniżone 10 000
+            self.assertIn("zawęź", str(e).lower())
+            self.assertNotIn("Brak wyników", str(e))
+            self.assertEqual(out, "")
+            # nie strzelamy w offset ≥ 10 000 (API i tak zwraca pusto) — total z pierwszej strony
+            self.assertEqual(wyw, [{"offset": 0, "limit": 1, "sortKey": None}])
+
+    def test_strona_za_oknem_ale_zbior_mniejszy_to_poza_zakresem(self):
+        odp = {"content": [], "totalMatchingElements": 455}
+        out, e, _ = self._uruchom(["szukaj", "--regon", "1", "--strona", "300", "--limit", "50"], odp)
+        self.assertIn("poza zakresem", str(e))
+        self.assertNotIn("oknem", str(e))
+
+    def test_kolejna_strona_tylko_w_oknie(self):
+        odp = {"content": [self.UMOWA] * 50, "totalMatchingElements": 11076}
+        out, e, _ = self._uruchom(["szukaj", "--woj", "podlaskie", "--strona", "198", "--limit", "50"], odp)
+        self.assertIsNone(e)
+        self.assertIn("Kolejna strona: --strona 199", out)
+        out, e, _ = self._uruchom(["szukaj", "--woj", "podlaskie", "--strona", "199", "--limit", "50"], odp)
+        self.assertIsNone(e)
+        self.assertNotIn("Kolejna strona", out)
+        self.assertIn("Okno 10000 wyników wyczerpane", out)
+        self.assertIn("zawęź", out)
+
+    def test_ostatnia_strona_w_malym_zbiorze(self):
+        odp = {"content": [self.UMOWA] * 5, "totalMatchingElements": 455}
+        out, e, _ = self._uruchom(["szukaj", "--regon", "1", "--strona", "9", "--limit", "50"], odp)
+        self.assertIsNone(e)
+        self.assertNotIn("Kolejna strona", out)
+        self.assertIn("Ostatnia strona (stron: 10)", out)
+        odp = {"content": [self.UMOWA] * 50, "totalMatchingElements": 455}
+        out, e, _ = self._uruchom(["szukaj", "--regon", "1", "--strona", "8", "--limit", "50"], odp)
+        self.assertIn("Kolejna strona: --strona 9", out)
+
+    def test_pelna_strona_na_koncu_zbioru_bez_kolejnej(self):
+        odp = {"content": [self.UMOWA] * 50, "totalMatchingElements": 100}
+        out, e, _ = self._uruchom(["szukaj", "--regon", "1", "--strona", "1", "--limit", "50"], odp)
+        self.assertIsNone(e)
+        self.assertNotIn("Kolejna strona", out)
+
+    def test_stron(self):
+        self.assertEqual(rejestrumow._stron(455, 50), 10)
+        self.assertEqual(rejestrumow._stron(11076, 50), 200)   # okno ucina do 10 000
+        self.assertEqual(rejestrumow._stron(0, 50), 0)
+        self.assertEqual(rejestrumow._stron(1, 50), 1)
+
+
+class TestUmowaFormat(unittest.TestCase):
+    """Szczegóły umowy: adres z powiatem i gminą/dzielnicą, wyłączenie jawności bez repr dict/None."""
+    STRONA = {"kraj": "Polska", "rodzaj": "Przedsiębiorca", "nazwa": "TEXMET S.C.", "nip": "8982125781",
+              "regon": "020646100", "czyKonsorcjum": None,
+              "daneAdresowe": {"ulica": "ul. Mikołaja Reja", "numerNieruchomosci": "35", "numerLokalu": None,
+                               "wojewodztwo": "DOLNOŚLĄSKIE", "powiat": "Wrocław",
+                               "gminaMiastoDzielnica": "Wrocław-Śródmieście", "miejscowosc": "Wrocław",
+                               "kodPocztowy": "50-338"},
+              "niejawnoscStrony": None}
+    NIEJAWNA = {"kraj": "Polska", "rodzaj": "Osoba fizyczna", "nazwa": None, "nip": None, "regon": None,
+                "imie": None, "nazwisko": None, "czyKonsorcjum": False, "daneAdresowe": {},
+                "niejawnoscStrony": {"podstawa": "Art. 5 ust. 2 ustawy o dostępie do informacji publicznej",
+                                     "zakres": "Dane strony umowy",
+                                     "organLubOsobaWylaczajaca": "osoba odpowiedzialna za przygotowanie umowy",
+                                     "komentarz": None}}
+
+    def _strona(self, s):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rejestrumow._strona_umowy(2, s)
+        return out.getvalue()
+
+    def test_adres_z_powiatem_i_gmina(self):
+        out = self._strona(self.STRONA)
+        self.assertIn("ul. Mikołaja Reja 35, 50-338 Wrocław, gmina/dzielnica Wrocław-Śródmieście, "
+                      "powiat Wrocław, woj. dolnośląskie", out)
+
+    def test_niejawnosc_sformatowana_bez_repr(self):
+        out = self._strona(self.NIEJAWNA)
+        self.assertIn("(dane strony niejawne)", out)
+        self.assertIn("WYŁĄCZENIE JAWNOŚCI strony: zakres: Dane strony umowy; podstawa: Art. 5 ust. 2", out)
+        self.assertIn("wyłączający: osoba odpowiedzialna", out)
+        for zly in ("{'", "None", "komentarz"):
+            self.assertNotIn(zly, out)
+
+    def test_niejawnosc_helper(self):
+        self.assertEqual(rejestrumow._niejawnosc({"podstawa": "INNA", "zakres": "Wartość umowy",
+                                                  "organLubOsobaWylaczajaca": "Dyrektor", "komentarz": "art. 29a"}),
+                         "zakres: Wartość umowy; podstawa: INNA; wyłączający: Dyrektor; komentarz: art. 29a")
+        self.assertEqual(rejestrumow._niejawnosc({"podstawa": None}), "(bez szczegółów)")
+        self.assertEqual(rejestrumow._niejawnosc("tekst"), "tekst")
+
+    def test_cmd_umowa_wylaczenie_wartosci(self):
+        d = {"idUmowy": "00385481-27c7-4311-83c4-7d3866a18019", "podstawoweDane": {"statusUmowy": "Aktywna"},
+             "szczegolyUmowy": {"przedmiotUmowy": "KONCERT", "wartoscPrzedmiotu": None,
+                                "niejawnoscWartosciPrzedmiotu": {"podstawa": "INNA", "zakres": "Wartość umowy",
+                                                                 "organLubOsobaWylaczajaca": "Dyrektor",
+                                                                 "komentarz": None},
+                                "opisWartosciPrzedmiotu": None},
+             "stronyUmowy": [self.STRONA]}
+        out = io.StringIO()
+        with mock.patch.object(rejestrumow, "_req", return_value=d), \
+                mock.patch.object(sys, "argv", ["rejestrumow.py", "umowa", d["idUmowy"]]), \
+                contextlib.redirect_stdout(out):
+            rejestrumow.main()
+        self.assertIn("WYŁĄCZENIE JAWNOŚCI wartości: zakres: Wartość umowy; podstawa: INNA; wyłączający: Dyrektor",
+                      out.getvalue())
+        self.assertNotIn("{'", out.getvalue())
+        self.assertNotIn("None", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_uodo.py
+++ b/tools/test_uodo.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline unit tests for uodo.py (no network — `_get`/`_szukaj` are mocked). Run: python3 tools/test_uodo.py"""
+import contextlib
+import io
+import json
+import sys
+import importlib.util
+import pathlib
+import unittest
+import urllib.error
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "uodo", ROOT / "plugins/prawo-pl-uodo/skills/prawo-pl-uodo/scripts/uodo.py")
+uodo = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(uodo)
+
+
+# --- fixtures: shapes copied from the live API (2026-08-23) ---------------------------------
+META_BISNODE = {  # ZSPR.421.3.2018: status final, but the fine (pkt 2) annulled by WSA; NSA dismissed cassation
+    "refid": "urn:ndoc:gov:pl:uodo:2018:zspr_421_3", "refname": "ZSPR.421.3.2018", "kind": "decision",
+    "name": {"pl": "Decyzja Prezesa UODO nr ZSPR.421.3.2018"}, "title": {"pl": "nakaz … oraz nałożenie kary."},
+    "publication": {"status": "final", "inforce": True}, "parts": 1,
+    "dates": [
+        {"date": "2019-03-15", "use": "announcement", "status": "nonfinal"},
+        {"date": "2019-03-26", "use": "publication", "status": "nonfinal"},
+        {"date": "2019-12-11", "use": "repealed", "status": "nonfinal", "refid": "urn:ndoc:court:pl:sa:2019:ii_sa-wa_1030"},
+        {"date": "2023-09-19", "use": "defended", "status": "final", "refid": "urn:ndoc:court:pl:sa:2021:iii_osk_2538"},
+    ]}
+META_MORELE = {  # ZSPR.421.2.2019: annulled in full by NSA; API still says inforce=True
+    "refid": "urn:ndoc:gov:pl:uodo:2019:zspr_421_2", "refname": "ZSPR.421.2.2019", "kind": "decision",
+    "name": {"pl": "Decyzja Prezesa UODO nr ZSPR.421.2.2019"}, "title": {"pl": "nałożenie kary."},
+    "publication": {"status": "repealed", "inforce": True}, "parts": 1,
+    "dates": [
+        {"date": "2019-09-10", "use": "announcement"}, {"date": "2019-09-19", "use": "publication"},
+        {"date": "2020-09-03", "use": "defended", "refid": "urn:ndoc:court:pl:sa:2019:ii_sa-wa_2559"},
+        {"date": "2023-02-09", "use": "repealed", "status": "repealed", "refid": "urn:ndoc:court:pl:sa:2021:iii_osk_3945"},
+    ]}
+META_KONTROLNA = {  # DKN.5131.33.2021: both courts dismissed the complaints — final stays final
+    "refid": "urn:ndoc:gov:pl:uodo:2021:dkn_5131_33", "refname": "DKN.5131.33.2021", "kind": "decision",
+    "name": {"pl": "Decyzja Prezesa UODO nr DKN.5131.33.2021"}, "title": {"pl": "kara."},
+    "publication": {"status": "final", "inforce": True}, "parts": 1,
+    "dates": [
+        {"date": "2022-01-19", "use": "announcement"},
+        {"date": "2022-11-15", "use": "defended", "refid": "urn:ndoc:court:pl:sa:2022:ii_sa-wa_546"},
+        {"date": "2023-01-23", "use": "publication"},
+        {"date": "2026-03-06", "use": "defended", "status": "final", "refid": "urn:ndoc:court:pl:sa:2023:iii_osk_377"},
+    ]}
+META_NONFINAL = {
+    "refid": "urn:ndoc:gov:pl:uodo:2023:dkn_5131_34", "refname": "DKN.5131.34.2023", "kind": "decision",
+    "name": {"pl": "Decyzja Prezesa UODO nr DKN.5131.34.2023"}, "title": {"pl": "kara."},
+    "publication": {"status": "nonfinal", "inforce": True}, "parts": 1,
+    "dates": [{"date": "2026-06-13", "use": "announcement"}, {"date": "2026-06-25", "use": "publication"}]}
+META_WYROK = {  # court ruling record: parts=0, no body in the portal
+    "refid": "urn:ndoc:court:pl:sa:2023:iii_osk_377", "refname": "III OSK 377/23", "kind": "Wyrok",
+    "name": {"pl": "Wyrok - Naczelny Sąd Administracyjny"},
+    "title": {"pl": "Naczelny Sąd Administracyjny w składzie: … oddala skargę kasacyjną"},
+    "publication": {"status": "published", "inforce": True}, "parts": 0,
+    "dates": [{"date": "2026-03-06", "use": "announcement", "text": {"pl": "Data orzeczenia"}},
+              {"date": "2023-02-21", "use": "other", "text": {"pl": "Data wpływu"}}]}
+META_SAD_WSA = {"refid": "urn:ndoc:court:pl:sa:2019:ii_sa-wa_1030", "refname": "II SA/Wa 1030/19",
+                "kind": "Wyrok", "name": {"pl": "Wyrok - Wojewódzki Sąd Administracyjny w Warszawie"}, "parts": 0}
+
+HTML_DECYZJI = """<h1>
+<span>Decyzja</span>
+<span>DKN.1.1.2025</span>
+</h1>
+<dl class="first_level"><dd><h2 id="B1"><div class="num"></div><div> </div></h2>
+<dl class="first_level"><dt class="first_level"></dt><dd id="n0">
+<div>Na podstawie art. 104 (<a href=urn:ndoc:pro:pl:durp:2025:1691>Dz. U. z 2025 r. poz. 1691</a>), polegające na:</div><dl>
+<dt>a)</dt><dd id="n0:la"><div>niewdrożeniu środków,</div></dd></dl>
+<dl><dt>b)</dt><dd id="n0:lb"><div>braku testowania.</div></dd></dl>
+</dd></dl></dd></dl>
+<dl class="first_level"><dd><h2 id="B2"><div class="num">II.</div><div><span>Uzasadnienie</span></div></h2>
+<dl class="first_level"><dt class="first_level">1.</dt><dd id="s1">
+<div>Zgodnie z art. 34 u.o.d.o.<sup><a href="#g1">[1]</a></sup>, Prezes UODO jest organem &amp; basta.</div></dd></dl>
+<dl class="first_level"><dt class="first_level">2.</dt><dd id="s2"><div>Administrator wyjaśnił, że</div><dl>
+<dt>„</dt><dd id="s2:c1"><div><i>W celu zabezpieczenia podjęto środki:</i></div><dl>
+<dt>1)</dt><dd id="s2:c1:p1"><div><i>(…),</i></div></dd></dl>
+<dl><dt>2)</dt><dd id="s2:c1:p2"><div><i>(…)”</i></div></dd></dl></dd></dl></dd></dl>
+</dd></dl>
+
+<div class="glosses">
+<div id="g1">[1] <span>Ustawa z dnia 10 maja 2018 r. o ochronie danych osobowych, dalej jako „u.o.d.o.”</span></div>
+<div id="g2">[2] <span>Tamże, str. 10, pkt 24.</span></div>
+</div>
+"""
+
+
+def _fake_get(odpowiedzi):
+    """Zastępuje uodo._get: dopasowanie po fragmencie ścieżki; brak dopasowania = HTTP 404."""
+    def f(path, params=None, raw=False, brak_ok=False):
+        for klucz, wart in odpowiedzi.items():
+            if klucz in path:
+                if isinstance(wart, BaseException):
+                    raise wart
+                return wart
+        if brak_ok:
+            return None
+        raise SystemExit(f"BŁĄD HTTP 404 (nie znaleziono): {path}")
+    return f
+
+
+def _uruchom(argv, odpowiedzi=None, szukaj=None):
+    """main() z podmienioną siecią; zwraca (stdout, kod wyjścia albo None)."""
+    out = io.StringIO()
+    patches = [mock.patch.object(sys, "argv", ["uodo.py"] + argv), contextlib.redirect_stdout(out)]
+    if odpowiedzi is not None:
+        patches.append(mock.patch.object(uodo, "_get", side_effect=_fake_get(odpowiedzi)))
+    if szukaj is not None:
+        patches.append(mock.patch.object(uodo, "_szukaj", return_value=szukaj))
+    kod = None
+    with contextlib.ExitStack() as stos:
+        for p in patches:
+            stos.enter_context(p)
+        try:
+            uodo.main()
+        except SystemExit as e:
+            kod = e.code if isinstance(e.code, int) else 1
+            if not isinstance(e.code, int):
+                kod = (1, str(e.code))
+    return out.getvalue(), kod
+
+
+class TestRefid(unittest.TestCase):
+    def test_sygnatura_dkn(self):
+        self.assertEqual(uodo._refid("DKN.5131.9.2025"), "urn:ndoc:gov:pl:uodo:2025:dkn_5131_9")
+
+    def test_sygnatura_dke(self):
+        self.assertEqual(uodo._refid("DKE.561.1.2026"), "urn:ndoc:gov:pl:uodo:2026:dke_561_1")
+
+    def test_diakrytyki_transliterowane(self):
+        # URN-y portalu są w ASCII: ZSOŚS → zsoss (zweryfikowane na żywym API)
+        self.assertEqual(uodo._refid("ZSOŚS.440.259.2019"), "urn:ndoc:gov:pl:uodo:2019:zsoss_440_259")
+
+    def test_urn_przechodzi(self):
+        urn = "urn:ndoc:gov:pl:uodo:2025:dkn_5131_9"
+        self.assertEqual(uodo._refid(urn), urn)
+        self.assertEqual(uodo._refid(urn.upper()), urn)
+
+    def test_bez_roku_exits(self):
+        with self.assertRaises(SystemExit):
+            uodo._refid("DKN")
+
+    def test_sygnatura_sadowa_to_urn_rekordu_powiazanego(self):
+        # D6: 'decyzja "III OSK 377/23"' nie może kończyć się 'Nie umiem zbudować URN'
+        self.assertEqual(uodo._refid("III OSK 377/23"), "urn:ndoc:court:pl:sa:2023:iii_osk_377")
+        self.assertEqual(uodo._refid("II SA/Wa 1030/19"), "urn:ndoc:court:pl:sa:2019:ii_sa-wa_1030")
+        self.assertEqual(uodo._refid("III SA/Łd 147/24"), "urn:ndoc:court:pl:sa:2024:iii_sa-łd_147")
+        self.assertEqual(uodo._refid("I C 475/19"), "urn:ndoc:court:pl:sp:2019:i_c_475")
+
+
+class TestSygnaturaZUrn(unittest.TestCase):
+    """Odtwarzanie sygnatury sądowej z refid (zweryfikowane na 171/172 parach refid→refname z indeksu;
+    jedyna rozbieżność to literówka portalu 'II SA-Wa 609-20')."""
+
+    def test_wsa(self):
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sa:2019:ii_sa-wa_1030"), "II SA/Wa 1030/19")
+
+    def test_nsa(self):
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sa:2021:iii_osk_3945"), "III OSK 3945/21")
+
+    def test_diakrytyk_i_sufiks_p(self):
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sa:2024:iii_sa-łd_147"), "III SA/Łd 147/24")
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sa:2023:i_ops_1_p_20230515"), "I OPS 1/23")
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sa:2021:iii_osk_6508_p"), "III OSK 6508/21")
+
+    def test_sad_powszechny_i_tsue(self):
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sp:2018:vi_aca_397"), "VI ACa 397/18")
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:pl:sp:2021:iv_pa_10"), "IV Pa 10/21")
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:court:eu:tsue:2022:c_621"), "C-621/22")
+
+    def test_nieznany_urn_bez_zmian(self):
+        self.assertEqual(uodo._sygnatura_z_urn("urn:ndoc:pro:pl:durp:2023:1368"), "urn:ndoc:pro:pl:durp:2023:1368")
+        self.assertEqual(uodo._sygnatura_z_urn(""), "")
+
+
+class TestTimespan(unittest.TestCase):
+    def test_pusty(self):
+        self.assertEqual(uodo._timespan(None, None), ",")
+
+    def test_od(self):
+        self.assertEqual(uodo._timespan("2026-01-01", None), "2026-01-01,")
+
+    def test_od_do(self):
+        self.assertEqual(uodo._timespan("2026-01-01", "2026-06-30"), "2026-01-01,2026-06-30")
+
+
+class TestPl(unittest.TestCase):
+    def test_dict_pl(self):
+        self.assertEqual(uodo._pl({"pl": "tytuł"}), "tytuł")
+
+    def test_dict_bez_pl(self):
+        self.assertEqual(uodo._pl({"en": "title"}), "title")
+
+    def test_string(self):
+        self.assertEqual(uodo._pl("zwykły"), "zwykły")
+
+    def test_none(self):
+        self.assertEqual(uodo._pl(None), "")
+
+
+class TestDaty(unittest.TestCase):
+    def test_announcement_publication(self):
+        item = {"dates": [
+            {"date": "2025-08-07", "use": "announcement"},
+            {"date": "2025-08-27", "use": "publication"},
+            {"date": "2025-09-11", "use": "validation"},
+        ]}
+        d = uodo._daty(item)
+        self.assertEqual(d["announcement"], "2025-08-07")
+        self.assertEqual(d["publication"], "2025-08-27")
+        self.assertEqual(d["validation"], "2025-09-11")
+
+    def test_brak_dat(self):
+        self.assertEqual(uodo._daty({}), {})
+
+
+class TestKontrolaSadowa(unittest.TestCase):
+    """D1: wpisy dates[] use=repealed/defended/trial z refid wyroku nie mogą ginąć."""
+
+    def test_bisnode_dwa_wpisy_z_sygnaturami(self):
+        k = uodo._kontrola_sadowa(META_BISNODE)
+        self.assertEqual([(x["use"], x["date"], x["sygnatura"]) for x in k],
+                         [("repealed", "2019-12-11", "II SA/Wa 1030/19"),
+                          ("defended", "2023-09-19", "III OSK 2538/21")])
+        self.assertIn("UCHYLONA", k[0]["znaczenie"])
+        self.assertIn("utrzymana", k[1]["znaczenie"])
+
+    def test_uchylona_mimo_statusu_final(self):
+        # częściowe uchylenie (sama kara) — portal zostawia status 'final'
+        self.assertTrue(uodo._uchylona(META_BISNODE, uodo._kontrola_sadowa(META_BISNODE)))
+        self.assertTrue(uodo._uchylona(META_MORELE, uodo._kontrola_sadowa(META_MORELE)))
+        self.assertFalse(uodo._uchylona(META_KONTROLNA, uodo._kontrola_sadowa(META_KONTROLNA)))
+        self.assertFalse(uodo._uchylona(META_NONFINAL, uodo._kontrola_sadowa(META_NONFINAL)))
+
+    def test_rekord_sadowy_bez_kontroli(self):
+        # 'other' = „Data wpływu" bez refid na rekordzie wyroku — to nie kontrola sądowa
+        self.assertEqual(uodo._kontrola_sadowa(META_WYROK), [])
+
+    def test_trial_w_toku(self):
+        k = uodo._kontrola_sadowa({"dates": [{"date": "2025-04-10", "use": "trial",
+                                              "refid": "urn:ndoc:court:pl:sa:2024:ii_sa-wa_1266"}]})
+        self.assertEqual(k[0]["sygnatura"], "II SA/Wa 1266/24")
+        self.assertIn("w toku", k[0]["znaczenie"])
+
+
+class TestTekstZHtml(unittest.TestCase):
+    """D3: tekst z body.html — numeracja list, odnośniki [n], jeden blok przypisów."""
+
+    def setUp(self):
+        self.txt = uodo._tekst_z_html(HTML_DECYZJI)
+        self.linie = self.txt.split("\n")
+
+    def test_naglowek_i_etykiety_list(self):
+        self.assertEqual(self.linie[0], "Decyzja DKN.1.1.2025")
+        self.assertIn("  a) niewdrożeniu środków,", self.linie)
+        self.assertIn("  b) braku testowania.", self.linie)
+        self.assertIn("1. Zgodnie z art. 34 u.o.d.o.[1], Prezes UODO jest organem & basta.", self.linie)
+        self.assertIn("2. Administrator wyjaśnił, że", self.linie)
+        self.assertIn("  „W celu zabezpieczenia podjęto środki:", self.linie)
+        self.assertIn("    1) (…),", self.linie)
+        self.assertIn("    2) (…)”", self.linie)
+
+    def test_naglowek_sekcji_z_numerem_w_jednej_linii(self):
+        self.assertIn("II. Uzasadnienie", self.linie)
+
+    def test_przypisy_raz_z_numerami(self):
+        self.assertEqual(self.txt.count("Ustawa z dnia 10 maja 2018 r."), 1)
+        self.assertIn("[1] Ustawa z dnia 10 maja 2018 r. o ochronie danych osobowych, dalej jako „u.o.d.o.”", self.linie)
+        self.assertIn("[2] Tamże, str. 10, pkt 24.", self.linie)
+        self.assertIn("Przypisy:", self.linie)
+
+    def test_bez_znacznikow_i_pusty(self):
+        self.assertNotIn("<", self.txt)
+        self.assertEqual(uodo._tekst_z_html(""), "")
+
+
+class TestTresc(unittest.TestCase):
+    def test_html_ma_pierwszenstwo(self):
+        with mock.patch.object(uodo, "_get", side_effect=_fake_get({"body.html": HTML_DECYZJI, "body.txt": "txt"})):
+            txt, zrodlo = uodo._tresc("urn:ndoc:gov:pl:uodo:2025:dkn_1_1")
+        self.assertEqual(zrodlo, "body.html")
+        self.assertIn("[1] Ustawa", txt)
+
+    def test_awaryjnie_body_txt(self):
+        with mock.patch.object(uodo, "_get", side_effect=_fake_get({"body.txt": "  tekst z txt  "})):
+            self.assertEqual(uodo._tresc("urn:ndoc:gov:pl:uodo:2025:dkn_1_1"), ("tekst z txt", "body.txt"))
+
+
+class TestWiersz(unittest.TestCase):
+    def _wiersz(self, item):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            uodo._wiersz(item)
+        return out.getvalue()
+
+    def test_orzeczenie_sadu_bez_strzalki_decyzja(self):
+        # D6: 200/700 rekordów to wyroki bez treści — nie reklamuj '→ decyzja'
+        w = self._wiersz(META_WYROK)
+        self.assertNotIn("→ decyzja", w)
+        self.assertIn('prawo-pl-cbosa sygnatura "III OSK 377/23"', w)
+        self.assertIn("status: published (rekord niebędący decyzją)", w)
+
+    def test_decyzja_uchylona_ma_marker(self):
+        w = self._wiersz(META_BISNODE)
+        self.assertIn("→ decyzja ZSPR.421.3.2018", w)
+        self.assertIn("kontrola sądowa: UCHYLONA (w całości lub w części) — II SA/Wa 1030/19 (2019-12-11)", w)
+        w = self._wiersz(META_MORELE)
+        self.assertIn("status: repealed (UCHYLONA)", w)
+
+    def test_inne_rekordy_powiazane(self):
+        self.assertIn("prawo-pl-eli", self._wiersz({"refid": "urn:ndoc:pro:pl:durp:2023:1368", "refname": "Dz.U. 2023 poz. 1368"}))
+        self.assertIn("prawo-eu-eurlex", self._wiersz({"refid": "urn:ndoc:court:eu:tsue:2022:c_621", "refname": "62022CJ0621"}))
+
+
+class TestFragmenty(unittest.TestCase):
+    def test_okno_wokol_frazy(self):
+        txt = ("X" * 50) + "KARA" + ("Y" * 50)
+        spans = uodo._fragmenty(txt, "kara")
+        self.assertEqual(len(spans), 1)
+        self.assertIn("KARA", txt[spans[0][0]:spans[0][1]])
+
+    def test_brak_trafien(self):
+        self.assertEqual(uodo._fragmenty("dowolny tekst", "nie ma"), [])
+
+
+class TestFlagaJson(unittest.TestCase):
+    """--json musi działać także PO komendzie — modele piszą flagi właśnie tam."""
+
+    ARGV = ["szukaj"]
+
+    def _parsuj(self, argv):
+        """Uruchamia main() z podmienionym cmd_szukaj — parsowanie bez wykonania (bez sieci)."""
+        zlapane = {}
+        oryg_argv, oryg_cmd = sys.argv, uodo.cmd_szukaj
+        uodo.cmd_szukaj = lambda a: zlapane.update(vars(a))
+        sys.argv = ["silnik.py"] + argv
+        try:
+            uodo.main()
+        finally:
+            sys.argv, uodo.cmd_szukaj = oryg_argv, oryg_cmd
+        return zlapane
+
+    def test_flaga_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--json"])["json"])
+
+    def test_flaga_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--json"] + self.ARGV)["json"])
+
+    def test_bez_flagi(self):
+        self.assertFalse(self._parsuj(self.ARGV)["json"])
+
+    def test_strict_po_komendzie(self):
+        self.assertTrue(self._parsuj(self.ARGV + ["--strict"])["strict"])
+
+    def test_strict_przed_komenda(self):
+        self.assertTrue(self._parsuj(["--strict"] + self.ARGV)["strict"])
+
+    def test_bez_strict(self):
+        self.assertFalse(self._parsuj(self.ARGV)["strict"])
+
+    def test_pub_od_do(self):
+        a = self._parsuj(self.ARGV + ["--pub-od", "2026-01-01", "--pub-do", "2026-03-31"])
+        self.assertEqual((a["pub_od"], a["pub_do"]), ("2026-01-01", "2026-03-31"))
+
+
+class TestDecyzja(unittest.TestCase):
+    SIEC_BISNODE = {"zspr_421_3/meta.json": META_BISNODE, "ii_sa-wa_1030/meta.json": META_SAD_WSA,
+                    "body.html": HTML_DECYZJI}
+
+    def test_uchylona_naglowek_kontrola_i_inforce_z_zastrzezeniem(self):
+        out, kod = _uruchom(["decyzja", "ZSPR.421.3.2018"], self.SIEC_BISNODE)
+        self.assertIsNone(kod)
+        self.assertTrue(out.startswith("!!! DECYZJA UCHYLONA PRZEZ SĄD (w całości lub w części)"))
+        self.assertIn('prawo-pl-cbosa sygnatura "II SA/Wa 1030/19"', out)
+        self.assertIn("## Kontrola sądowa", out)
+        self.assertIn("2019-12-11  UCHYLONA (w całości lub w części)  Wyrok - Wojewódzki Sąd Administracyjny w Warszawie, II SA/Wa 1030/19", out)
+        self.assertIn("2023-09-19  utrzymana (oddalono skargę)  III OSK 2538/21", out)  # bez meta sądu: sygnatura z URN
+        self.assertIn("publication.inforce wg API: tak (pole nie odzwierciedla uchylenia)", out)
+        self.assertNotIn("w obrocie: tak", out)
+        self.assertIn("źródło: body.html", out)
+        self.assertIn("[1] Ustawa z dnia 10 maja 2018 r.", out)
+
+    def test_strict_blokuje_uchylona_takze_json(self):
+        for argv in (["--strict", "decyzja", "ZSPR.421.3.2018"], ["decyzja", "ZSPR.421.3.2018", "--strict", "--json"]):
+            out, kod = _uruchom(argv, self.SIEC_BISNODE)
+            self.assertEqual(out, "")
+            self.assertEqual(kod[0], 1)
+            self.assertIn("UCHYLONA", kod[1])
+            self.assertIn('prawo-pl-cbosa sygnatura "II SA/Wa 1030/19"', kod[1])
+        out, kod = _uruchom(["decyzja", "ZSPR.421.2.2019", "--strict"],
+                            {"zspr_421_2/meta.json": META_MORELE, "body.html": HTML_DECYZJI})
+        self.assertEqual(out, "")
+        self.assertIn("III OSK 3945/21 z 2023-02-09", kod[1])
+
+    def test_strict_przepuszcza_nonfinal_i_kontrolna(self):
+        out, kod = _uruchom(["decyzja", "DKN.5131.34.2023", "--strict"],
+                            {"dkn_5131_34/meta.json": META_NONFINAL, "body.html": HTML_DECYZJI})
+        self.assertIsNone(kod)
+        self.assertIn("UWAGA:      decyzja NIEPRAWOMOCNA (status nonfinal)", out)
+        self.assertNotIn("UCHYLONA", out)
+        out, kod = _uruchom(["decyzja", "DKN.5131.33.2021", "--strict"],
+                            {"dkn_5131_33/meta.json": META_KONTROLNA, "body.txt": "treść"})
+        self.assertIsNone(kod)
+        self.assertIn("utrzymana (oddalono skargę)  II SA/Wa 546/22", out)
+        self.assertNotIn("!!!", out)
+        self.assertIn("źródło: body.txt", out)
+
+    def test_json_zawiera_kontrole(self):
+        out, kod = _uruchom(["decyzja", "ZSPR.421.3.2018", "--json"], self.SIEC_BISNODE)
+        self.assertIsNone(kod)
+        d = json.loads(out)
+        self.assertTrue(d["_uchylona"])
+        self.assertEqual(d["_tresc_zrodlo"], "body.html")
+        self.assertEqual([k["sygnatura"] for k in d["_kontrola_sadowa"]], ["II SA/Wa 1030/19", "III OSK 2538/21"])
+        self.assertIn("[1] Ustawa", d["_body"])
+
+    def test_rekord_sadowy_wyjasnia_zamiast_literowki(self):
+        for ident in ("III OSK 377/23", "urn:ndoc:court:pl:sa:2023:iii_osk_377"):
+            out, kod = _uruchom(["decyzja", ident], {"iii_osk_377/meta.json": META_WYROK})
+            self.assertEqual(out, "")
+            self.assertEqual(kod[0], 1)
+            self.assertIn("To NIE jest decyzja Prezesa UODO", kod[1])
+            self.assertIn('prawo-pl-cbosa sygnatura "III OSK 377/23"', kod[1])
+            self.assertNotIn("Sprawdź sygnaturę", kod[1])
+
+    def test_brak_w_portalu_z_zastrzezeniem(self):
+        out, kod = _uruchom(["decyzja", "DKN.9999.99.2025"], {})
+        self.assertEqual(out, "")
+        self.assertIn("brak w portalu ≠ nieistnienie decyzji", kod[1])
+        self.assertIn("https://uodo.gov.pl", kod[1])
+        self.assertNotIn("uodo.gov.pl/decyzje", kod[1])
+        out, kod = _uruchom(["decyzja", "II SA/Wa 9999/19"], {})
+        self.assertIn('prawo-pl-cbosa sygnatura "II SA/Wa 9999/19"', kod[1])
+
+    def test_t14_strict_blokuje_brak_pelnej_tresci_i_stdout_jest_pusty(self):
+        out, kod = _uruchom(["decyzja", "DKN.5131.34.2023", "--strict"],
+                            {"dkn_5131_34/meta.json": META_NONFINAL, "body.txt": ""})
+        self.assertEqual(out, "")
+        self.assertEqual(kod[0], 1)
+        self.assertIn("bez zweryfikowanej pełnej treści", kod[1])
+
+    def test_awaria_pobrania_tresci_nie_zostawia_czesciowego_stdout(self):
+        for argv in (["decyzja", "DKN.5131.34.2023"], ["decyzja", "DKN.5131.34.2023", "--json", "--strict"]):
+            out, kod = _uruchom(argv, {"dkn_5131_34/meta.json": META_NONFINAL, "body.txt": SystemExit("awaria body.txt")})
+            self.assertEqual(out, "")
+            self.assertIsNotNone(kod)
+
+
+class TestListy(unittest.TestCase):
+    WIERSZE = [
+        {"refid": "urn:ndoc:gov:pl:uodo:2025:dkn_1_1", "refname": "DKN.1.1.2025", "kind": "decision",
+         "publication": {"status": "final"}, "dates": [{"use": "announcement", "date": "2026-02-10"},
+                                                       {"use": "publication", "date": "2026-04-22"}]},
+        {"refid": "urn:ndoc:gov:pl:uodo:2024:dkn_2_2", "refname": "DKN.2.2.2024", "kind": "decision",
+         "publication": {"status": "nonfinal"}, "dates": [{"use": "announcement", "date": "2025-12-29"},
+                                                          {"use": "publication", "date": "2026-01-16"}]},
+        META_WYROK,
+    ]
+
+    def test_najnowsze_naglowek_mowi_po_czym_sortuje(self):
+        out, kod = _uruchom(["najnowsze", "--limit", "3"], szukaj=self.WIERSZE)
+        self.assertIsNone(kod)
+        self.assertIn("Ostatnio WYDANE", out)
+        self.assertIn("po dacie decyzji/orzeczenia (announcement), NIE po dacie publikacji", out)
+        self.assertNotIn("Ostatnio opublikowane", out)
+
+    def test_szukaj_naglowek_filtr_po_dacie_decyzji(self):
+        out, kod = _uruchom(["szukaj", "--od", "2026-01-01", "--do", "2026-03-31"], szukaj=self.WIERSZE)
+        self.assertIsNone(kod)
+        self.assertIn("filtr po dacie decyzji (announcement): 2026-01-01–2026-03-31", out)
+        self.assertIn('prawo-pl-cbosa sygnatura "III OSK 377/23"', out)
+        self.assertEqual(out.count("→ decyzja"), 2)
+
+    def test_pub_do_filtruje_po_stronie_klienta(self):
+        with mock.patch.object(uodo, "_szukaj", return_value=self.WIERSZE) as sz:
+            out, kod = _uruchom(["szukaj", "--pub-od", "2026-01-01", "--pub-do", "2026-03-31", "--json"])
+        self.assertIsNone(kod)
+        self.assertEqual([r["refname"] for r in json.loads(out)], ["DKN.2.2.2024"])
+        # jedyny wolny warunek → filtr 'od' po stronie API; okno announcement zawężone do pub-do
+        self.assertEqual(sz.call_args.args[:2], (",2026-03-31", "date_publication:ge:2026-01-01"))
+
+    def test_pub_filtr_z_fraza_jest_klient_side(self):
+        with mock.patch.object(uodo, "_szukaj", return_value=self.WIERSZE) as sz:
+            out, kod = _uruchom(["szukaj", "biometr", "--pub-od", "2026-04-01"])
+        self.assertIsNone(kod)
+        self.assertEqual(sz.call_args.args[1], "content_pl:regex:biometr")
+        self.assertIn("po stronie klienta, tylko w obrębie 3 pobranych rekordów", out)
+        self.assertIn("[DKN.1.1.2025]", out)
+        self.assertNotIn("[DKN.2.2.2024]", out)
+
+    def test_pub_filtr_zero_po_filtrze_konczy_bledem_takze_json(self):
+        out, kod = _uruchom(["szukaj", "--pub-od", "2027-01-01", "--json"], szukaj=self.WIERSZE)
+        self.assertEqual(out, "")
+        self.assertEqual(kod[0], 1)
+        self.assertIn("To NIE dowód", kod[1])
+
+    def test_t15_json_strict_nie_emituje_wyniku_gdy_kontrola_nie_przeszla(self):
+        for argv in (["najnowsze", "--json", "--strict"], ["szukaj", "biometr", "--json", "--strict"]):
+            out, kod = _uruchom(argv, szukaj={"error": "maintenance"})
+            self.assertEqual(out, "")
+            self.assertIsNotNone(kod)
+
+
+class TestT16PrzekierowaniaHttps(unittest.TestCase):
+    def test_host_tresci_jest_podnoszony_a_obcy_host_odrzucany(self):
+        req = uodo.urllib.request.Request("https://orzeczenia.uodo.gov.pl/api/documents/public")
+        handler = uodo._PrzekierowaniaHttps()
+        nowy = handler.redirect_request(
+            req, None, 302, "Found", {}, "http://orzeczenia.uodo.gov.pl/api/body.txt")
+        self.assertEqual(nowy.full_url, "https://orzeczenia.uodo.gov.pl/api/body.txt")
+        with self.assertRaisesRegex(urllib.error.URLError, "niezaufany host"):
+            handler.redirect_request(req, None, 302, "Found", {}, "http://example.test/body.txt")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Gałąź techniczna do `/code-review ultra`: pełna zawartość plików z `release/2.0.0` (część 2 z 2, ≤8000 linii) na pustej bazie, żeby ultrareview objął cały kod, a nie tylko diff. **Nie mergować** — do zamknięcia po przeglądzie.